### PR TITLE
feat: first-run guidance offers /login and /connect

### DIFF
--- a/apps/cli/src/cli/run-prompt.ts
+++ b/apps/cli/src/cli/run-prompt.ts
@@ -232,7 +232,7 @@ function requireConfiguredModel(...models: readonly (string | undefined)[]): str
   const model = configuredModel(...models);
   if (model === undefined) {
     throw new Error(
-      'No model configured. Run `byf` and use /login or /connect to sign in, then retry; or set default_model in config.toml.',
+      'No model configured. Run `byf` and use /login or /connect to configure a provider, then retry; or set default_model in config.toml.',
     );
   }
   return model;

--- a/apps/cli/src/cli/run-prompt.ts
+++ b/apps/cli/src/cli/run-prompt.ts
@@ -232,7 +232,7 @@ function requireConfiguredModel(...models: readonly (string | undefined)[]): str
   const model = configuredModel(...models);
   if (model === undefined) {
     throw new Error(
-      'No model configured. Run `byf` and use /login to sign in, then retry; or set default_model in config.toml.',
+      'No model configured. Run `byf` and use /login or /connect to sign in, then retry; or set default_model in config.toml.',
     );
   }
   return model;

--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -4424,7 +4424,7 @@ export class ByfTui {
     if (entries.length === 0) {
       this.showNotice(
         'No models configured',
-        'Run /connect to add a provider from the model catalog.',
+        'Run /login or /connect to add a provider.',
       );
       return;
     }

--- a/apps/cli/src/tui/constant/byf-tui.ts
+++ b/apps/cli/src/tui/constant/byf-tui.ts
@@ -1,9 +1,9 @@
 export { OAUTH_LOGIN_REQUIRED_CODE, PRODUCT_NAME } from '#/constant/app';
 
-export const LLM_NOT_SET_MESSAGE = 'LLM not set. Use /connect to configure a provider.';
-export const NO_ACTIVE_SESSION_MESSAGE = 'No active session. Use /connect to configure a provider.';
+export const LLM_NOT_SET_MESSAGE = 'LLM not set. Use /login or /connect to configure a provider.';
+export const NO_ACTIVE_SESSION_MESSAGE = 'No active session. Use /login or /connect to configure a provider.';
 export const CTRL_D_HINT = 'Press Ctrl+D again to exit';
 export const CTRL_C_HINT = 'Press Ctrl+C again to exit';
 export const MAIN_AGENT_ID = 'main';
-export const OAUTH_LOGIN_REQUIRED_STARTUP_NOTICE = 'Authentication required. Use /connect to configure a provider.';
+export const OAUTH_LOGIN_REQUIRED_STARTUP_NOTICE = 'Authentication required. Use /login or /connect to configure a provider.';
 export const EXIT_CONFIRM_WINDOW_MS = 1500;

--- a/apps/cli/test/cli/run-prompt.test.ts
+++ b/apps/cli/test/cli/run-prompt.test.ts
@@ -690,7 +690,7 @@ describe('runPrompt', () => {
         stderr: { write: vi.fn(() => true) },
       }),
     ).rejects.toThrow(
-      'No model configured. Run `byf` and use /login or /connect to sign in, then retry; or set default_model in config.toml.',
+      'No model configured. Run `byf` and use /login or /connect to configure a provider, then retry; or set default_model in config.toml.',
     );
 
     expect(mocks.harnessClose).toHaveBeenCalled();

--- a/apps/cli/test/cli/run-prompt.test.ts
+++ b/apps/cli/test/cli/run-prompt.test.ts
@@ -690,7 +690,7 @@ describe('runPrompt', () => {
         stderr: { write: vi.fn(() => true) },
       }),
     ).rejects.toThrow(
-      'No model configured. Run `byf` and use /login to sign in, then retry; or set default_model in config.toml.',
+      'No model configured. Run `byf` and use /login or /connect to sign in, then retry; or set default_model in config.toml.',
     );
 
     expect(mocks.harnessClose).toHaveBeenCalled();

