### PR TITLE
feat: BYF data paths (BYF_HOME + .byf)

### DIFF
--- a/apps/cli/src/cli/sub/export.ts
+++ b/apps/cli/src/cli/sub/export.ts
@@ -102,7 +102,7 @@ export function registerExportCommand(parent: Command, deps?: Partial<ExportDeps
     .option('-y, --yes', 'Skip previous-session confirmation.')
     .option(
       '--no-include-global-log',
-      'Skip bundling the active global diagnostic log (~/.kimi-code/logs/kimi-code.log, not rotated .1 files). By default the global log is included.',
+      'Skip bundling the active global diagnostic log (~/.byf/logs/byf.log, not rotated .1 files). By default the global log is included.',
     )
     .argument('[sessionId]', 'Session id to export. Defaults to the most recent session.')
     .action(

--- a/apps/cli/src/constant/app.ts
+++ b/apps/cli/src/constant/app.ts
@@ -14,14 +14,14 @@ export const CLI_SHUTDOWN_TIMEOUT_MS = 3000;
 export const NPM_PACKAGE_NAME = '@byf/cli';
 
 // App-owned data paths. SDK/core runtime config is intentionally not routed here.
-export const KIMI_CODE_HOME_ENV = 'BYF_HOME';
-export const KIMI_CODE_DATA_DIR_NAME = '.byf';
-export const KIMI_CODE_LOG_DIR_NAME = 'logs';
-export const KIMI_CODE_UPDATE_DIR_NAME = 'updates';
-export const KIMI_CODE_UPDATE_STATE_FILE_NAME = 'latest.json';
-export const KIMI_CODE_INPUT_HISTORY_DIR_NAME = 'user-history';
+export const BYF_HOME_ENV = 'BYF_HOME';
+export const BYF_DATA_DIR_NAME = '.byf';
+export const BYF_LOG_DIR_NAME = 'logs';
+export const BYF_UPDATE_DIR_NAME = 'updates';
+export const BYF_UPDATE_STATE_FILE_NAME = 'latest.json';
+export const BYF_INPUT_HISTORY_DIR_NAME = 'user-history';
 
-// Managed Kimi auth provider key shared with OAuth/SDK config.
+// Managed auth provider key shared with OAuth/SDK config.
 export const DEFAULT_OAUTH_PROVIDER_NAME = 'managed:byf';
 
 // SDK/core error code that tells the TUI to show a login-required startup

--- a/apps/cli/src/migration/detect-pending.ts
+++ b/apps/cli/src/migration/detect-pending.ts
@@ -55,7 +55,7 @@ export async function detectPendingMigration(
 
 /**
  * True when the legacy `.migrated-to-kimi-code` marker records a migration
- * into *this* target home. A marker written for a different `KIMI_CODE_HOME`
+ * into *this* target home. A marker written for a different `BYF_HOME`
  * must not suppress the prompt — that target has never received migrated data.
  * An unreadable/old marker without `target_path` is treated as "matches"
  * (conservative: do not re-prompt when the marker exists but is ambiguous).

--- a/apps/cli/src/tui/components/dialogs/api-key-input-dialog.ts
+++ b/apps/cli/src/tui/components/dialogs/api-key-input-dialog.ts
@@ -62,7 +62,7 @@ export class ApiKeyInputDialogComponent extends Container implements Focusable {
     this.onDone = onDone;
     this.colors = colors;
     this.title = `Enter API key for ${platformName}`;
-    this.subtitle = 'Your key will be saved to ~/.kimi-code/config.toml';
+    this.subtitle = 'Your key will be saved to ~/.byf/config.toml';
     this.input.onSubmit = (value) => {
       this.submit(value);
     };

--- a/apps/cli/src/tui/config.ts
+++ b/apps/cli/src/tui/config.ts
@@ -2,7 +2,7 @@
  * TUI-owned configuration.
  *
  * Agent/runtime settings live in core's `config.toml`; this file owns only
- * terminal UI preferences for the kimi-code client.
+ * terminal UI preferences for the BYF client.
  */
 
 import { existsSync } from 'node:fs';
@@ -15,7 +15,7 @@ import { z } from 'zod';
 import { getDataDir } from '#/utils/paths';
 
 export const INVALID_TUI_CONFIG_MESSAGE =
-  'Invalid TUI config in ~/.kimi-code/tui.toml; using defaults.';
+  'Invalid TUI config in ~/.byf/tui.toml; using defaults.';
 
 export const TuiThemeSchema = z.enum(['dark', 'light', 'auto']);
 
@@ -126,9 +126,9 @@ export function normalizeTuiConfig(config: TuiConfigFileShape): TuiConfig {
 }
 
 export function renderTuiConfig(config: TuiConfig): string {
-  return `# ~/.kimi-code/tui.toml
-# Terminal UI preferences for kimi-code.
-# Agent/runtime settings stay in ~/.kimi-code/config.toml.
+  return `# ~/.byf/tui.toml
+# Terminal UI preferences for BYF.
+# Agent/runtime settings stay in ~/.byf/config.toml.
 
 theme = "${config.theme}" # "auto" | "dark" | "light"
 

--- a/apps/cli/src/utils/paths.ts
+++ b/apps/cli/src/utils/paths.ts
@@ -10,39 +10,39 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 import {
-  KIMI_CODE_DATA_DIR_NAME,
-  KIMI_CODE_HOME_ENV,
-  KIMI_CODE_INPUT_HISTORY_DIR_NAME,
-  KIMI_CODE_LOG_DIR_NAME,
-  KIMI_CODE_UPDATE_DIR_NAME,
-  KIMI_CODE_UPDATE_STATE_FILE_NAME,
+  BYF_DATA_DIR_NAME,
+  BYF_HOME_ENV,
+  BYF_INPUT_HISTORY_DIR_NAME,
+  BYF_LOG_DIR_NAME,
+  BYF_UPDATE_DIR_NAME,
+  BYF_UPDATE_STATE_FILE_NAME,
 } from '#/constant/app';
 
 /**
- * Return the root data directory for Kimi Code.
+ * Return the root data directory for BYF.
  *
- * Priority: `KIMI_CODE_HOME` env var > `~/.kimi-code`.
+ * Priority: `BYF_HOME` env var > `~/.byf`.
  */
 export function getDataDir(): string {
-  const envDir = process.env[KIMI_CODE_HOME_ENV];
+  const envDir = process.env[BYF_HOME_ENV];
   if (envDir) {
     return envDir;
   }
-  return join(homedir(), KIMI_CODE_DATA_DIR_NAME);
+  return join(homedir(), BYF_DATA_DIR_NAME);
 }
 
 /**
  * Return the diagnostic log directory: `<dataDir>/logs/`.
  */
 export function getLogDir(): string {
-  return join(getDataDir(), KIMI_CODE_LOG_DIR_NAME);
+  return join(getDataDir(), BYF_LOG_DIR_NAME);
 }
 
 /**
  * Return the update cache file: `<dataDir>/updates/latest.json`.
  */
 export function getUpdateStateFile(): string {
-  return join(getDataDir(), KIMI_CODE_UPDATE_DIR_NAME, KIMI_CODE_UPDATE_STATE_FILE_NAME);
+  return join(getDataDir(), BYF_UPDATE_DIR_NAME, BYF_UPDATE_STATE_FILE_NAME);
 }
 
 /**
@@ -51,5 +51,5 @@ export function getUpdateStateFile(): string {
  */
 export function getInputHistoryFile(workDir: string): string {
   const hash = createHash('md5').update(workDir, 'utf-8').digest('hex');
-  return join(getDataDir(), KIMI_CODE_INPUT_HISTORY_DIR_NAME, `${hash}.jsonl`);
+  return join(getDataDir(), BYF_INPUT_HISTORY_DIR_NAME, `${hash}.jsonl`);
 }

--- a/apps/cli/test/cli/run-shell.test.ts
+++ b/apps/cli/test/cli/run-shell.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => {
     readonly fallback: TuiConfigFallback;
 
     constructor(fallback: TuiConfigFallback) {
-      super('Invalid TUI config in ~/.kimi-code/tui.toml; using defaults.');
+      super('Invalid TUI config in ~/.byf/tui.toml; using defaults.');
       this.fallback = fallback;
     }
   }
@@ -467,7 +467,7 @@ describe('runShell', () => {
     expect(mocks.detectTerminalTheme).toHaveBeenCalledOnce();
     const [, , startupInput] = mocks.kimiTuiConstructor.mock.calls[0]!;
     expect(startupInput).toMatchObject({
-      startupNotice: 'Invalid TUI config in ~/.kimi-code/tui.toml; using defaults.',
+      startupNotice: 'Invalid TUI config in ~/.byf/tui.toml; using defaults.',
       resolvedTheme: 'light',
       tuiConfig: {
         theme: 'auto',
@@ -568,7 +568,7 @@ describe('runShell', () => {
     });
     mocks.detectPendingMigration.mockResolvedValue({ totalSessions: 1 });
     mocks.harnessGetConfig.mockRejectedValue(
-      new Error('Invalid configuration in ~/.kimi-code/config.toml'),
+      new Error('Invalid configuration in ~/.byf/config.toml'),
     );
 
     // A broken config.toml must fail loudly — `kimi migrate` must not swallow

--- a/apps/cli/test/e2e/local-logging-export.e2e.test.ts
+++ b/apps/cli/test/e2e/local-logging-export.e2e.test.ts
@@ -11,8 +11,8 @@ import { createKimiCodeHostIdentity } from '#/cli/version';
 import { KimiHarness, log } from '@byf/sdk';
 import { __resetRootLoggerForTest } from '../../../../packages/agent-core/src/logging/logger';
 
-const SESSION_LOG = 'logs/kimi-code.log';
-const GLOBAL_LOG = 'logs/global/kimi-code.log';
+const SESSION_LOG = 'logs/byf.log';
+const GLOBAL_LOG = 'logs/global/byf.log';
 const MAIN_WIRE = 'agents/main/wire.jsonl';
 const ENABLED = process.env['KIMI_E2E'] === '1';
 

--- a/apps/cli/test/e2e/local-logging-export.e2e.test.ts
+++ b/apps/cli/test/e2e/local-logging-export.e2e.test.ts
@@ -24,16 +24,16 @@ beforeEach(async () => {
   await __resetRootLoggerForTest();
   homeDir = await mkdtemp(join(tmpdir(), 'kimi-cli-log-home-'));
   workDir = await mkdtemp(join(tmpdir(), 'kimi-cli-log-work-'));
-  oldHome = process.env['KIMI_CODE_HOME'];
-  process.env['KIMI_CODE_HOME'] = homeDir;
+  oldHome = process.env['BYF_HOME'];
+  process.env['BYF_HOME'] = homeDir;
 });
 
 afterEach(async () => {
   await __resetRootLoggerForTest();
   if (oldHome === undefined) {
-    delete process.env['KIMI_CODE_HOME'];
+    delete process.env['BYF_HOME'];
   } else {
-    process.env['KIMI_CODE_HOME'] = oldHome;
+    process.env['BYF_HOME'] = oldHome;
   }
   await rm(homeDir, { recursive: true, force: true });
   await rm(workDir, { recursive: true, force: true });

--- a/apps/cli/test/migration/migration-screen.test.ts
+++ b/apps/cli/test/migration/migration-screen.test.ts
@@ -34,7 +34,7 @@ describe('MigrationScreenComponent — ask phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -54,7 +54,7 @@ describe('MigrationScreenComponent — ask phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -68,7 +68,7 @@ describe('MigrationScreenComponent — ask phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: (r) => {
         result = r;
@@ -84,7 +84,7 @@ describe('MigrationScreenComponent — ask phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       runMigration: async (input) => {
         captured = input;
@@ -103,7 +103,7 @@ describe('MigrationScreenComponent — ask phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       runMigration: async (input) => {
         captured = input;
@@ -122,7 +122,7 @@ describe('MigrationScreenComponent — ask phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan({ totalSessions: 1365 }),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -139,7 +139,7 @@ describe('MigrationScreenComponent — ask phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan({ totalSessions: 0 }),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -154,7 +154,7 @@ describe('MigrationScreenComponent — ask phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       skipDecisionStep: true,
       onComplete: () => {},
@@ -170,7 +170,7 @@ describe('MigrationScreenComponent — ask phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       skipDecisionStep: true,
       runMigration: async (input) => {
@@ -190,7 +190,7 @@ describe('MigrationScreenComponent — progress phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -210,7 +210,7 @@ describe('MigrationScreenComponent — progress phase', () => {
       const c = new MigrationScreenComponent({
         plan: makePlan(),
         sourceHome: '/x/.kimi',
-        targetHome: '/y/.kimi-code',
+        targetHome: '/y/.byf',
         colors: darkColors,
         skipDecisionStep: true,
         // A migration that never settles keeps the screen in the progress
@@ -235,7 +235,7 @@ describe('MigrationScreenComponent — progress phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -260,7 +260,7 @@ function makeReport(
     completedAt: 'e',
     migratorVersion: '0.1.1',
     source: '/x/.kimi',
-    target: '/y/.kimi-code',
+    target: '/y/.byf',
     summary: {
       config: {
         migrated: true,
@@ -311,7 +311,7 @@ describe('MigrationScreenComponent — result phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -326,7 +326,7 @@ describe('MigrationScreenComponent — result phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -360,7 +360,7 @@ describe('MigrationScreenComponent — result phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: (r) => {
         result = r;
@@ -376,7 +376,7 @@ describe('MigrationScreenComponent — result phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -412,7 +412,7 @@ describe('MigrationScreenComponent — result phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -453,7 +453,7 @@ describe('MigrationScreenComponent — result phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -495,7 +495,7 @@ describe('MigrationScreenComponent — result phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -510,7 +510,7 @@ describe('MigrationScreenComponent — result phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -543,7 +543,7 @@ describe('MigrationScreenComponent — result phase', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
     });
@@ -560,7 +560,7 @@ describe('MigrationScreenComponent — execution wiring', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: (r) => {
         onCompleteResult = r;
@@ -582,7 +582,7 @@ describe('MigrationScreenComponent — execution wiring', () => {
     const c = new MigrationScreenComponent({
       plan: makePlan(),
       sourceHome: '/x/.kimi',
-      targetHome: '/y/.kimi-code',
+      targetHome: '/y/.byf',
       colors: darkColors,
       onComplete: () => {},
       runMigration: async () => {

--- a/apps/cli/test/native/cache-base.test.ts
+++ b/apps/cli/test/native/cache-base.test.ts
@@ -13,10 +13,10 @@ describe('getNativeCacheBase precedence', () => {
     expect(got).toBe('/custom/cache');
   });
 
-  it('ignores KIMI_CODE_HOME (no longer affects native cache)', () => {
+  it('ignores BYF_HOME (no longer affects native cache)', () => {
     const got = getNativeCacheBase({
       ...baseOptions,
-      env: { KIMI_CODE_HOME: '/legacy' },
+      env: { BYF_HOME: '/legacy' },
       platform: 'darwin',
     });
     expect(got).toBe('/home/u/Library/Caches/kimi-code');

--- a/apps/cli/test/scripts/nix/update-pnpm-deps.test.ts
+++ b/apps/cli/test/scripts/nix/update-pnpm-deps.test.ts
@@ -143,7 +143,7 @@ async function runUpdateScript(
 function flakeWithHash(hash: string): string {
   return `{
   outputs = { self, nixpkgs }: {
-    packages.x86_64-linux.kimi-code-pnpm-deps = {
+    packages.x86_64-linux.byf-pnpm-deps = {
       hash = "${hash}";
     };
   };

--- a/apps/cli/test/tui/components/panels/plan-box.test.ts
+++ b/apps/cli/test/tui/components/panels/plan-box.test.ts
@@ -31,7 +31,7 @@ describe('PlanBoxComponent', () => {
       '# Hello',
       theme,
       darkColors.success,
-      '/tmp/projects/foo/.kimi-code/plans/very-long-slug-name.md',
+      '/tmp/projects/foo/.byf/plans/very-long-slug-name.md',
     );
     const out = strip(box.render(80).join('\n'));
     const top = out.split('\n')[0]!;

--- a/apps/cli/test/tui/config.test.ts
+++ b/apps/cli/test/tui/config.test.ts
@@ -32,7 +32,7 @@ describe('TUI config', () => {
 
     expect(result).toEqual(DEFAULT_TUI_CONFIG);
     const text = readFileSync(filePath, 'utf-8');
-    expect(text).toContain('Terminal UI preferences for kimi-code.');
+    expect(text).toContain('Terminal UI preferences for BYF.');
     expect(text).toContain('theme = "auto"');
     expect(text).toContain('command = ""');
     expect(text).toContain('[notifications]');

--- a/apps/vis/server/src/config.ts
+++ b/apps/vis/server/src/config.ts
@@ -1,13 +1,13 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-/** Resolve KIMI_CODE_HOME (env > ~/.kimi-code). */
-function resolveKimiCodeHome(): string {
-  const envHome = process.env['KIMI_CODE_HOME'];
+/** Resolve BYF_HOME (env > ~/.byf). */
+function resolveByfHome(): string {
+  const envHome = process.env['BYF_HOME'];
   if (envHome !== undefined && envHome.length > 0) {
     return envHome;
   }
-  return join(homedir(), '.kimi-code');
+  return join(homedir(), '.byf');
 }
 
 /** HTTP port for the vis API server. */
@@ -51,4 +51,4 @@ export function resolveVisAuthToken(host: string = resolveHost()): string | unde
   return undefined;
 }
 
-export const KIMI_CODE_HOME: string = resolveKimiCodeHome();
+export const BYF_HOME: string = resolveByfHome();

--- a/apps/vis/server/src/index.ts
+++ b/apps/vis/server/src/index.ts
@@ -1,7 +1,7 @@
 import { serve } from '@hono/node-server';
 
 import { createApp } from './app';
-import { KIMI_CODE_HOME, resolveHost, resolvePort, resolveVisAuthToken } from './config';
+import { BYF_HOME, resolveHost, resolvePort, resolveVisAuthToken } from './config';
 import { formatStartupBanner } from './startup-banner';
 
 async function main(): Promise<void> {
@@ -15,7 +15,7 @@ async function main(): Promise<void> {
       formatStartupBanner({
         authToken,
         host,
-        kimiCodeHome: KIMI_CODE_HOME,
+        kimiCodeHome: BYF_HOME,
         port: info.port,
       }),
     );

--- a/apps/vis/server/src/routes/context.ts
+++ b/apps/vis/server/src/routes/context.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { join } from 'node:path';
 
-import { KIMI_CODE_HOME } from '../config';
+import { BYF_HOME } from '../config';
 import { isSafeAgentId, readSessionDetail } from '../lib/session-store';
 import { readAgentWire } from '../lib/wire-reader';
 import { projectContext } from '../lib/context-projector';
@@ -14,7 +14,7 @@ export function contextRoute(): Hono {
     if (!isSafeAgentId(agentId)) {
       return c.json({ error: 'invalid agent id', code: 'BAD_REQUEST' }, 400);
     }
-    const detail = await readSessionDetail(KIMI_CODE_HOME, id);
+    const detail = await readSessionDetail(BYF_HOME, id);
     if (!detail) {
       return c.json({ error: 'session not found', code: 'NOT_FOUND' }, 404);
     }

--- a/apps/vis/server/src/routes/session-detail.ts
+++ b/apps/vis/server/src/routes/session-detail.ts
@@ -1,12 +1,12 @@
 import { Hono } from 'hono';
-import { KIMI_CODE_HOME } from '../config';
+import { BYF_HOME } from '../config';
 import { readSessionDetail } from '../lib/session-store';
 
 export function sessionDetailRoute(): Hono {
   const r = new Hono();
   r.get('/:id', async (c) => {
     const id = c.req.param('id');
-    const detail = await readSessionDetail(KIMI_CODE_HOME, id);
+    const detail = await readSessionDetail(BYF_HOME, id);
     if (!detail) return c.json({ error: 'session not found', code: 'NOT_FOUND' }, 404);
     return c.json(detail);
   });

--- a/apps/vis/server/src/routes/sessions.ts
+++ b/apps/vis/server/src/routes/sessions.ts
@@ -1,18 +1,18 @@
 import { Hono } from 'hono';
 import { rm } from 'node:fs/promises';
-import { KIMI_CODE_HOME } from '../config';
+import { BYF_HOME } from '../config';
 import { revealInOs } from '../lib/reveal';
 import { listSessions, readSessionDetail } from '../lib/session-store';
 
 export function sessionsRoute(): Hono {
   const r = new Hono();
   r.get('/', async (c) => {
-    const sessions = await listSessions(KIMI_CODE_HOME);
+    const sessions = await listSessions(BYF_HOME);
     return c.json({ sessions });
   });
   r.delete('/:id', async (c) => {
     const id = c.req.param('id');
-    const all = await listSessions(KIMI_CODE_HOME);
+    const all = await listSessions(BYF_HOME);
     const target = all.find((s) => s.sessionId === id);
     if (!target) return c.json({ error: 'session not found', code: 'NOT_FOUND' }, 404);
     await rm(target.sessionDir, { recursive: true, force: true });
@@ -22,7 +22,7 @@ export function sessionsRoute(): Hono {
   // opened on the SERVER host — only meaningful when vis runs locally.
   r.post('/:id/reveal', async (c) => {
     const id = c.req.param('id');
-    const detail = await readSessionDetail(KIMI_CODE_HOME, id);
+    const detail = await readSessionDetail(BYF_HOME, id);
     if (!detail) return c.json({ error: 'session not found', code: 'NOT_FOUND' }, 404);
     try {
       await revealInOs(detail.sessionDir);

--- a/apps/vis/server/src/routes/subagents.ts
+++ b/apps/vis/server/src/routes/subagents.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { KIMI_CODE_HOME } from '../config';
+import { BYF_HOME } from '../config';
 import { readSessionDetail } from '../lib/session-store';
 import { buildAgentTree } from '../lib/agent-tree';
 
@@ -7,7 +7,7 @@ export function subagentsRoute(): Hono {
   const r = new Hono();
   r.get('/:id/agents', async (c) => {
     const id = c.req.param('id');
-    const detail = await readSessionDetail(KIMI_CODE_HOME, id);
+    const detail = await readSessionDetail(BYF_HOME, id);
     if (!detail) {
       return c.json({ error: 'session not found', code: 'NOT_FOUND' }, 404);
     }

--- a/apps/vis/server/src/routes/wire.ts
+++ b/apps/vis/server/src/routes/wire.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { join } from 'node:path';
 
-import { KIMI_CODE_HOME } from '../config';
+import { BYF_HOME } from '../config';
 import { isSafeAgentId, readSessionDetail } from '../lib/session-store';
 import { readAgentWire } from '../lib/wire-reader';
 
@@ -13,7 +13,7 @@ export function wireRoute(): Hono {
     if (!isSafeAgentId(agentId)) {
       return c.json({ error: 'invalid agent id', code: 'BAD_REQUEST' }, 400);
     }
-    const detail = await readSessionDetail(KIMI_CODE_HOME, id);
+    const detail = await readSessionDetail(BYF_HOME, id);
     if (!detail) {
       return c.json({ error: 'session not found', code: 'NOT_FOUND' }, 404);
     }

--- a/apps/vis/server/src/startup-banner.ts
+++ b/apps/vis/server/src/startup-banner.ts
@@ -9,7 +9,7 @@ export function formatStartupBanner(options: StartupBannerOptions): string {
   const authStatus = options.authToken === undefined ? 'auth=disabled' : 'auth=required';
   return (
     `[vis-server] listening on http://${hostForUrl(options.host)}:${String(options.port)} ` +
-    `(${authStatus}, KIMI_CODE_HOME=${options.kimiCodeHome})\n`
+    `(${authStatus}, BYF_HOME=${options.kimiCodeHome})\n`
   );
 }
 

--- a/apps/vis/server/test/lib/session-store.test.ts
+++ b/apps/vis/server/test/lib/session-store.test.ts
@@ -147,7 +147,7 @@ describe('session-store', () => {
     expect(d!.agents.map((a) => a.agentId).sort()).toEqual(['agent-0', 'main']);
   });
 
-  it('rejects session_index entries that point outside KIMI_CODE_HOME', async () => {
+  it('rejects session_index entries that point outside BYF_HOME', async () => {
     const { home, cleanup: c } = await buildSessionFixture('sample-main');
     cleanup = c;
     const { writeFile, mkdir } = await import('node:fs/promises');

--- a/apps/vis/web/src/components/sessions/SessionRail.tsx
+++ b/apps/vis/web/src/components/sessions/SessionRail.tsx
@@ -85,7 +85,7 @@ export function SessionRail() {
 
   async function handleDeleteSession(session: SessionSummary) {
     const label = session.title ?? session.lastPrompt ?? session.sessionId;
-    if (!window.confirm(`Delete session "${label}"?\n\nThis removes its files from KIMI_CODE_HOME.`)) {
+    if (!window.confirm(`Delete session "${label}"?\n\nThis removes its files from BYF_HOME.`)) {
       return;
     }
     try {

--- a/packages/agent-core/src/config/path.ts
+++ b/packages/agent-core/src/config/path.ts
@@ -3,7 +3,7 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 
 export function resolveKimiHome(homeDir?: string | undefined): string {
-  return homeDir ?? process.env['KIMI_CODE_HOME'] ?? join(homedir(), '.kimi-code');
+  return homeDir ?? process.env['BYF_HOME'] ?? join(homedir(), '.byf');
 }
 
 export function resolveConfigPath(input: {

--- a/packages/agent-core/src/config/toml.ts
+++ b/packages/agent-core/src/config/toml.ts
@@ -40,10 +40,10 @@ function camelToSnake(str: string): string {
 /*  Read / parse                                                       */
 /* ------------------------------------------------------------------ */
 
-const DEFAULT_CONFIG_FILE_TEXT = `# ~/.kimi-code/config.toml
-# Runtime settings for Kimi Code.
+const DEFAULT_CONFIG_FILE_TEXT = `# ~/.byf/config.toml
+# Runtime settings for BYF.
 # This file starts empty so built-in defaults can apply.
-# Login will populate managed Kimi provider and model entries.
+# Login will populate managed provider and model entries.
 `;
 
 export async function ensureConfigFile(filePath: string): Promise<void> {

--- a/packages/agent-core/src/logging/logger.ts
+++ b/packages/agent-core/src/logging/logger.ts
@@ -66,7 +66,7 @@ class RootLoggerImpl implements RootLogger {
       return makeNoopHandle(input.sessionId);
     }
     const sink = new RotatingFileSink({
-      path: join(input.sessionDir, 'logs', 'kimi-code.log'),
+      path: join(input.sessionDir, 'logs', 'byf.log'),
       maxBytes: config.sessionMaxBytes,
       files: config.sessionFiles,
     });
@@ -433,5 +433,5 @@ export async function __resetRootLoggerForTest(): Promise<void> {
 }
 
 export function resolveGlobalLogPath(homeDir: string): string {
-  return join(homeDir, 'logs', 'kimi-code.log');
+  return join(homeDir, 'logs', 'byf.log');
 }

--- a/packages/agent-core/src/mcp/config-loader.ts
+++ b/packages/agent-core/src/mcp/config-loader.ts
@@ -23,7 +23,7 @@ export interface ResolveMcpJsonPathsInput {
 export function resolveMcpJsonPaths(input: ResolveMcpJsonPathsInput): McpJsonPaths {
   return {
     user: join(resolveKimiHome(input.homeDir), 'mcp.json'),
-    project: join(input.cwd, '.kimi-code', 'mcp.json'),
+    project: join(input.cwd, '.byf', 'mcp.json'),
   };
 }
 
@@ -33,8 +33,8 @@ export interface LoadMcpServersInput {
 }
 
 /**
- * Load MCP server declarations from the user-global `~/.kimi-code/mcp.json`
- * and the project-local `<cwd>/.kimi-code/mcp.json`. Entries in the project
+ * Load MCP server declarations from the user-global `~/.byf/mcp.json`
+ * and the project-local `<cwd>/.byf/mcp.json`. Entries in the project
  * file override user-global entries with the same key, so a repo can specialise
  * or replace a shared definition.
  *

--- a/packages/agent-core/src/mcp/oauth/provider.ts
+++ b/packages/agent-core/src/mcp/oauth/provider.ts
@@ -3,8 +3,8 @@
  *
  * One provider instance per server/resource identity. The provider:
  *  - Persists OAuth tokens, the registered DCR client info, and discovery
- *    state under `<KIMI_CODE_HOME>/credentials/mcp/<key>-*.json`
- *    (mode 0600; default home is `~/.kimi-code`).
+ *    state under `<BYF_HOME>/credentials/mcp/<key>-*.json`
+ *    (mode 0600; default home is `~/.byf`).
  *  - Captures the authorization URL when the SDK calls
  *    `redirectToAuthorization` — the {@link McpOAuthService} reads that field
  *    after the first `auth()` call returns `'REDIRECT'`.
@@ -62,7 +62,7 @@ export class McpOAuthClientProvider implements OAuthClientProvider {
     this.serverUrl = canonicalMcpOAuthResource(options.serverUrl);
     this.storeKey = mcpOAuthStoreKey(options.serverName, this.serverUrl);
     this.store = options.store;
-    this.clientLabel = options.clientLabel ?? `kimi-code (${options.serverName})`;
+    this.clientLabel = options.clientLabel ?? `byf (${options.serverName})`;
   }
 
   // ── flow-scoped state, set by McpOAuthService before invoking auth() ────

--- a/packages/agent-core/src/mcp/oauth/store.ts
+++ b/packages/agent-core/src/mcp/oauth/store.ts
@@ -1,8 +1,8 @@
 /**
  * Small atomic JSON file store used by the MCP OAuth provider to persist
  * tokens, registered client info, and discovery state under
- * `<KIMI_CODE_HOME>/credentials/mcp/` (default
- * `~/.kimi-code/credentials/mcp/`).
+ * `<BYF_HOME>/credentials/mcp/` (default
+ * `~/.byf/credentials/mcp/`).
  *
  * Write semantics: write to `<file>.tmp.<pid>.<rand>` → fsync → rename.
  * Atomic on POSIX; best-effort on Windows. Files land at mode 0600 (parent
@@ -32,7 +32,7 @@ export function mcpCredentialsDir(kimiHomeDir: string): string {
 }
 
 export function defaultMcpCredentialsDir(): string {
-  return mcpCredentialsDir(join(homedir(), '.kimi-code'));
+  return mcpCredentialsDir(join(homedir(), '.byf'));
 }
 
 export function sanitizeStoreKey(name: string): string {

--- a/packages/agent-core/src/profile/context.ts
+++ b/packages/agent-core/src/profile/context.ts
@@ -54,7 +54,7 @@ export async function loadAgentsMd(kaos: Kaos, workDir: string): Promise<string>
 
   // User-level files come first so any project-level AGENTS.md overrides them.
   const home = kaos.gethome();
-  await collect(joinPath(kaos, home, '.kimi-code', 'AGENTS.md'));
+  await collect(joinPath(kaos, home, '.byf', 'AGENTS.md'));
 
   // Generic user-level dir (.agents) matches skill discovery.
   const genericDirs = [joinPath(kaos, home, '.agents')];
@@ -66,7 +66,7 @@ export async function loadAgentsMd(kaos: Kaos, workDir: string): Promise<string>
   }
 
   for (const dir of dirs) {
-    await collect(joinPath(kaos, dir, '.kimi-code', 'AGENTS.md'));
+    await collect(joinPath(kaos, dir, '.byf', 'AGENTS.md'));
     for (const fileName of ['AGENTS.md', 'agents.md']) {
       if (await collect(joinPath(kaos, dir, fileName))) break;
     }

--- a/packages/agent-core/src/rpc/core-api.ts
+++ b/packages/agent-core/src/rpc/core-api.ts
@@ -57,7 +57,7 @@ export interface ExportSessionPayload {
   readonly outputPath?: string | undefined;
   /**
    * When true, the active global diagnostic log (`$BYF_HOME/logs/byf.log`)
-   * is copied into the zip at `logs/global/kimi-code.log`. Off by default to
+   * is copied into the zip at `logs/global/byf.log`. Off by default to
    * avoid bundling events from concurrent sessions / other projects.
    */
   readonly includeGlobalLog?: boolean | undefined;

--- a/packages/agent-core/src/rpc/core-api.ts
+++ b/packages/agent-core/src/rpc/core-api.ts
@@ -56,7 +56,7 @@ export interface ExportSessionPayload {
   readonly sessionId: string;
   readonly outputPath?: string | undefined;
   /**
-   * When true, the active global diagnostic log (`$KIMI_CODE_HOME/logs/kimi-code.log`)
+   * When true, the active global diagnostic log (`$BYF_HOME/logs/byf.log`)
    * is copied into the zip at `logs/global/kimi-code.log`. Off by default to
    * avoid bundling events from concurrent sessions / other projects.
    */

--- a/packages/agent-core/src/session/export/session-export.ts
+++ b/packages/agent-core/src/session/export/session-export.ts
@@ -12,8 +12,8 @@ import {
 } from '#/session/export/zip';
 import type { ExportSessionPayload, ExportSessionResult, SessionSummary } from '#/rpc/core-api';
 
-const SESSION_LOG_REL = 'logs/kimi-code.log';
-const GLOBAL_LOG_REL = 'logs/global/kimi-code.log';
+const SESSION_LOG_REL = 'logs/byf.log';
+const GLOBAL_LOG_REL = 'logs/global/byf.log';
 
 export async function exportSessionDirectory(input: {
   readonly request: ExportSessionPayload;

--- a/packages/agent-core/src/skill/scanner.ts
+++ b/packages/agent-core/src/skill/scanner.ts
@@ -5,9 +5,9 @@ import { SkillParseError, UnsupportedSkillTypeError, parseSkillFromFile } from '
 import type { SkillDefinition, SkillRoot, SkillSource, SkippedSkill } from './types';
 import { normalizeSkillName } from './types';
 
-const USER_BRAND_DIRS = ['.kimi-code/skills'] as const;
+const USER_BRAND_DIRS = ['.byf/skills'] as const;
 const USER_GENERIC_DIRS = ['.agents/skills'] as const;
-const PROJECT_BRAND_DIRS = ['.kimi-code/skills'] as const;
+const PROJECT_BRAND_DIRS = ['.byf/skills'] as const;
 const PROJECT_GENERIC_DIRS = ['.agents/skills'] as const;
 
 // Bounds recursion so a directory symlink cycle inside a skill root cannot

--- a/packages/agent-core/src/tools/support/rg-locator.ts
+++ b/packages/agent-core/src/tools/support/rg-locator.ts
@@ -4,8 +4,8 @@
  * Lookup order (first hit wins):
  *   1. System PATH (`which rg`) — fastest, respects developer setup
  *   2. Bundled vendor binary (hook; not wired yet — `getVendorRgPath` is a stub)
- *   3. `<KIMI_CODE_HOME>/bin/rg` — persistent cache for this app.
- *   4. CDN download to <KIMI_CODE_HOME>/bin/ — one-off bootstrap
+ *   3. `<BYF_HOME>/bin/rg` — persistent cache for this app.
+ *   4. CDN download to <BYF_HOME>/bin/ — one-off bootstrap
  *
  * If steps 1-4 all fail, callers receive a structured error they can
  * turn into a user-facing "install ripgrep" hint instead of the naked
@@ -125,9 +125,9 @@ function rgBinaryName(): string {
 }
 
 function getShareDir(): string {
-  const override = process.env['KIMI_CODE_HOME'];
+  const override = process.env['BYF_HOME'];
   if (override !== undefined && override !== '') return override;
-  return join(homedir(), '.kimi-code');
+  return join(homedir(), '.byf');
 }
 
 function getVendorRgPath(_binName: string): string | undefined {

--- a/packages/agent-core/test/agent/skill-tool-manager.test.ts
+++ b/packages/agent-core/test/agent/skill-tool-manager.test.ts
@@ -190,7 +190,7 @@ describe('ToolManager SkillTool registration', () => {
     try {
       const homeDir = join(tmp, 'home');
       const workDir = join(tmp, 'work');
-      const skillDir = join(workDir, '.kimi-code', 'skills', 'review');
+      const skillDir = join(workDir, '.byf', 'skills', 'review');
       await mkdir(skillDir, { recursive: true });
       await writeFile(
         join(skillDir, 'SKILL.md'),

--- a/packages/agent-core/test/config/configs.test.ts
+++ b/packages/agent-core/test/config/configs.test.ts
@@ -464,10 +464,8 @@ describe('harness config schema and patch merge', () => {
 
 describe('config path env override', () => {
   it('uses BYF_HOME when no explicit homeDir is supplied', () => {
-    const savedByf = process.env['BYF_HOME'];
-    const savedKimi = process.env['BYF_HOME'];
+    const saved = process.env['BYF_HOME'];
     try {
-      delete process.env['BYF_HOME'];
       process.env['BYF_HOME'] = '/tmp/byf-from-env';
 
       expect(resolveKimiHome()).toBe('/tmp/byf-from-env');
@@ -475,27 +473,21 @@ describe('config path env override', () => {
       expect(resolveConfigPath({})).toBe('/tmp/byf-from-env/config.toml');
       expect(resolveConfigPath({ configPath: '/tmp/custom.toml' })).toBe('/tmp/custom.toml');
     } finally {
-      if (savedByf === undefined) delete process.env['BYF_HOME'];
-      else process.env['BYF_HOME'] = savedByf;
-      if (savedKimi === undefined) delete process.env['BYF_HOME'];
-      else process.env['BYF_HOME'] = savedKimi;
+      if (saved === undefined) delete process.env['BYF_HOME'];
+      else process.env['BYF_HOME'] = saved;
     }
   });
 
   it('defaults to ~/.byf when no env var is set', () => {
-    const savedByf = process.env['BYF_HOME'];
-    const savedKimi = process.env['BYF_HOME'];
+    const saved = process.env['BYF_HOME'];
     try {
-      delete process.env['BYF_HOME'];
       delete process.env['BYF_HOME'];
 
       const result = resolveKimiHome();
       expect(result).toMatch(/\/\.byf$/);
     } finally {
-      if (savedByf === undefined) delete process.env['BYF_HOME'];
-      else process.env['BYF_HOME'] = savedByf;
-      if (savedKimi === undefined) delete process.env['BYF_HOME'];
-      else process.env['BYF_HOME'] = savedKimi;
+      if (saved === undefined) delete process.env['BYF_HOME'];
+      else process.env['BYF_HOME'] = saved;
     }
   });
 });

--- a/packages/agent-core/test/config/configs.test.ts
+++ b/packages/agent-core/test/config/configs.test.ts
@@ -243,7 +243,7 @@ describe('harness config TOML loader', () => {
     await ensureConfigFile(configPath);
 
     const text = await readFile(configPath, 'utf-8');
-    expect(text).toContain('Runtime settings for Kimi Code.');
+    expect(text).toContain('Runtime settings for BYF.');
     expect(text).not.toMatch(/^default_thinking =/m);
     expect(text).not.toMatch(/^default_model =/m);
 
@@ -463,18 +463,39 @@ describe('harness config schema and patch merge', () => {
 });
 
 describe('config path env override', () => {
-  it('uses KIMI_CODE_HOME when no explicit homeDir is supplied', () => {
-    const saved = process.env['KIMI_CODE_HOME'];
+  it('uses BYF_HOME when no explicit homeDir is supplied', () => {
+    const savedByf = process.env['BYF_HOME'];
+    const savedKimi = process.env['BYF_HOME'];
     try {
-      process.env['KIMI_CODE_HOME'] = '/tmp/kimi-from-env';
+      delete process.env['BYF_HOME'];
+      process.env['BYF_HOME'] = '/tmp/byf-from-env';
 
-      expect(resolveKimiHome()).toBe('/tmp/kimi-from-env');
-      expect(resolveKimiHome('/tmp/kimi-explicit')).toBe('/tmp/kimi-explicit');
-      expect(resolveConfigPath({})).toBe('/tmp/kimi-from-env/config.toml');
+      expect(resolveKimiHome()).toBe('/tmp/byf-from-env');
+      expect(resolveKimiHome('/tmp/byf-explicit')).toBe('/tmp/byf-explicit');
+      expect(resolveConfigPath({})).toBe('/tmp/byf-from-env/config.toml');
       expect(resolveConfigPath({ configPath: '/tmp/custom.toml' })).toBe('/tmp/custom.toml');
     } finally {
-      if (saved === undefined) delete process.env['KIMI_CODE_HOME'];
-      else process.env['KIMI_CODE_HOME'] = saved;
+      if (savedByf === undefined) delete process.env['BYF_HOME'];
+      else process.env['BYF_HOME'] = savedByf;
+      if (savedKimi === undefined) delete process.env['BYF_HOME'];
+      else process.env['BYF_HOME'] = savedKimi;
+    }
+  });
+
+  it('defaults to ~/.byf when no env var is set', () => {
+    const savedByf = process.env['BYF_HOME'];
+    const savedKimi = process.env['BYF_HOME'];
+    try {
+      delete process.env['BYF_HOME'];
+      delete process.env['BYF_HOME'];
+
+      const result = resolveKimiHome();
+      expect(result).toMatch(/\/\.byf$/);
+    } finally {
+      if (savedByf === undefined) delete process.env['BYF_HOME'];
+      else process.env['BYF_HOME'] = savedByf;
+      if (savedKimi === undefined) delete process.env['BYF_HOME'];
+      else process.env['BYF_HOME'] = savedKimi;
     }
   });
 });

--- a/packages/agent-core/test/harness/skill-session.test.ts
+++ b/packages/agent-core/test/harness/skill-session.test.ts
@@ -59,7 +59,7 @@ describe('HarnessAPI session skills', () => {
       source: 'project',
       disableModelInvocation: true,
     });
-    expect(listed?.path.endsWith('/.kimi-code/skills/phase-one-review/SKILL.md')).toBe(true);
+    expect(listed?.path.endsWith('/.byf/skills/phase-one-review/SKILL.md')).toBe(true);
     expect(JSON.stringify(skills)).not.toContain('Review the requested file.');
   });
 
@@ -114,10 +114,10 @@ describe('HarnessAPI session skills', () => {
     expect(names.has('sandbox-only')).toBe(false);
   });
 
-  it('resolves user skills from the OS home directory even when KIMI_CODE_HOME is set', async () => {
+  it('resolves user skills from the OS home directory even when BYF_HOME is set', async () => {
     const processHome = join(tmp, 'env-process-home');
     vi.stubEnv('HOME', processHome);
-    vi.stubEnv('KIMI_CODE_HOME', homeDir);
+    vi.stubEnv('BYF_HOME', homeDir);
     await writeUserSkill(processHome, 'env-real-home-only', 'Env real home skill');
     await writeUserSkill(homeDir, 'env-sandbox-only', 'Env sandbox skill');
     const { rpc } = await createTestRpc({});
@@ -262,7 +262,7 @@ describe('HarnessAPI session skills', () => {
 
     const records = await readMainWire(created.sessionDir);
     const prompt = records.find((record) => record['type'] === 'turn.prompt');
-    const skillDir = await realpath(join(workDir, '.kimi-code', 'skills', 'templated-review'));
+    const skillDir = await realpath(join(workDir, '.byf', 'skills', 'templated-review'));
     const expectedPrompt = [
       'Target: src/app.ts',
       'Mode: careful',
@@ -485,13 +485,13 @@ describe('HarnessAPI session skills', () => {
   });
 
   async function writeSkill(name: string, lines: readonly string[]): Promise<void> {
-    const dir = join(workDir, '.kimi-code', 'skills', name);
+    const dir = join(workDir, '.byf', 'skills', name);
     await mkdir(dir, { recursive: true });
     await writeFile(join(dir, 'SKILL.md'), lines.join('\n'));
   }
 
   async function writeUserSkill(userHomeDir: string, name: string, description: string): Promise<void> {
-    const dir = join(userHomeDir, '.kimi-code', 'skills', name);
+    const dir = join(userHomeDir, '.byf', 'skills', name);
     await mkdir(dir, { recursive: true });
     await writeFile(
       join(dir, 'SKILL.md'),
@@ -502,7 +502,7 @@ describe('HarnessAPI session skills', () => {
   }
 
   async function writeFlatSkill(name: string, lines: readonly string[]): Promise<void> {
-    const dir = join(workDir, '.kimi-code', 'skills');
+    const dir = join(workDir, '.byf', 'skills');
     await mkdir(dir, { recursive: true });
     await writeFile(join(dir, `${name}.md`), lines.join('\n'));
   }

--- a/packages/agent-core/test/logging/logger.test.ts
+++ b/packages/agent-core/test/logging/logger.test.ts
@@ -247,7 +247,7 @@ describe('session routing', () => {
       await handle.flush();
       await getRootLogger().flush();
       const global = await readGlobal();
-      const session = await readFile(join(sessionDir, 'logs', 'kimi-code.log'), 'utf-8');
+      const session = await readFile(join(sessionDir, 'logs', 'byf.log'), 'utf-8');
       expect(global).toContain('hello');
       expect(session).toContain('hello');
       await handle.close();
@@ -271,7 +271,7 @@ describe('session routing', () => {
       expect(global).toMatch(/llm config.*sessionId=ses_abc/);
       expect(global).toMatch(/llm request.*sessionId=ses_abc/);
 
-      const session = await readFile(join(sessionDir, 'logs', 'kimi-code.log'), 'utf-8');
+      const session = await readFile(join(sessionDir, 'logs', 'byf.log'), 'utf-8');
       expect(session).toMatch(/llm config.*sessionId=ses_abc/);
       expect(session).toMatch(/llm request(?!.*sessionId=ses_abc)/);
       expect(session).toMatch(/llm request(?!.*agentId=main)/);
@@ -291,7 +291,7 @@ describe('session routing', () => {
       await handle.flush();
       await getRootLogger().flush();
 
-      const session = await readFile(join(sessionDir, 'logs', 'kimi-code.log'), 'utf-8');
+      const session = await readFile(join(sessionDir, 'logs', 'byf.log'), 'utf-8');
       expect(session).toMatch(/llm request.*agentId=agent-0/);
       expect(session).toMatch(/llm request(?!.*sessionId=ses_abc)/);
       await handle.close();
@@ -312,7 +312,7 @@ describe('session routing', () => {
       expect(global).toContain('bootstrap event');
       let sessionText = '';
       try {
-        sessionText = await readFile(join(sessionDir, 'logs', 'kimi-code.log'), 'utf-8');
+        sessionText = await readFile(join(sessionDir, 'logs', 'byf.log'), 'utf-8');
       } catch {}
       expect(sessionText).not.toContain('bootstrap event');
       await handle.close();
@@ -337,8 +337,8 @@ describe('session routing', () => {
       log.info('ambiguous session id', { sessionId: 'ses_same' });
       await getRootLogger().flush();
 
-      const firstText = await readFile(join(firstDir, 'logs', 'kimi-code.log'), 'utf-8');
-      const secondText = await readFile(join(secondDir, 'logs', 'kimi-code.log'), 'utf-8');
+      const firstText = await readFile(join(firstDir, 'logs', 'byf.log'), 'utf-8');
+      const secondText = await readFile(join(secondDir, 'logs', 'byf.log'), 'utf-8');
       expect(firstText).toContain('first only');
       expect(firstText).not.toContain('second only');
       expect(firstText).not.toContain('ambiguous session id');
@@ -372,7 +372,7 @@ describe('session routing', () => {
       second.logger.info('still routes after first close');
       await second.flush();
 
-      const text = await readFile(join(sessionDir, 'logs', 'kimi-code.log'), 'utf-8');
+      const text = await readFile(join(sessionDir, 'logs', 'byf.log'), 'utf-8');
       expect(text).toContain('still routes after first close');
       await second.close();
     } finally {
@@ -400,7 +400,7 @@ describe('session routing', () => {
       second.logger.info('replacement still routes');
       await second.flush();
 
-      const secondText = await readFile(join(secondDir, 'logs', 'kimi-code.log'), 'utf-8');
+      const secondText = await readFile(join(secondDir, 'logs', 'byf.log'), 'utf-8');
       expect(secondText).toContain('replacement still routes');
       await second.close();
     } finally {
@@ -420,7 +420,7 @@ describe('session routing', () => {
       await expect(getRootLogger().flushSession('ses_closing')).resolves.toBe(true);
       await closing;
 
-      const text = await readFile(join(sessionDir, 'logs', 'kimi-code.log'), 'utf-8');
+      const text = await readFile(join(sessionDir, 'logs', 'byf.log'), 'utf-8');
       expect(text).toContain('close flush marker');
     } finally {
       await rm(sessionDir, { recursive: true, force: true });

--- a/packages/agent-core/test/mcp/config-loader.test.ts
+++ b/packages/agent-core/test/mcp/config-loader.test.ts
@@ -29,9 +29,9 @@ async function writeJson(path: string, value: unknown): Promise<void> {
 
 describe('resolveMcpJsonPaths', () => {
   it('returns the canonical user and project paths', () => {
-    const paths = resolveMcpJsonPaths({ cwd: '/work/proj', homeDir: '/home/user/.kimi-code' });
-    expect(paths.user).toBe('/home/user/.kimi-code/mcp.json');
-    expect(paths.project).toBe('/work/proj/.kimi-code/mcp.json');
+    const paths = resolveMcpJsonPaths({ cwd: '/work/proj', homeDir: '/home/user/.byf' });
+    expect(paths.user).toBe('/home/user/.byf/mcp.json');
+    expect(paths.project).toBe('/work/proj/.byf/mcp.json');
   });
 });
 
@@ -61,7 +61,7 @@ describe('loadMcpServers', () => {
         userOnly: { transport: 'stdio', command: 'user-only' },
       },
     });
-    await writeJson(join(cwd, '.kimi-code', 'mcp.json'), {
+    await writeJson(join(cwd, '.byf', 'mcp.json'), {
       mcpServers: {
         shared: { transport: 'stdio', command: 'shared-project' },
         local: { transport: 'http', url: 'http://localhost:8080/mcp' },
@@ -148,20 +148,20 @@ describe('loadMcpServers', () => {
     });
   });
 
-  it('honors KIMI_CODE_HOME env var when homeDir is not supplied', async () => {
+  it('honors BYF_HOME env var when homeDir is not supplied', async () => {
     const home = makeTempDir();
     const cwd = makeTempDir();
     await writeJson(join(home, 'mcp.json'), {
       mcpServers: { from_env: { transport: 'stdio', command: 'env-cmd' } },
     });
-    const saved = process.env['KIMI_CODE_HOME'];
-    process.env['KIMI_CODE_HOME'] = home;
+    const saved = process.env['BYF_HOME'];
+    process.env['BYF_HOME'] = home;
     try {
       const servers = await loadMcpServers({ cwd });
       expect(servers['from_env']).toEqual({ transport: 'stdio', command: 'env-cmd' });
     } finally {
-      if (saved === undefined) delete process.env['KIMI_CODE_HOME'];
-      else process.env['KIMI_CODE_HOME'] = saved;
+      if (saved === undefined) delete process.env['BYF_HOME'];
+      else process.env['BYF_HOME'] = saved;
     }
   });
 });

--- a/packages/agent-core/test/mcp/connection-manager.test.ts
+++ b/packages/agent-core/test/mcp/connection-manager.test.ts
@@ -692,7 +692,7 @@ describe('Session MCP startup', () => {
       ).resolves.toContain('session-token');
       await expect(
         readFile(
-          join(processHome, '.kimi-code', 'credentials', 'mcp', `${provider.storeKey}-tokens.json`),
+          join(processHome, '.byf', 'credentials', 'mcp', `${provider.storeKey}-tokens.json`),
           'utf-8',
         ),
       ).rejects.toMatchObject({ code: 'ENOENT' });

--- a/packages/agent-core/test/profile/context.test.ts
+++ b/packages/agent-core/test/profile/context.test.ts
@@ -24,8 +24,8 @@ afterEach(async () => {
 
 describe('loadAgentsMd user-level discovery', () => {
   it('loads user-level branded and generic files before project-level', async () => {
-    await mkdir(join(homeDir, '.kimi-code'), { recursive: true });
-    await writeFile(join(homeDir, '.kimi-code', 'AGENTS.md'), 'user branded', 'utf-8');
+    await mkdir(join(homeDir, '.byf'), { recursive: true });
+    await writeFile(join(homeDir, '.byf', 'AGENTS.md'), 'user branded', 'utf-8');
     await mkdir(join(homeDir, '.agents'), { recursive: true });
     await writeFile(join(homeDir, '.agents', 'AGENTS.md'), 'user generic', 'utf-8');
     await writeFile(join(workDir, 'AGENTS.md'), 'project instructions', 'utf-8');
@@ -58,8 +58,8 @@ describe('loadAgentsMd user-level discovery', () => {
   });
 
   it('does not load the same file twice when the work dir is the home dir', async () => {
-    await mkdir(join(homeDir, '.kimi-code'), { recursive: true });
-    await writeFile(join(homeDir, '.kimi-code', 'AGENTS.md'), 'home branded', 'utf-8');
+    await mkdir(join(homeDir, '.byf'), { recursive: true });
+    await writeFile(join(homeDir, '.byf', 'AGENTS.md'), 'home branded', 'utf-8');
 
     const result = await loadAgentsMd(localKaos, homeDir);
 

--- a/packages/agent-core/test/session/subagent-host.test.ts
+++ b/packages/agent-core/test/session/subagent-host.test.ts
@@ -832,7 +832,7 @@ describe('Session.createAgent', () => {
             '/repo/packages',
             workDir,
             `${workDir}/src`,
-            `${workDir}/.kimi-code`,
+            `${workDir}/.byf`,
           ].includes(path)
         ) {
           return stat('dir');
@@ -840,7 +840,7 @@ describe('Session.createAgent', () => {
         if (
           [
             '/repo/AGENTS.md',
-            `${workDir}/.kimi-code/AGENTS.md`,
+            `${workDir}/.byf/AGENTS.md`,
             `${workDir}/AGENTS.md`,
             `${workDir}/package.json`,
             `${workDir}/src/index.ts`,
@@ -864,7 +864,7 @@ describe('Session.createAgent', () => {
       },
       readText: vi.fn(async (path: string) => {
         if (path === '/repo/AGENTS.md') return 'root instructions';
-        if (path === `${workDir}/.kimi-code/AGENTS.md`) return 'brand instructions';
+        if (path === `${workDir}/.byf/AGENTS.md`) return 'brand instructions';
         if (path === `${workDir}/AGENTS.md`) return 'leaf instructions';
         throw new Error(`ENOENT ${path}`);
       }),
@@ -896,7 +896,7 @@ describe('Session.createAgent', () => {
     expect(created.agent.config.systemPrompt).toContain('<!-- From: /repo/AGENTS.md -->');
     expect(created.agent.config.systemPrompt).toContain('root instructions');
     expect(created.agent.config.systemPrompt).toContain(
-      '<!-- From: /repo/packages/app/.kimi-code/AGENTS.md -->',
+      '<!-- From: /repo/packages/app/.byf/AGENTS.md -->',
     );
     expect(created.agent.config.systemPrompt).toContain('brand instructions');
     expect(created.agent.config.systemPrompt).toContain(

--- a/packages/agent-core/test/skill/scanner.test.ts
+++ b/packages/agent-core/test/skill/scanner.test.ts
@@ -17,9 +17,9 @@ afterEach(async () => {
 describe('skill discovery', () => {
   it('resolves documented roots in precedence order with brand merging enabled by default', async () => {
     const { homeDir, repoDir, workDir } = await makeWorkspace();
-    await mkdir(path.join(repoDir, '.kimi-code', 'skills'), { recursive: true });
+    await mkdir(path.join(repoDir, '.byf', 'skills'), { recursive: true });
     await mkdir(path.join(repoDir, '.agents', 'skills'), { recursive: true });
-    await mkdir(path.join(homeDir, '.kimi-code', 'skills'), { recursive: true });
+    await mkdir(path.join(homeDir, '.byf', 'skills'), { recursive: true });
     await mkdir(path.join(homeDir, '.agents', 'skills'), { recursive: true });
     await mkdir(path.join(repoDir, 'team-skills'), { recursive: true });
     const realRepoDir = await realpath(repoDir);
@@ -30,9 +30,9 @@ describe('skill discovery', () => {
     });
 
     expect(roots.map((root) => path.relative(realRepoDir, root.path))).toEqual([
-      '.kimi-code/skills',
+      '.byf/skills',
       '.agents/skills',
-      path.relative(realRepoDir, await realpath(path.join(homeDir, '.kimi-code', 'skills'))),
+      path.relative(realRepoDir, await realpath(path.join(homeDir, '.byf', 'skills'))),
       path.relative(realRepoDir, await realpath(path.join(homeDir, '.agents', 'skills'))),
       'team-skills',
     ]);
@@ -47,8 +47,8 @@ describe('skill discovery', () => {
 
   it('uses only the first brand directory when brand merging is disabled', async () => {
     const { homeDir, repoDir, workDir } = await makeWorkspace();
-    await mkdir(path.join(repoDir, '.kimi-code', 'skills'), { recursive: true });
-    await mkdir(path.join(homeDir, '.kimi-code', 'skills'), { recursive: true });
+    await mkdir(path.join(repoDir, '.byf', 'skills'), { recursive: true });
+    await mkdir(path.join(homeDir, '.byf', 'skills'), { recursive: true });
 
     const roots = await resolveSkillRoots({
       paths: { userHomeDir: homeDir, workDir },
@@ -56,15 +56,15 @@ describe('skill discovery', () => {
     });
 
     expect(roots.map((root) => root.path)).toEqual([
-      await realpath(path.join(repoDir, '.kimi-code', 'skills')),
-      await realpath(path.join(homeDir, '.kimi-code', 'skills')),
+      await realpath(path.join(repoDir, '.byf', 'skills')),
+      await realpath(path.join(homeDir, '.byf', 'skills')),
     ]);
   });
 
   it('lets explicit skill dirs replace automatic project and user discovery', async () => {
     const { homeDir, repoDir, workDir } = await makeWorkspace();
-    await mkdir(path.join(repoDir, '.kimi-code', 'skills'), { recursive: true });
-    await mkdir(path.join(homeDir, '.kimi-code', 'skills'), { recursive: true });
+    await mkdir(path.join(repoDir, '.byf', 'skills'), { recursive: true });
+    await mkdir(path.join(homeDir, '.byf', 'skills'), { recursive: true });
     await mkdir(path.join(repoDir, 'explicit-skills'), { recursive: true });
     await mkdir(path.join(repoDir, 'extra-skills'), { recursive: true });
 
@@ -83,8 +83,8 @@ describe('skill discovery', () => {
 
   it('discovers flat markdown skills, keeps directory skills over same-name flat files, and preserves source precedence', async () => {
     const { homeDir, repoDir } = await makeWorkspace();
-    const projectRoot = path.join(repoDir, '.kimi-code', 'skills');
-    const userRoot = path.join(homeDir, '.kimi-code', 'skills');
+    const projectRoot = path.join(repoDir, '.byf', 'skills');
+    const userRoot = path.join(homeDir, '.byf', 'skills');
     await writeSkill(projectRoot, 'review.md', ['Project review body first line.', '', 'Details.']);
     await writeSkill(userRoot, path.join('review', 'SKILL.md'), [
       '---',
@@ -123,7 +123,7 @@ describe('skill discovery', () => {
 
   it('keeps flow skills user-visible while excluding them from model invocation', async () => {
     const { repoDir } = await makeWorkspace();
-    const projectRoot = path.join(repoDir, '.kimi-code', 'skills');
+    const projectRoot = path.join(repoDir, '.byf', 'skills');
     await writeSkill(projectRoot, path.join('review-flow', 'SKILL.md'), [
       '---',
       'name: review-flow',
@@ -146,7 +146,7 @@ describe('skill discovery', () => {
 
   it('skips directory skills with missing frontmatter metadata', async () => {
     const { repoDir } = await makeWorkspace();
-    const projectRoot = path.join(repoDir, '.kimi-code', 'skills');
+    const projectRoot = path.join(repoDir, '.byf', 'skills');
     await writeSkill(projectRoot, path.join('valid', 'SKILL.md'), [
       '---',
       'name: valid',
@@ -192,7 +192,7 @@ describe('skill discovery', () => {
 describe('discoverSkills shape and ordering', () => {
   it('parses frontmatter name/description for subdir skills', async () => {
     const { repoDir } = await makeWorkspace();
-    const root = path.join(repoDir, '.kimi-code', 'skills');
+    const root = path.join(repoDir, '.byf', 'skills');
     await writeSkill(root, path.join('alpha', 'SKILL.md'), [
       '---',
       'name: alpha-skill',
@@ -239,7 +239,7 @@ describe('discoverSkills shape and ordering', () => {
 
   it('does not register a top-level SKILL.md as a flat skill', async () => {
     const { repoDir } = await makeWorkspace();
-    const root = path.join(repoDir, '.kimi-code', 'skills');
+    const root = path.join(repoDir, '.byf', 'skills');
     await mkdir(root, { recursive: true });
     await writeFile(
       path.join(root, 'SKILL.md'),
@@ -253,7 +253,7 @@ describe('discoverSkills shape and ordering', () => {
 
   it('lists flat skills with frontmatter name and description', async () => {
     const { repoDir } = await makeWorkspace();
-    const root = path.join(repoDir, '.kimi-code', 'skills');
+    const root = path.join(repoDir, '.byf', 'skills');
     await mkdir(root, { recursive: true });
     await writeFile(
       path.join(root, 'demo-ui-components.md'),
@@ -269,7 +269,7 @@ describe('discoverSkills shape and ordering', () => {
 
   it('discovers both flat and subdir skills alongside in the same root', async () => {
     const { repoDir } = await makeWorkspace();
-    const root = path.join(repoDir, '.kimi-code', 'skills');
+    const root = path.join(repoDir, '.byf', 'skills');
     await writeSkill(root, path.join('subdir-skill', 'SKILL.md'), [
       '---',
       'name: subdir-skill',
@@ -288,7 +288,7 @@ describe('discoverSkills shape and ordering', () => {
 
   it('prefers the subdir version when a flat and subdir skill share a name', async () => {
     const { repoDir } = await makeWorkspace();
-    const root = path.join(repoDir, '.kimi-code', 'skills');
+    const root = path.join(repoDir, '.byf', 'skills');
     await writeSkill(root, path.join('greet', 'SKILL.md'), [
       '---',
       'name: greet',
@@ -308,7 +308,7 @@ describe('discoverSkills shape and ordering', () => {
 
   it('discovers skills nested in subdirectories at multiple depths', async () => {
     const { repoDir } = await makeWorkspace();
-    const root = path.join(repoDir, '.kimi-code', 'skills');
+    const root = path.join(repoDir, '.byf', 'skills');
     await writeSkill(root, path.join('top', 'SKILL.md'), [
       '---',
       'name: top',
@@ -337,7 +337,7 @@ describe('discoverSkills shape and ordering', () => {
 
   it('does not descend into a skill bundle subdirectory', async () => {
     const { repoDir } = await makeWorkspace();
-    const root = path.join(repoDir, '.kimi-code', 'skills');
+    const root = path.join(repoDir, '.byf', 'skills');
     await writeSkill(root, path.join('outer', 'SKILL.md'), [
       '---',
       'name: outer',
@@ -358,7 +358,7 @@ describe('discoverSkills shape and ordering', () => {
 
   it('skips node_modules when scanning nested directories', async () => {
     const { repoDir } = await makeWorkspace();
-    const root = path.join(repoDir, '.kimi-code', 'skills');
+    const root = path.join(repoDir, '.byf', 'skills');
     await writeSkill(root, path.join('real', 'SKILL.md'), [
       '---',
       'name: real',
@@ -379,7 +379,7 @@ describe('discoverSkills shape and ordering', () => {
 
   it('stops recursing past the maximum scan depth', async () => {
     const { repoDir } = await makeWorkspace();
-    const root = path.join(repoDir, '.kimi-code', 'skills');
+    const root = path.join(repoDir, '.byf', 'skills');
     await writeSkill(root, path.join('shallow', 'SKILL.md'), [
       '---',
       'name: shallow',
@@ -401,7 +401,7 @@ describe('discoverSkills shape and ordering', () => {
 
   it('prefers a shallower skill over a deeper one with the same name', async () => {
     const { repoDir } = await makeWorkspace();
-    const root = path.join(repoDir, '.kimi-code', 'skills');
+    const root = path.join(repoDir, '.byf', 'skills');
     await writeSkill(root, path.join('dup', 'SKILL.md'), [
       '---',
       'name: dup',
@@ -423,7 +423,7 @@ describe('discoverSkills shape and ordering', () => {
 
   it('resolves a same-name collision across sibling directories deterministically', async () => {
     const { repoDir } = await makeWorkspace();
-    const root = path.join(repoDir, '.kimi-code', 'skills');
+    const root = path.join(repoDir, '.byf', 'skills');
     // Created out of alphabetical order so the result cannot depend on
     // filesystem readdir order; the alphabetically-first sibling must win.
     await writeSkill(root, path.join('group-b', 'dup', 'SKILL.md'), [
@@ -508,7 +508,7 @@ describe('resolveSkillRoots ordering and priority', () => {
       'description: generic version',
       '---',
     ]);
-    const brand = path.join(homeDir, '.kimi-code', 'skills');
+    const brand = path.join(homeDir, '.byf', 'skills');
     await writeSkill(brand, path.join('greet', 'SKILL.md'), [
       '---',
       'name: greet',
@@ -525,9 +525,9 @@ describe('resolveSkillRoots ordering and priority', () => {
 
   it('returns proj-brand, proj-generic, user-brand, user-generic, builtin in that order without merging', async () => {
     const { homeDir, repoDir, workDir } = await makeWorkspace();
-    const userBrand = path.join(homeDir, '.kimi-code', 'skills');
+    const userBrand = path.join(homeDir, '.byf', 'skills');
     const userGeneric = path.join(homeDir, '.agents', 'skills');
-    const projBrand = path.join(repoDir, '.kimi-code', 'skills');
+    const projBrand = path.join(repoDir, '.byf', 'skills');
     const projGeneric = path.join(repoDir, '.agents', 'skills');
     const builtin = path.join(repoDir, 'builtin');
     for (const d of [userBrand, userGeneric, projBrand, projGeneric, builtin]) {
@@ -553,7 +553,7 @@ describe('resolveSkillRoots ordering and priority', () => {
     const { homeDir, workDir } = await makeWorkspace();
     const generic = path.join(homeDir, '.config', 'agents', 'skills');
     await mkdir(generic, { recursive: true });
-    const brand = path.join(homeDir, '.kimi-code', 'skills');
+    const brand = path.join(homeDir, '.byf', 'skills');
     await writeSkill(brand, path.join('deploy', 'SKILL.md'), [
       '---',
       'name: deploy',
@@ -569,12 +569,12 @@ describe('resolveSkillRoots ordering and priority', () => {
 
   it('defaults to merging user brand dirs', async () => {
     const { homeDir, workDir } = await makeWorkspace();
-    await mkdir(path.join(homeDir, '.kimi-code', 'skills'), { recursive: true });
+    await mkdir(path.join(homeDir, '.byf', 'skills'), { recursive: true });
 
     const roots = await resolveSkillRoots({ paths: { userHomeDir: homeDir, workDir } });
 
     const paths = roots.map((r) => r.path);
-    expect(paths).toContain(await realpath(path.join(homeDir, '.kimi-code', 'skills')));
+    expect(paths).toContain(await realpath(path.join(homeDir, '.byf', 'skills')));
   });
 });
 
@@ -687,9 +687,9 @@ describe('resolveSkillRoots extra dirs', () => {
 
   it('combines explicit dirs with extra dirs and suppresses auto-discovery', async () => {
     const { homeDir, repoDir, workDir } = await makeWorkspace();
-    const userBrand = path.join(homeDir, '.kimi-code', 'skills');
+    const userBrand = path.join(homeDir, '.byf', 'skills');
     await mkdir(userBrand, { recursive: true });
-    const projectBrand = path.join(repoDir, '.kimi-code', 'skills');
+    const projectBrand = path.join(repoDir, '.byf', 'skills');
     await mkdir(projectBrand, { recursive: true });
     const cli = path.join(repoDir, 'cli');
     await mkdir(cli, { recursive: true });
@@ -777,7 +777,7 @@ describe('resolveSkillRoots extra dirs', () => {
 
   it('keeps the higher-priority scope when an extra dir overlaps with auto-discovered user dirs', async () => {
     const { homeDir, repoDir, workDir } = await makeWorkspace();
-    const userBrand = path.join(homeDir, '.kimi-code', 'skills');
+    const userBrand = path.join(homeDir, '.byf', 'skills');
     await writeSkill(userBrand, path.join('foo', 'SKILL.md'), [
       '---',
       'name: foo',
@@ -808,7 +808,7 @@ describe('scope priority across resolution and discovery', () => {
       'description: builtin version',
       '---',
     ]);
-    const userBrand = path.join(homeDir, '.kimi-code', 'skills');
+    const userBrand = path.join(homeDir, '.byf', 'skills');
     await writeSkill(userBrand, path.join('foo', 'SKILL.md'), [
       '---',
       'name: foo',
@@ -829,14 +829,14 @@ describe('scope priority across resolution and discovery', () => {
 
   it('lets a project-scope skill win over a same-named user-scope skill', async () => {
     const { homeDir, repoDir, workDir } = await makeWorkspace();
-    const userBrand = path.join(homeDir, '.kimi-code', 'skills');
+    const userBrand = path.join(homeDir, '.byf', 'skills');
     await writeSkill(userBrand, path.join('foo', 'SKILL.md'), [
       '---',
       'name: foo',
       'description: user version',
       '---',
     ]);
-    const projBrand = path.join(repoDir, '.kimi-code', 'skills');
+    const projBrand = path.join(repoDir, '.byf', 'skills');
     await writeSkill(projBrand, path.join('foo', 'SKILL.md'), [
       '---',
       'name: foo',
@@ -861,7 +861,7 @@ describe('scope priority across resolution and discovery', () => {
       'description: builtin version',
       '---',
     ]);
-    const projBrand = path.join(repoDir, '.kimi-code', 'skills');
+    const projBrand = path.join(repoDir, '.byf', 'skills');
     await writeSkill(projBrand, path.join('foo', 'SKILL.md'), [
       '---',
       'name: foo',
@@ -911,7 +911,7 @@ describe('scope priority across resolution and discovery', () => {
 
   it('lets a user-scope skill win over a same-named extra-scope skill', async () => {
     const { homeDir, repoDir, workDir } = await makeWorkspace();
-    const userBrand = path.join(homeDir, '.kimi-code', 'skills');
+    const userBrand = path.join(homeDir, '.byf', 'skills');
     await writeSkill(userBrand, path.join('foo', 'SKILL.md'), [
       '---',
       'name: foo',
@@ -939,14 +939,14 @@ describe('scope priority across resolution and discovery', () => {
 
   it('fully excludes user and project scopes when explicit dirs are supplied', async () => {
     const { homeDir, repoDir, workDir } = await makeWorkspace();
-    const userBrand = path.join(homeDir, '.kimi-code', 'skills');
+    const userBrand = path.join(homeDir, '.byf', 'skills');
     await writeSkill(userBrand, path.join('foo', 'SKILL.md'), [
       '---',
       'name: foo',
       'description: user version',
       '---',
     ]);
-    const projBrand = path.join(repoDir, '.kimi-code', 'skills');
+    const projBrand = path.join(repoDir, '.byf', 'skills');
     await writeSkill(projBrand, path.join('foo', 'SKILL.md'), [
       '---',
       'name: foo',
@@ -981,14 +981,14 @@ describe('scope priority across resolution and discovery', () => {
       'description: builtin version',
       '---',
     ]);
-    const userBrand = path.join(homeDir, '.kimi-code', 'skills');
+    const userBrand = path.join(homeDir, '.byf', 'skills');
     await writeSkill(userBrand, path.join('foo', 'SKILL.md'), [
       '---',
       'name: foo',
       'description: user version',
       '---',
     ]);
-    const projBrand = path.join(repoDir, '.kimi-code', 'skills');
+    const projBrand = path.join(repoDir, '.byf', 'skills');
     await writeSkill(projBrand, path.join('foo', 'SKILL.md'), [
       '---',
       'name: foo',
@@ -1041,9 +1041,9 @@ describe('scope priority across resolution and discovery', () => {
 describe('explicit dir override and scope stamping', () => {
   it('suppresses user and project auto-discovery when explicit dirs are present', async () => {
     const { homeDir, repoDir, workDir } = await makeWorkspace();
-    const userBrand = path.join(homeDir, '.kimi-code', 'skills');
+    const userBrand = path.join(homeDir, '.byf', 'skills');
     await mkdir(userBrand, { recursive: true });
-    const projBrand = path.join(repoDir, '.kimi-code', 'skills');
+    const projBrand = path.join(repoDir, '.byf', 'skills');
     await mkdir(projBrand, { recursive: true });
     const extraA = path.join(repoDir, 'extra_a');
     const extraB = path.join(repoDir, 'extra_b');
@@ -1070,7 +1070,7 @@ describe('explicit dir override and scope stamping', () => {
     const { homeDir, workDir } = await makeWorkspace();
     const generic = path.join(homeDir, '.agents', 'skills');
     await mkdir(generic, { recursive: true });
-    const brand = path.join(homeDir, '.kimi-code', 'skills');
+    const brand = path.join(homeDir, '.byf', 'skills');
     await mkdir(brand, { recursive: true });
 
     const roots = await resolveSkillRoots({ paths: { userHomeDir: homeDir, workDir } });
@@ -1085,14 +1085,14 @@ describe('explicit dir override and scope stamping', () => {
 
   it('stamps each discovered skill with the scope of its root', async () => {
     const { homeDir, repoDir, workDir } = await makeWorkspace();
-    const userBrand = path.join(homeDir, '.kimi-code', 'skills');
+    const userBrand = path.join(homeDir, '.byf', 'skills');
     await writeSkill(userBrand, path.join('user-skill', 'SKILL.md'), [
       '---',
       'name: user-skill',
       'description: u',
       '---',
     ]);
-    const projBrand = path.join(repoDir, '.kimi-code', 'skills');
+    const projBrand = path.join(repoDir, '.byf', 'skills');
     await writeSkill(projBrand, path.join('proj-skill', 'SKILL.md'), [
       '---',
       'name: proj-skill',
@@ -1130,7 +1130,7 @@ describe('project root discovery (.git walk-up)', () => {
     const repo = await mkdtemp(path.join(tmpdir(), 'kimi-skill-walkup-'));
     tempDirs.push(repo);
     await mkdir(path.join(repo, '.git'), { recursive: true });
-    const repoKimi = path.join(repo, '.kimi-code', 'skills');
+    const repoKimi = path.join(repo, '.byf', 'skills');
     await writeSkill(repoKimi, path.join('foo', 'SKILL.md'), [
       '---',
       'name: foo',
@@ -1153,7 +1153,7 @@ describe('project root discovery (.git walk-up)', () => {
     const noGitTmp = await mkdtemp(path.join(tmpdir(), 'kimi-skill-nogit-'));
     tempDirs.push(noGitTmp);
     const project = path.join(noGitTmp, 'project');
-    await mkdir(path.join(project, '.kimi-code', 'skills'), { recursive: true });
+    await mkdir(path.join(project, '.byf', 'skills'), { recursive: true });
     const workDir = path.join(project, 'foo');
     await mkdir(workDir, { recursive: true });
 
@@ -1162,7 +1162,7 @@ describe('project root discovery (.git walk-up)', () => {
     });
     const projectPaths = roots.filter((r) => r.source === 'project').map((r) => r.path);
 
-    expect(projectPaths.some((p) => p.includes(path.join('project', '.kimi-code', 'skills')))).toBe(false);
+    expect(projectPaths.some((p) => p.includes(path.join('project', '.byf', 'skills')))).toBe(false);
   });
 });
 

--- a/packages/node-sdk/examples/kimi-harness-log-marker.ts
+++ b/packages/node-sdk/examples/kimi-harness-log-marker.ts
@@ -32,7 +32,7 @@ const USAGE = `Usage:
 
 Options:
   -s, --session <id>   Existing session id to resume and mark
-      --home <dir>     Kimi home dir; defaults to KIMI_CODE_HOME or ~/.kimi-code
+      --home <dir>     Kimi home dir; defaults to BYF_HOME or ~/.byf
       --level <level>  error | warn; defaults to error
   -m, --message <text> Marker text; defaults to MANUAL_SESSION_LOG_MARKER_<timestamp>
   -h, --help           Show this help
@@ -89,7 +89,7 @@ async function main(): Promise<void> {
     process.stderr.write(
       [
         'error: marker was not found in the session log.',
-        'Check that KIMI_LOG_LEVEL is not "off" and that the session id exists in this KIMI_CODE_HOME.',
+        'Check that KIMI_LOG_LEVEL is not "off" and that the session id exists in this BYF_HOME.',
         '',
       ].join('\n'),
     );

--- a/packages/node-sdk/examples/kimi-harness-log-marker.ts
+++ b/packages/node-sdk/examples/kimi-harness-log-marker.ts
@@ -54,7 +54,7 @@ async function main(): Promise<void> {
       throw new Error(`Session "${session.id}" resumed without a sessionDir summary`);
     }
 
-    sessionLogPath = join(sessionDir, 'logs', 'kimi-code.log');
+    sessionLogPath = join(sessionDir, 'logs', 'byf.log');
     const payload = {
       sessionId: session.id,
       purpose: 'manual-log-marker',

--- a/packages/node-sdk/examples/kimi-harness-logging-smoke.ts
+++ b/packages/node-sdk/examples/kimi-harness-logging-smoke.ts
@@ -4,8 +4,8 @@ import { join } from 'node:path';
 
 import { KimiHarness, log } from '@byf/sdk';
 
-const SESSION_LOG = 'logs/kimi-code.log';
-const GLOBAL_LOG = 'logs/global/kimi-code.log';
+const SESSION_LOG = 'logs/byf.log';
+const GLOBAL_LOG = 'logs/global/byf.log';
 const MAIN_WIRE = 'agents/main/wire.jsonl';
 const TEST_HOME = join(homedir(), '.byf-test');
 const MAX_LOG_BYTES = 4096;
@@ -28,15 +28,15 @@ async function readSessionLogs(sessionDir: string): Promise<{
 }> {
   const logsDir = join(sessionDir, 'logs');
   const files = (await readdir(logsDir))
-    .filter((file) => file === 'kimi-code.log' || file.startsWith('kimi-code.log.'))
+    .filter((file) => file === 'byf.log' || file.startsWith('byf.log.'))
     .toSorted();
   const chunks = await Promise.all(files.map((file) => readFile(join(logsDir, file), 'utf-8')));
   return { files, text: chunks.join('\n') };
 }
 
 async function assertRotatedFilesStayBounded(sessionDir: string, files: readonly string[]): Promise<void> {
-  assert(files.includes('kimi-code.log.1'), 'session log did not rotate after exceeding max bytes');
-  assert(!files.includes('kimi-code.log.2'), 'session log kept more archives than configured');
+  assert(files.includes('byf.log.1'), 'session log did not rotate after exceeding max bytes');
+  assert(!files.includes('byf.log.2'), 'session log kept more archives than configured');
   for (const file of files) {
     const size = (await stat(join(sessionDir, 'logs', file))).size;
     assert(size <= MAX_LOG_BYTES, `${file} exceeded ${MAX_LOG_BYTES} bytes: ${size}`);
@@ -150,7 +150,7 @@ async function main(): Promise<void> {
     assert(withGlobal.manifest.globalLogPath === GLOBAL_LOG, 'bad globalLogPath');
 
     const globalFiles = (await readdir(join(TEST_HOME, 'logs')))
-      .filter((file) => file === 'kimi-code.log' || file.startsWith('kimi-code.log.'))
+      .filter((file) => file === 'byf.log' || file.startsWith('byf.log.'))
       .toSorted();
     const globalLog = (
       await Promise.all(globalFiles.map((file) => readFile(join(TEST_HOME, 'logs', file), 'utf-8')))
@@ -176,22 +176,22 @@ async function main(): Promise<void> {
         'production defaults are larger; this small cap is only for rotation testing.',
         '',
         'Open these files:',
-        '  - logs/kimi-code.log',
-        '  - logs/kimi-code.log.1',
-        `  - ${summary.sessionDir}/logs/kimi-code.log`,
-        `  - ${summary.sessionDir}/logs/kimi-code.log.1`,
+        '  - logs/byf.log',
+        '  - logs/byf.log.1',
+        `  - ${summary.sessionDir}/logs/byf.log`,
+        `  - ${summary.sessionDir}/logs/byf.log.1`,
         '',
         'Rotation evidence:',
         `  - should NOT appear in session logs: ${evictedEntry}`,
         `  - should appear in session logs: ${finalEntry}`,
-        '  - kimi-code.log.1 exists',
-        '  - kimi-code.log.2 does not exist',
+        '  - byf.log.1 exists',
+        '  - byf.log.2 does not exist',
         '',
         'Export evidence:',
         '  - logging-session.zip includes session logs and wire.jsonl',
-        '  - logging-session.zip does not include logs/global/kimi-code.log',
-        '  - logging-with-global.zip includes only the active global log at logs/global/kimi-code.log',
-        '  - global rotated logs such as ~/.byf-test/logs/kimi-code.log.1 are intentionally not bundled',
+        '  - logging-session.zip does not include logs/global/byf.log',
+        '  - logging-with-global.zip includes only the active global log at logs/global/byf.log',
+        '  - global rotated logs such as ~/.byf-test/logs/byf.log.1 are intentionally not bundled',
         '',
         'Redaction evidence:',
         '  - must-not-leak should NOT appear',

--- a/packages/node-sdk/examples/kimi-harness-logging-smoke.ts
+++ b/packages/node-sdk/examples/kimi-harness-logging-smoke.ts
@@ -7,7 +7,7 @@ import { KimiHarness, log } from '@byf/sdk';
 const SESSION_LOG = 'logs/kimi-code.log';
 const GLOBAL_LOG = 'logs/global/kimi-code.log';
 const MAIN_WIRE = 'agents/main/wire.jsonl';
-const TEST_HOME = join(homedir(), '.kimi-code-test');
+const TEST_HOME = join(homedir(), '.byf-test');
 const MAX_LOG_BYTES = 4096;
 
 function assert(value: unknown, message: string): asserts value {
@@ -53,7 +53,7 @@ async function describeFiles(dir: string, files: readonly string[]): Promise<str
 }
 
 async function main(): Promise<void> {
-  process.env['KIMI_CODE_HOME'] = TEST_HOME;
+  process.env['BYF_HOME'] = TEST_HOME;
   process.env['KIMI_LOG_LEVEL'] = 'warn';
   process.env['KIMI_LOG_SESSION_MAX_BYTES'] = String(MAX_LOG_BYTES);
   process.env['KIMI_LOG_SESSION_FILES'] = '2';
@@ -191,7 +191,7 @@ async function main(): Promise<void> {
         '  - logging-session.zip includes session logs and wire.jsonl',
         '  - logging-session.zip does not include logs/global/kimi-code.log',
         '  - logging-with-global.zip includes only the active global log at logs/global/kimi-code.log',
-        '  - global rotated logs such as ~/.kimi-code-test/logs/kimi-code.log.1 are intentionally not bundled',
+        '  - global rotated logs such as ~/.byf-test/logs/kimi-code.log.1 are intentionally not bundled',
         '',
         'Redaction evidence:',
         '  - must-not-leak should NOT appear',

--- a/packages/node-sdk/test/config.test.ts
+++ b/packages/node-sdk/test/config.test.ts
@@ -295,7 +295,7 @@ describe('KimiHarness config API', () => {
     await harness.ensureConfigFile();
 
     const text = await readFile(configPath, 'utf-8');
-    expect(text).toContain('Runtime settings for Kimi Code.');
+    expect(text).toContain('Runtime settings for BYF.');
     expect(text).not.toMatch(/^default_thinking =/m);
     expect(text).not.toMatch(/^default_model =/m);
 

--- a/packages/node-sdk/test/export-session.test.ts
+++ b/packages/node-sdk/test/export-session.test.ts
@@ -199,9 +199,9 @@ describe('exportSessionDirectory', () => {
     });
 
     expect(result.manifest.globalLogPath).toBeUndefined();
-    expect(result.entries).not.toContain('logs/global/kimi-code.log');
+    expect(result.entries).not.toContain('logs/global/byf.log');
     const entries = readZipEntries(await readFile(outputPath));
-    expect(entries.has('logs/global/kimi-code.log')).toBe(false);
+    expect(entries.has('logs/global/byf.log')).toBe(false);
     const manifest = JSON.parse(entries.get('manifest.json')!.toString('utf-8')) as Record<
       string,
       unknown

--- a/packages/node-sdk/test/local-logging.test.ts
+++ b/packages/node-sdk/test/local-logging.test.ts
@@ -117,8 +117,8 @@ describe('Local logging — harness integration', () => {
       (s) => s.id === session.id,
     )!;
 
-    const globalPath = join(homeDir, 'logs', 'kimi-code.log');
-    const sessionLogPath = join(summary.sessionDir, 'logs', 'kimi-code.log');
+    const globalPath = join(homeDir, 'logs', 'byf.log');
+    const sessionLogPath = join(summary.sessionDir, 'logs', 'byf.log');
 
     // Trigger an export — this flushes both global and session via KimiCore
     const exportOut = join(workDir, 'out.zip');
@@ -150,18 +150,18 @@ describe('Local logging — harness integration', () => {
     const zipBuf = await readFile(result.zipPath);
     const entries = readZipEntries(zipBuf);
     expect(entries.has('agents/main/wire.jsonl')).toBe(true);
-    expect(entries.has('logs/kimi-code.log')).toBe(true);
-    expect(entries.has('logs/global/kimi-code.log')).toBe(false);
-    expect(entries.get('logs/kimi-code.log')!.toString('utf-8')).toContain(
+    expect(entries.has('logs/byf.log')).toBe(true);
+    expect(entries.has('logs/global/byf.log')).toBe(false);
+    expect(entries.get('logs/byf.log')!.toString('utf-8')).toContain(
       'session export marker',
     );
-    expect(result.manifest.sessionLogPath).toBe('logs/kimi-code.log');
+    expect(result.manifest.sessionLogPath).toBe('logs/byf.log');
     expect(result.manifest.globalLogPath).toBeUndefined();
     const manifest = JSON.parse(entries.get('manifest.json')!.toString('utf-8')) as Record<
       string,
       unknown
     >;
-    expect(manifest['sessionLogPath']).toBe('logs/kimi-code.log');
+    expect(manifest['sessionLogPath']).toBe('logs/byf.log');
     expect(manifest['globalLogPath']).toBeUndefined();
   });
 
@@ -176,7 +176,7 @@ describe('Local logging — harness integration', () => {
 
     const entries = readZipEntries(await readFile(result.zipPath));
     expect(entries.has('agents/main/wire.jsonl')).toBe(true);
-    expect(entries.has('logs/kimi-code.log')).toBe(false);
+    expect(entries.has('logs/byf.log')).toBe(false);
     expect(result.manifest.sessionLogPath).toBeUndefined();
     const manifest = JSON.parse(entries.get('manifest.json')!.toString('utf-8')) as Record<
       string,
@@ -185,7 +185,7 @@ describe('Local logging — harness integration', () => {
     expect(manifest['sessionLogPath']).toBeUndefined();
   });
 
-  it('default export includes rotated session log files without requiring active kimi-code.log', async () => {
+  it('default export includes rotated session log files without requiring active byf.log', async () => {
     const env = snapshotLogEnv();
     process.env['KIMI_LOG_LEVEL'] = 'warn';
     process.env['KIMI_LOG_SESSION_MAX_BYTES'] = '1024';
@@ -210,13 +210,13 @@ describe('Local logging — harness integration', () => {
 
       const entries = readZipEntries(await readFile(result.zipPath));
       const sessionLogEntries = [...entries.keys()].filter(
-        (entry) => entry === 'logs/kimi-code.log' || entry.startsWith('logs/kimi-code.log.'),
+        (entry) => entry === 'logs/byf.log' || entry.startsWith('logs/byf.log.'),
       );
       expect(sessionLogEntries.length).toBeGreaterThan(0);
-      expect(sessionLogEntries).toContain('logs/kimi-code.log.1');
-      expect(entries.has('logs/global/kimi-code.log')).toBe(false);
-      if (entries.has('logs/kimi-code.log')) {
-        expect(result.manifest.sessionLogPath).toBe('logs/kimi-code.log');
+      expect(sessionLogEntries).toContain('logs/byf.log.1');
+      expect(entries.has('logs/global/byf.log')).toBe(false);
+      if (entries.has('logs/byf.log')) {
+        expect(result.manifest.sessionLogPath).toBe('logs/byf.log');
       } else {
         expect(result.manifest.sessionLogPath).toBeUndefined();
       }
@@ -242,10 +242,10 @@ describe('Local logging — harness integration', () => {
     const zipBuf = await readFile(result.zipPath);
     const entries = readZipEntries(zipBuf);
     expect(entries.has('agents/main/wire.jsonl')).toBe(true);
-    expect(entries.has('logs/global/kimi-code.log')).toBe(true);
-    expect(result.manifest.globalLogPath).toBe('logs/global/kimi-code.log');
+    expect(entries.has('logs/global/byf.log')).toBe(true);
+    expect(result.manifest.globalLogPath).toBe('logs/global/byf.log');
     // Global log carries entries that don't have a sessionId routed to a sink.
-    expect(entries.get('logs/global/kimi-code.log')!.toString('utf-8')).toContain(
+    expect(entries.get('logs/global/byf.log')!.toString('utf-8')).toContain(
       'untagged probe',
     );
   });
@@ -269,8 +269,8 @@ describe('Local logging — harness integration', () => {
     });
 
     const entries = readZipEntries(await readFile(result.zipPath));
-    const globalLog = entries.get('logs/global/kimi-code.log')!.toString('utf-8');
-    const firstLog = await readOptionalFile(join(firstHome, 'logs', 'kimi-code.log'));
+    const globalLog = entries.get('logs/global/byf.log')!.toString('utf-8');
+    const firstLog = await readOptionalFile(join(firstHome, 'logs', 'byf.log'));
     expect(globalLog).toContain('active-global-export-marker');
     expect(firstLog).not.toContain('active-global-export-marker');
 
@@ -301,8 +301,8 @@ describe('Local logging — harness integration', () => {
       });
 
       const entries = readZipEntries(await readFile(result.zipPath));
-      const sessionLog = entries.get('logs/kimi-code.log')!.toString('utf-8');
-      const globalLog = entries.get('logs/global/kimi-code.log')!.toString('utf-8');
+      const sessionLog = entries.get('logs/byf.log')!.toString('utf-8');
+      const globalLog = entries.get('logs/global/byf.log')!.toString('utf-8');
       expect(sessionLog).toContain('export session log flush failed');
       expect(sessionLog).toContain('export global log flush failed');
       expect(globalLog).toContain('export global log flush failed');
@@ -328,8 +328,8 @@ describe('Local logging — harness integration', () => {
     log.warn('second-home-marker');
     await getRootLogger().flushGlobal();
 
-    const firstLog = await readOptionalFile(join(firstHome, 'logs', 'kimi-code.log'));
-    const secondLog = await readFile(join(secondHome, 'logs', 'kimi-code.log'), 'utf-8');
+    const firstLog = await readOptionalFile(join(firstHome, 'logs', 'byf.log'));
+    const secondLog = await readFile(join(secondHome, 'logs', 'byf.log'), 'utf-8');
     expect(firstLog).not.toContain('second-home-marker');
     expect(secondLog).toContain('second-home-marker');
 
@@ -368,7 +368,7 @@ describe('Local logging — harness integration', () => {
       } catch {
         // intentional — directory may not exist when level=off
       }
-      expect(logsDir).not.toContain('kimi-code.log');
+      expect(logsDir).not.toContain('byf.log');
     } finally {
       restoreLogEnv(env);
     }
@@ -380,7 +380,7 @@ describe('Local logging — harness integration', () => {
     log.warn('untagged before close');
     // No `await flush()` here on purpose — close() must do it.
     await harness.close();
-    const globalPath = join(homeDir, 'logs', 'kimi-code.log');
+    const globalPath = join(homeDir, 'logs', 'byf.log');
     const text = await readFile(globalPath, 'utf-8');
     expect(text).toContain('untagged before close');
   });

--- a/packages/node-sdk/test/session-skills.test.ts
+++ b/packages/node-sdk/test/session-skills.test.ts
@@ -93,7 +93,7 @@ describe('Session skills', () => {
         source: 'project',
         disableModelInvocation: true,
       });
-      expect(listed?.path.endsWith('/.kimi-code/skills/review/SKILL.md')).toBe(true);
+      expect(listed?.path.endsWith('/.byf/skills/review/SKILL.md')).toBe(true);
       expect(JSON.stringify(skills)).not.toContain('Review the requested file.');
     } finally {
       await harness.close();
@@ -192,12 +192,12 @@ describe('Session skills', () => {
     }
   });
 
-  it('resolves user skills from the OS home directory, independently of KIMI_CODE_HOME', async () => {
+  it('resolves user skills from the OS home directory, independently of BYF_HOME', async () => {
     const homeDir = await makeTempDir(tempDirs, 'kimi-sdk-skills-home-');
     const processHome = await makeTempDir(tempDirs, 'kimi-sdk-skills-process-home-');
     const workDir = await makeTempDir(tempDirs, 'kimi-sdk-skills-work-');
     vi.stubEnv('HOME', processHome);
-    vi.stubEnv('KIMI_CODE_HOME', homeDir);
+    vi.stubEnv('BYF_HOME', homeDir);
     await writeUserSkill(processHome, 'sdk-real-home-only', 'SDK real home skill');
     await writeUserSkill(homeDir, 'sdk-sandbox-only', 'SDK sandbox skill');
     const harness = new KimiHarness({ identity: TEST_IDENTITY });
@@ -283,13 +283,13 @@ describe('Session skills', () => {
 });
 
 async function writeSkill(workDir: string, name: string, lines: readonly string[]): Promise<void> {
-  const dir = join(workDir, '.kimi-code', 'skills', name);
+  const dir = join(workDir, '.byf', 'skills', name);
   await mkdir(dir, { recursive: true });
   await writeFile(join(dir, 'SKILL.md'), lines.join('\n'));
 }
 
 async function writeUserSkill(userHomeDir: string, name: string, description: string): Promise<void> {
-  const dir = join(userHomeDir, '.kimi-code', 'skills', name);
+  const dir = join(userHomeDir, '.byf', 'skills', name);
   await mkdir(dir, { recursive: true });
   await writeFile(
     join(dir, 'SKILL.md'),

--- a/packages/oauth/src/oauth-manager.ts
+++ b/packages/oauth/src/oauth-manager.ts
@@ -80,7 +80,7 @@ export interface OAuthManagerOptions {
    * genuine mis-wiring.
    *
    * When omitted AND `process.env.NODE_ENV === 'test'`, the manager
-   * falls back to `process.env.KIMI_CODE_HOME` so multi-process test
+   * falls back to `process.env.BYF_HOME` so multi-process test
    * harnesses don't need to thread the dir through every fixture. In
    * production the fallback is inert. Windows platforms and
    * `process.env.KIMI_DISABLE_OAUTH_LOCK === '1'` always skip; the
@@ -146,12 +146,12 @@ export class OAuthManager {
         pollDeviceToken(config, deviceCode, {
           deviceHeaders: this.resolveDeviceHeaders(),
         }));
-    // The `KIMI_CODE_HOME` fallback MUST stay test-only so production
+    // The `BYF_HOME` fallback MUST stay test-only so production
     // entry points can't silently run without a lock just because the
     // env happens to be unset. vitest sets `NODE_ENV='test'` by default,
     // so multi-process test workers still pick up the test home path.
     const envConfigDir =
-      process.env['NODE_ENV'] === 'test' ? process.env['KIMI_CODE_HOME'] : undefined;
+      process.env['NODE_ENV'] === 'test' ? process.env['BYF_HOME'] : undefined;
     this.configDir = options.configDir ?? envConfigDir;
   }
 

--- a/packages/oauth/src/storage.ts
+++ b/packages/oauth/src/storage.ts
@@ -2,7 +2,7 @@
  * File-based OAuth token storage.
  *
  * Tokens are persisted under a directory (default
- * `~/.kimi-code/credentials/`) as `<name>.json` with mode 0600 (parent
+ * `~/.byf/credentials/`) as `<name>.json` with mode 0600 (parent
  * dir 0700). Wire format uses snake_case to match the server contract.
  *
  * Write semantics: write to `<name>.tmp.<pid>.<rand>` → fsync → rename.

--- a/packages/oauth/src/toolkit.ts
+++ b/packages/oauth/src/toolkit.ts
@@ -294,7 +294,7 @@ export function resolveKimiTokenStorageName(input: {
 }
 
 function defaultKimiHome(): string {
-  const override = process.env['KIMI_CODE_HOME'];
+  const override = process.env['BYF_HOME'];
   if (override !== undefined && override.length > 0) return override;
-  return join(homedir(), '.kimi-code');
+  return join(homedir(), '.byf');
 }

--- a/packages/oauth/test/helpers.ts
+++ b/packages/oauth/test/helpers.ts
@@ -66,7 +66,7 @@ export async function spawnInlineWorkers(
     const child = spawn(tsxCli, [scriptPath, String(id)], {
       env: {
         ...process.env,
-        KIMI_CODE_HOME: opts.shareDir,
+        BYF_HOME: opts.shareDir,
         KIMI_WORKER_ID: String(id),
         ...opts.env,
       },

--- a/packages/oauth/test/oauth-manager-multi-process.test.ts
+++ b/packages/oauth/test/oauth-manager-multi-process.test.ts
@@ -50,7 +50,7 @@ const WORKER_SCRIPT = `
   import { join } from 'node:path';
   const { OAuthManager } = await import(process.env.KIMI_OAUTH_ENTRY);
 
-  const shareDir = process.env.KIMI_CODE_HOME;
+  const shareDir = process.env.BYF_HOME;
   const tokenPath = join(shareDir, 'token.json');
   const counterPath = join(shareDir, 'refresh-count.txt');
   const readyPath = join(shareDir, 'first-load-ready.txt');


### PR DESCRIPTION
## Summary

- Replace all `KIMI_CODE_HOME` env var references with `BYF_HOME` across agent-core, CLI, vis server, oauth, and SDK packages
- Replace all `.kimi-code` directory references with `.byf` in source code, config templates, skill directories, credential storage, and UI text
- Rename constants from `KIMI_CODE_*` to `BYF_*` in `apps/cli/src/constant/app.ts`
- Update vis server config to export `BYF_HOME` instead of `KIMI_CODE_HOME`
- Add TDD tests for `BYF_HOME` env var and `.byf` default path resolution

## Acceptance Criteria (from #3)

- [x] Setting `BYF_HOME=/tmp/byf-test` makes BYF store data in that directory
- [x] Default data directory is `~/.byf/`
- [x] No `KIMI_CODE_HOME` string references in source (excluding migration-legacy package)
- [x] No `.kimi-code` path references in source (excluding migration-legacy package)

## Test plan

- [x] All 4456 tests pass (excluding pre-existing flaky `oauth-manager-multi-process` test)
- [x] New tests added for BYF_HOME env var override and .byf default path
- [x] Grep verification confirms zero matches for `KIMI_CODE_HOME` and `.kimi-code` in source/tests/examples

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)