--- a/apps/cli/test/tui/byf-tui-message-flow.test.ts
+++ b/apps/cli/test/tui/byf-tui-message-flow.test.ts
@@ -1102,12 +1102,13 @@ describe('ByfTui message flow', () => {
   });
 
   it('shows /login and /connect in model picker when no models are configured', async () => {
-    const { driver, session } = await makeDriver();
-    (driver.state.appState as unknown as Record<string, unknown>)['availableModels'] = {};
+    const { driver } = await makeDriver();
+    driver.state.appState.availableModels = {};
 
     driver.handleUserInput('/model');
 
     const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('No models configured');
     expect(transcript).toContain('/login');
     expect(transcript).toContain('/connect');
   });

--- a/apps/cli/test/tui/byf-tui-message-flow.test.ts
+++ b/apps/cli/test/tui/byf-tui-message-flow.test.ts
@@ -1101,6 +1101,17 @@ describe('ByfTui message flow', () => {
     expect(driver.state.transcriptContainer.render(120).join('\n')).toContain('LLM not set');
   });
 
+  it('shows /login and /connect in model picker when no models are configured', async () => {
+    const { driver, session } = await makeDriver();
+    (driver.state.appState as unknown as Record<string, unknown>)['availableModels'] = {};
+
+    driver.handleUserInput('/model');
+
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('/login');
+    expect(transcript).toContain('/connect');
+  });
+
   it('shows the login prompt for auth.login_required session errors', async () => {
     const { driver } = await makeDriver();
 
@@ -1117,7 +1128,7 @@ describe('ByfTui message flow', () => {
     );
 
     const transcript = stripSgr(renderTranscript(driver));
-    expect(transcript).toContain('Authentication required. Use /connect to configure a provider.');
+    expect(transcript).toContain('Authentication required. Use /login or /connect to configure a provider.');
     expect(transcript).not.toContain('[auth.login_required]');
     expect(transcript).not.toContain('byf export');
   });

--- a/apps/cli/test/tui/byf-tui-startup.test.ts
+++ b/apps/cli/test/tui/byf-tui-startup.test.ts
@@ -316,7 +316,7 @@ describe("ByfTui startup", () => {
 
     expect(driver.state.startupState).toBe("ready");
     expect(driver.state.startupNotice).toContain(
-      "Authentication required. Use /connect to configure a provider.",
+      "Authentication required. Use /login or /connect to configure a provider.",
     );
     expect(driver.state.appState).toMatchObject({
       sessionId: "",


### PR DESCRIPTION
## Summary

- Updates all user-facing error messages and hints to mention both `/login` and `/connect` when guiding users to configure a provider
- Adds a test verifying the model picker shows both commands when no models are configured

## Changes

| File | What changed |
|------|-------------|
| `constant/byf-tui.ts` | `LLM_NOT_SET_MESSAGE`, `NO_ACTIVE_SESSION_MESSAGE`, `OAUTH_LOGIN_REQUIRED_STARTUP_NOTICE` now mention `/login or /connect` |
| `byf-tui.ts` | Model picker empty-state hint updated from "Run /connect" to "Run /login or /connect" |
| `run-prompt.ts` | No-model error updated to mention both `/login or /connect` |
| Tests | Updated 3 existing assertions, added 1 new test for model picker |

## Acceptance criteria (from #19)

- [x] Welcome panel mentions both `/login` and `/connect` as options when no model is configured
- [x] All error messages that previously said "Use /connect" now mention both `/login` and `/connect`
- [x] No remaining references to `byf-cn`, `byf-ai`, or `OPEN_PLATFORMS` in any user-facing text
- [x] `/login` and `/connect` are both visible in slash command help
- [x] Test verifies both commands are mentioned in welcome/error output
- [x] `pnpm run test` passes

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)