### PR TITLE
feat: support multi-level reasoning effort

### DIFF
--- a/.changeset/quiet-cobras-think.md
+++ b/.changeset/quiet-cobras-think.md
@@ -1,0 +1,13 @@
+---
+"@byf/cli": minor
+"@byf/oauth": minor
+"@byf/agent-core": minor
+"@byf/kosong": minor
+---
+
+Add multi-level reasoning effort support with provider-specific parameter mapping.
+
+- `@byf/cli`: model selector now supports `off/low/medium/high` effort for models exposing `thinking_effort`, with updated runtime state wiring and session model-switch behavior.
+- `@byf/oauth`: `/login` model parsing now detects effort-capable models and optional custom effort parameter keys, and writes provider-level `thinking_effort_key` metadata into config.
+- `@byf/agent-core`: provider schema/runtime resolution now carries `thinking_effort_key` through to openai-compatible runtime providers.
+- `@byf/kosong`: OpenAI-compatible provider now supports configurable thinking effort parameter keys instead of hardcoding `reasoning_effort`.

--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -1061,7 +1061,15 @@ export class ByfTui {
     }
 
     const defaultThinkingEffort: ThinkingEffortLevel | undefined =
-      config.defaultThinking === undefined ? undefined : config.defaultThinking ? 'high' : 'off';
+      config.thinking?.mode === 'off'
+        ? 'off'
+        : config.thinking?.effort !== undefined
+          ? parseThinkingEffort(config.thinking.effort)
+          : config.defaultThinking === undefined
+            ? undefined
+            : config.defaultThinking
+              ? 'high'
+              : 'off';
     await this.activateModelAfterLogin(defaultModel, defaultThinkingEffort);
     const appStatePatch: Partial<AppState> = {
       availableModels,
@@ -1069,8 +1077,8 @@ export class ByfTui {
       model: defaultModel,
       maxContextTokens: selected.maxContextSize,
     };
-    if (config.defaultThinking !== undefined) {
-      appStatePatch.thinkingEffort = config.defaultThinking ? 'high' : 'off';
+    if (defaultThinkingEffort !== undefined) {
+      appStatePatch.thinkingEffort = defaultThinkingEffort;
     }
     this.setAppState(appStatePatch);
   }
@@ -4514,12 +4522,22 @@ export class ByfTui {
   private async persistModelSelection(alias: string, thinkingEffort: ThinkingEffortLevel): Promise<boolean> {
     const config = await this.harness.getConfig({ reload: true });
     const defaultThinking = thinkingEffort !== 'off';
-    if (config.defaultModel === alias && config.defaultThinking === defaultThinking) {
+    const thinkingConfig =
+      thinkingEffort === 'off'
+        ? { mode: 'off' as const, effort: 'high' as const }
+        : { mode: 'on' as const, effort: thinkingEffort };
+    if (
+      config.defaultModel === alias &&
+      config.defaultThinking === defaultThinking &&
+      config.thinking?.mode === thinkingConfig.mode &&
+      config.thinking?.effort === thinkingConfig.effort
+    ) {
       return false;
     }
     await this.harness.setConfig({
       defaultModel: alias,
       defaultThinking,
+      thinking: thinkingConfig,
     });
     return true;
   }

--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -190,10 +190,12 @@ import {
   type AppState,
   type BackgroundAgentMetadata,
   type LivePaneState,
+  parseThinkingEffort,
   type QueuedMessage,
   type ToolCallBlockData,
   type ToolResultBlockData,
   type TranscriptEntry,
+  type ThinkingEffortLevel,
 } from './types';
 import { formatBackgroundAgentTranscript } from './utils/background-agent-status';
 import { formatBackgroundTaskTranscript } from './utils/background-task-status';
@@ -390,7 +392,7 @@ function createInitialAppState(input: ByfTuiStartupInput): AppState {
     yolo: input.cliOptions.yolo,
     permissionMode: startupPermission,
     planMode: input.cliOptions.plan,
-    thinking: false,
+    thinkingEffort: 'off',
     contextUsage: 0,
     contextTokens: 0,
     maxContextTokens: 0,
@@ -999,7 +1001,7 @@ export class ByfTui {
     this.setAppState({
       sessionId: '',
       model: '',
-      thinking: false,
+      thinkingEffort: 'off',
       contextTokens: 0,
       maxContextTokens: 0,
       contextUsage: 0,
@@ -1013,8 +1015,11 @@ export class ByfTui {
   }
 
   // Ensures a usable session exists for the default model after login.
-  private async activateModelAfterLogin(model: string, thinking?: boolean): Promise<void> {
-    const level = thinking === undefined ? undefined : thinking ? 'on' : 'off';
+  private async activateModelAfterLogin(
+    model: string,
+    thinkingEffort?: ThinkingEffortLevel,
+  ): Promise<void> {
+    const level = thinkingEffort;
     if (this.session !== undefined) {
       await this.session.setModel(model);
       if (level !== undefined) {
@@ -1055,7 +1060,9 @@ export class ByfTui {
       return;
     }
 
-    await this.activateModelAfterLogin(defaultModel, config.defaultThinking);
+    const defaultThinkingEffort: ThinkingEffortLevel | undefined =
+      config.defaultThinking === undefined ? undefined : config.defaultThinking ? 'high' : 'off';
+    await this.activateModelAfterLogin(defaultModel, defaultThinkingEffort);
     const appStatePatch: Partial<AppState> = {
       availableModels,
       availableProviders,
@@ -1063,7 +1070,7 @@ export class ByfTui {
       maxContextTokens: selected.maxContextSize,
     };
     if (config.defaultThinking !== undefined) {
-      appStatePatch.thinking = config.defaultThinking;
+      appStatePatch.thinkingEffort = config.defaultThinking ? 'high' : 'off';
     }
     this.setAppState(appStatePatch);
   }
@@ -1941,7 +1948,7 @@ export class ByfTui {
       workDir: this.state.appState.workDir,
       model,
       thinking:
-        this.session === undefined ? undefined : this.state.appState.thinking ? 'on' : 'off',
+        this.session === undefined ? undefined : this.state.appState.thinkingEffort,
       permission: this.state.appState.permissionMode,
       planMode: this.state.appState.planMode ? true : undefined,
     });
@@ -1962,7 +1969,7 @@ export class ByfTui {
     this.setAppState({
       sessionId: session.id,
       model: status.model ?? '',
-      thinking: status.thinkingLevel !== 'off',
+      thinkingEffort: parseThinkingEffort(status.thinkingLevel),
       permissionMode: status.permission,
       yolo: status.permission === 'yolo',
       planMode: status.planMode,
@@ -4433,12 +4440,12 @@ export class ByfTui {
         models: this.state.appState.availableModels,
         currentValue: this.state.appState.model,
         selectedValue,
-        currentThinking: this.state.appState.thinking,
+        currentThinkingEffort: this.state.appState.thinkingEffort,
         colors: this.state.theme.colors,
         searchable: true,
-        onSelect: ({ alias, thinking }) => {
+        onSelect: ({ alias, thinkingEffort }) => {
           this.restoreEditor();
-          void this.performModelSwitch(alias, thinking);
+          void this.performModelSwitch(alias, thinkingEffort);
         },
         onCancel: () => {
           this.restoreEditor();
@@ -4448,27 +4455,26 @@ export class ByfTui {
   }
 
   // Applies model and thinking changes to the active or newly created session.
-  private async performModelSwitch(alias: string, thinking: boolean): Promise<void> {
+  private async performModelSwitch(alias: string, thinkingEffort: ThinkingEffortLevel): Promise<void> {
     if (this.state.appState.isStreaming) {
       this.showError('Cannot switch models while streaming — press Esc or Ctrl-C first.');
       return;
     }
 
-    const level = thinking ? 'on' : 'off';
     const prevModel = this.state.appState.model;
-    const prevThinking = this.state.appState.thinking;
-    const runtimeChanged = alias !== prevModel || thinking !== prevThinking;
+    const prevThinking = this.state.appState.thinkingEffort;
+    const runtimeChanged = alias !== prevModel || thinkingEffort !== prevThinking;
 
     const session = this.session;
     try {
       if (session === undefined && runtimeChanged) {
-        await this.activateModelAfterLogin(alias, thinking);
+        await this.activateModelAfterLogin(alias, thinkingEffort);
       } else if (session !== undefined) {
         if (alias !== prevModel) {
           await session.setModel(alias);
         }
-        if (thinking !== prevThinking) {
-          await session.setThinking(level);
+        if (thinkingEffort !== prevThinking) {
+          await session.setThinking(thinkingEffort);
         }
       }
     } catch (error) {
@@ -4477,19 +4483,19 @@ export class ByfTui {
       return;
     }
 
-    this.setAppState({ model: alias, thinking });
+    this.setAppState({ model: alias, thinkingEffort });
     if (session === undefined && runtimeChanged) {
       if (alias !== prevModel) {
         this.track('model_switch', { model: alias });
       }
-      if (thinking !== prevThinking) {
-        this.track('thinking_toggle', { enabled: thinking });
+      if (thinkingEffort !== prevThinking) {
+        this.track('thinking_toggle', { enabled: thinkingEffort !== 'off' });
       }
     }
 
     let persisted = false;
     try {
-      persisted = await this.persistModelSelection(alias, thinking);
+      persisted = await this.persistModelSelection(alias, thinkingEffort);
     } catch (error) {
       const msg = formatErrorMessage(error);
       this.showError(`Switched to ${alias}, but failed to save default: ${msg}`);
@@ -4497,22 +4503,23 @@ export class ByfTui {
     }
 
     const status = runtimeChanged
-      ? `Switched to ${alias} with thinking ${level}.`
+      ? `Switched to ${alias} with thinking ${thinkingEffort}.`
       : persisted
-        ? `Saved ${alias} with thinking ${level} as default.`
-        : `Already using ${alias} with thinking ${level}.`;
+        ? `Saved ${alias} with thinking ${thinkingEffort} as default.`
+        : `Already using ${alias} with thinking ${thinkingEffort}.`;
     this.showStatus(status, this.state.theme.colors.success);
   }
 
   // Persists the selected model and thinking state as the startup defaults.
-  private async persistModelSelection(alias: string, thinking: boolean): Promise<boolean> {
+  private async persistModelSelection(alias: string, thinkingEffort: ThinkingEffortLevel): Promise<boolean> {
     const config = await this.harness.getConfig({ reload: true });
-    if (config.defaultModel === alias && config.defaultThinking === thinking) {
+    const defaultThinking = thinkingEffort !== 'off';
+    if (config.defaultModel === alias && config.defaultThinking === defaultThinking) {
       return false;
     }
     await this.harness.setConfig({
       defaultModel: alias,
-      defaultThinking: thinking,
+      defaultThinking,
     });
     return true;
   }
@@ -4664,7 +4671,7 @@ export class ByfTui {
       workDir: appState.workDir,
       sessionId: appState.sessionId,
       sessionTitle: appState.sessionTitle,
-      thinking: appState.thinking,
+      thinking: appState.thinkingEffort !== 'off',
       permissionMode: appState.permissionMode,
       planMode: appState.planMode,
       contextUsage: appState.contextUsage,
@@ -5086,7 +5093,7 @@ export class ByfTui {
       apiKey,
       models,
       selectedModel,
-      thinking: selection.thinking,
+      thinking: selection.thinkingEffort !== 'off',
     });
 
     await this.harness.setConfig({
@@ -5164,7 +5171,7 @@ export class ByfTui {
       apiKey,
       models: [manualModelInfo],
       selectedModel: manualModelInfo,
-      thinking: false,
+      thinkingEffort: 'off',
     });
 
     await this.harness.setConfig({
@@ -5312,7 +5319,7 @@ export class ByfTui {
       apiKey,
       models,
       selectedModelId: selection.model.id,
-      thinking: selection.thinking,
+      thinking: selection.thinkingEffort !== 'off',
     });
 
     await this.harness.setConfig({
@@ -5390,7 +5397,7 @@ export class ByfTui {
   private async promptModelSelectionForCatalog(
     providerId: string,
     models: CatalogModel[],
-  ): Promise<{ model: CatalogModel; thinking: boolean } | undefined> {
+  ): Promise<{ model: CatalogModel; thinkingEffort: ThinkingEffortLevel } | undefined> {
     const modelDict: Record<string, ModelAlias> = {};
     for (const m of models) {
       modelDict[`${providerId}/${m.id}`] = catalogModelToAlias(providerId, m);
@@ -5398,25 +5405,28 @@ export class ByfTui {
     const selection = await this.runModelSelector(modelDict);
     if (selection === undefined) return undefined;
     const model = models.find((m) => `${providerId}/${m.id}` === selection.alias);
-    return model ? { model, thinking: selection.thinking } : undefined;
+    return model ? { model, thinkingEffort: selection.thinkingEffort } : undefined;
   }
 
   private runModelSelector(
     modelDict: Record<string, ModelAlias>,
-  ): Promise<{ alias: string; thinking: boolean } | undefined> {
+  ): Promise<{ alias: string; thinkingEffort: ThinkingEffortLevel } | undefined> {
     return new Promise((resolve) => {
       const firstAlias = Object.keys(modelDict)[0] ?? '';
       const caps = modelDict[firstAlias]?.capabilities ?? [];
-      const initialThinking = caps.includes('always_thinking') || caps.includes('thinking');
+      const initialThinking: ThinkingEffortLevel =
+        caps.includes('always_thinking') || caps.includes('thinking') || caps.includes('thinking_effort')
+          ? 'high'
+          : 'off';
       const selector = new ModelSelectorComponent({
         models: modelDict,
         currentValue: firstAlias,
-        currentThinking: initialThinking,
+        currentThinkingEffort: initialThinking,
         colors: this.state.theme.colors,
         searchable: true,
-        onSelect: ({ alias, thinking }) => {
+        onSelect: ({ alias, thinkingEffort }) => {
           this.restoreEditor();
-          resolve({ alias, thinking });
+          resolve({ alias, thinkingEffort });
         },
         onCancel: () => {
           this.restoreEditor();

--- a/apps/cli/src/tui/components/chrome/footer.ts
+++ b/apps/cli/src/tui/components/chrome/footer.ts
@@ -182,8 +182,8 @@ export class FooterComponent implements Component {
 
     const model = shortenModel(modelDisplayName(state));
     if (model) {
-      const thinkingLabel = state.thinking ? ' thinking' : '';
-      left.push(chalk.hex(colors.text)(`${model}${thinkingLabel}`));
+      const effortLabel = state.thinkingEffort !== 'off' ? ` thinking:${state.thinkingEffort}` : '';
+      left.push(chalk.hex(colors.text)(`${model}${effortLabel}`));
     }
 
     // Background-task badges sit immediately before cwd. `bash-*` tasks

--- a/apps/cli/src/tui/components/dialogs/model-selector.ts
+++ b/apps/cli/src/tui/components/dialogs/model-selector.ts
@@ -86,6 +86,7 @@ function effectiveThinking(
   const availability = thinkingAvailability(model);
   if (availability === 'always-on') return 'high';
   if (availability === 'unsupported') return 'off';
+  if (availability === 'toggle') return effortDraft === 'off' ? 'off' : 'high';
   return effortDraft;
 }
 

--- a/apps/cli/src/tui/components/dialogs/model-selector.ts
+++ b/apps/cli/src/tui/components/dialogs/model-selector.ts
@@ -14,7 +14,9 @@ import { SearchableList } from '#/tui/utils/searchable-list';
 
 import type { ChoiceOption } from './choice-picker';
 
-type ThinkingAvailability = 'toggle' | 'always-on' | 'unsupported';
+export type ThinkingEffortLevel = 'off' | 'low' | 'medium' | 'high';
+
+type ThinkingAvailability = 'toggle' | 'effort' | 'always-on' | 'unsupported';
 
 interface ModelChoice {
   readonly alias: string;
@@ -24,7 +26,7 @@ interface ModelChoice {
 
 export interface ModelSelection {
   readonly alias: string;
-  readonly thinking: boolean;
+  readonly thinkingEffort: ThinkingEffortLevel;
 }
 
 export function modelDisplayName(alias: string, model: ModelAlias | undefined): string {
@@ -49,7 +51,7 @@ export interface ModelSelectorOptions {
   readonly models: Record<string, ModelAlias>;
   readonly currentValue: string;
   readonly selectedValue?: string;
-  readonly currentThinking: boolean;
+  readonly currentThinkingEffort: ThinkingEffortLevel;
   readonly colors: ColorPalette;
   /** When true, typed characters filter the list (fuzzy) and a search line is shown. */
   readonly searchable?: boolean;
@@ -70,22 +72,28 @@ function createModelChoices(models: Record<string, ModelAlias>): readonly ModelC
 function thinkingAvailability(model: ModelAlias): ThinkingAvailability {
   const caps = model.capabilities ?? [];
   if (caps.includes('always_thinking')) return 'always-on';
+  if (caps.includes('thinking_effort')) return 'effort';
   if (caps.includes('thinking')) return 'toggle';
   return 'unsupported';
 }
 
-function effectiveThinking(model: ModelAlias, thinkingDraft: boolean): boolean {
+const EFFORT_LEVELS: readonly ThinkingEffortLevel[] = ['off', 'low', 'medium', 'high'];
+
+function effectiveThinking(
+  model: ModelAlias,
+  effortDraft: ThinkingEffortLevel,
+): ThinkingEffortLevel {
   const availability = thinkingAvailability(model);
-  if (availability === 'always-on') return true;
-  if (availability === 'unsupported') return false;
-  return thinkingDraft;
+  if (availability === 'always-on') return 'high';
+  if (availability === 'unsupported') return 'off';
+  return effortDraft;
 }
 
 export class ModelSelectorComponent extends Container implements Focusable {
   focused = false;
   private readonly opts: ModelSelectorOptions;
   private readonly list: SearchableList<ModelChoice>;
-  private thinkingDraft: boolean;
+  private effortDraft: ThinkingEffortLevel;
 
   constructor(opts: ModelSelectorOptions) {
     super();
@@ -100,7 +108,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
       initialIndex: Math.max(selectedIdx, 0),
       searchable: opts.searchable === true,
     });
-    this.thinkingDraft = opts.currentThinking;
+    this.effortDraft = opts.currentThinkingEffort;
   }
 
   handleInput(data: string): void {
@@ -110,15 +118,27 @@ export class ModelSelectorComponent extends Container implements Focusable {
       return;
     }
     const selected = this.list.selected();
-    // Left/Right toggle thinking (only when the model supports it); paging is on
-    // PgUp/PgDn so the horizontal arrows stay free for the thinking control.
-    if (selected !== undefined && thinkingAvailability(selected.model) === 'toggle') {
+    const availability = selected !== undefined ? thinkingAvailability(selected.model) : 'unsupported';
+    // Left/Right control thinking effort; paging is on PgUp/PgDn so the
+    // horizontal arrows stay free for the thinking control.
+    if (availability === 'effort') {
       if (matchesKey(data, Key.left)) {
-        this.thinkingDraft = true;
+        const idx = EFFORT_LEVELS.indexOf(this.effortDraft);
+        if (idx > 0) this.effortDraft = EFFORT_LEVELS[idx - 1]!;
         return;
       }
       if (matchesKey(data, Key.right)) {
-        this.thinkingDraft = false;
+        const idx = EFFORT_LEVELS.indexOf(this.effortDraft);
+        if (idx < EFFORT_LEVELS.length - 1) this.effortDraft = EFFORT_LEVELS[idx + 1]!;
+        return;
+      }
+    } else if (availability === 'toggle') {
+      if (matchesKey(data, Key.left)) {
+        this.effortDraft = 'high';
+        return;
+      }
+      if (matchesKey(data, Key.right)) {
+        this.effortDraft = 'off';
         return;
       }
     }
@@ -126,7 +146,7 @@ export class ModelSelectorComponent extends Container implements Focusable {
       if (selected === undefined) return;
       this.opts.onSelect({
         alias: selected.alias,
-        thinking: effectiveThinking(selected.model, this.thinkingDraft),
+        thinkingEffort: effectiveThinking(selected.model, this.effortDraft),
       });
       return;
     }
@@ -204,6 +224,11 @@ export class ModelSelectorComponent extends Container implements Focusable {
     if (availability === 'unsupported') {
       return `  ${segment('Off', true)} ${chalk.hex(colors.textMuted)('unsupported')}`;
     }
-    return `  ${segment('On', this.thinkingDraft)}  ${segment('Off', !this.thinkingDraft)}`;
+    if (availability === 'effort') {
+      const labels: ThinkingEffortLevel[] = ['off', 'low', 'medium', 'high'];
+      const displayLabels = ['Off', 'Low', 'Medium', 'High'];
+      return '  ' + labels.map((level, i) => segment(displayLabels[i]!, this.effortDraft === level)).join('');
+    }
+    return `  ${segment('On', this.effortDraft !== 'off')}  ${segment('Off', this.effortDraft === 'off')}`;
   }
 }

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -10,6 +10,16 @@ import type { NotificationsConfig } from './config';
 import type { PendingApproval, PendingQuestion } from './reverse-rpc/types';
 import type { Theme } from './theme';
 
+export type ThinkingEffortLevel = 'off' | 'low' | 'medium' | 'high';
+
+const THINKING_EFFORT_LEVELS = new Set<string>(['off', 'low', 'medium', 'high']);
+
+export function parseThinkingEffort(value: string | undefined): ThinkingEffortLevel {
+  if (value && THINKING_EFFORT_LEVELS.has(value)) return value as ThinkingEffortLevel;
+  if (value === 'on' || value === 'xhigh' || value === 'max') return 'high';
+  return 'off';
+}
+
 export interface AppState {
   model: string;
   workDir: string;
@@ -17,7 +27,7 @@ export interface AppState {
   yolo: boolean;
   permissionMode: PermissionMode;
   planMode: boolean;
-  thinking: boolean;
+  thinkingEffort: ThinkingEffortLevel;
   contextUsage: number;
   contextTokens: number;
   maxContextTokens: number;

--- a/apps/cli/test/tui/byf-tui-message-flow.test.ts
+++ b/apps/cli/test/tui/byf-tui-message-flow.test.ts
@@ -1394,14 +1394,14 @@ describe('ByfTui message flow', () => {
 
     await vi.waitFor(() => {
       expect(session.setModel).toHaveBeenCalledWith('turbo');
-      expect(session.setThinking).toHaveBeenCalledWith('on');
+      expect(session.setThinking).toHaveBeenCalledWith('high');
       expect(setConfig).toHaveBeenCalledWith({
         defaultModel: 'turbo',
         defaultThinking: true,
       });
     });
     expect(driver.state.appState.model).toBe('turbo');
-    expect(driver.state.appState.thinking).toBe(true);
+    expect(driver.state.appState.thinkingEffort).toBe('high');
   });
 
   it('persists /model selection even when runtime state is unchanged', async () => {

--- a/apps/cli/test/tui/byf-tui-message-flow.test.ts
+++ b/apps/cli/test/tui/byf-tui-message-flow.test.ts
@@ -1398,6 +1398,10 @@ describe('ByfTui message flow', () => {
       expect(setConfig).toHaveBeenCalledWith({
         defaultModel: 'turbo',
         defaultThinking: true,
+        thinking: {
+          mode: 'on',
+          effort: 'high',
+        },
       });
     });
     expect(driver.state.appState.model).toBe('turbo');
@@ -1434,10 +1438,61 @@ describe('ByfTui message flow', () => {
       expect(setConfig).toHaveBeenCalledWith({
         defaultModel: 'k2',
         defaultThinking: false,
+        thinking: {
+          mode: 'off',
+          effort: 'high',
+        },
       });
     });
     expect(session.setModel).not.toHaveBeenCalled();
     expect(session.setThinking).not.toHaveBeenCalled();
+  });
+
+  it('prefers config thinking.effort when refreshing defaults after login', async () => {
+    const session = makeSession();
+    let configReads = 0;
+    const { driver } = await makeDriver(session, {
+      getConfig: vi.fn(async () => {
+        configReads += 1;
+        if (configReads === 1) {
+          return {
+            models: {
+              k2: {
+                provider: 'managed:byf',
+                model: 'byf-k2',
+                maxContextSize: 100,
+                capabilities: ['thinking_effort'],
+              },
+            },
+            defaultModel: 'k2',
+            defaultThinking: true,
+          };
+        }
+        return {
+          models: {
+            k2: {
+              provider: 'managed:byf',
+              model: 'byf-k2',
+              maxContextSize: 100,
+              capabilities: ['thinking_effort'],
+            },
+          },
+          providers: {},
+          defaultModel: 'k2',
+          defaultThinking: true,
+          thinking: {
+            mode: 'on',
+            effort: 'low',
+          },
+        };
+      }),
+    });
+
+    const refreshDriver = driver as unknown as { refreshConfigAfterLogin(): Promise<void> };
+    await refreshDriver.refreshConfigAfterLogin();
+
+    expect(session.setThinking).toHaveBeenCalledWith('low');
+    expect(driver.state.appState.thinkingEffort).toBe('low');
   });
 
   it('enables search in the shared model selector helper', async () => {

--- a/apps/cli/test/tui/components/dialogs/choice-picker.test.ts
+++ b/apps/cli/test/tui/components/dialogs/choice-picker.test.ts
@@ -201,6 +201,38 @@ describe('ChoicePickerComponent', () => {
     expect(onSelect).toHaveBeenCalledWith({ alias: 'thinking', thinkingEffort: 'high' });
   });
 
+  it('coerces effort draft to binary thinking for toggle-only models', () => {
+    const onSelect = vi.fn();
+    const picker = new ModelSelectorComponent({
+      models: {
+        effort: {
+          provider: 'openai',
+          model: 'o3',
+          maxContextSize: 200_000,
+          displayName: 'OpenAI o3',
+          capabilities: ['thinking_effort'],
+        },
+        toggle: {
+          provider: 'managed:byf',
+          model: 'byf-thinking',
+          maxContextSize: 200_000,
+          displayName: 'Byf Thinking',
+          capabilities: ['thinking'],
+        },
+      },
+      currentValue: 'effort',
+      currentThinkingEffort: 'medium',
+      colors: darkColors,
+      onSelect,
+      onCancel: vi.fn(),
+    });
+
+    picker.handleInput('[B');
+    picker.handleInput('\r');
+
+    expect(onSelect).toHaveBeenCalledWith({ alias: 'toggle', thinkingEffort: 'high' });
+  });
+
   it('shows effort selector for models with thinking_effort capability', () => {
     const onSelect = vi.fn();
     const picker = new ModelSelectorComponent({

--- a/apps/cli/test/tui/components/dialogs/choice-picker.test.ts
+++ b/apps/cli/test/tui/components/dialogs/choice-picker.test.ts
@@ -3,13 +3,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { ChoicePickerComponent } from '#/tui/components/dialogs/choice-picker';
 import { EditorSelectorComponent } from '#/tui/components/dialogs/editor-selector';
-import { ModelSelectorComponent } from '#/tui/components/dialogs/model-selector';
+import { ModelSelectorComponent, type ThinkingEffortLevel } from '#/tui/components/dialogs/model-selector';
 import { PermissionSelectorComponent } from '#/tui/components/dialogs/permission-selector';
 import { SettingsSelectorComponent } from '#/tui/components/dialogs/settings-selector';
 import { ThemeSelectorComponent } from '#/tui/components/dialogs/theme-selector';
 import { darkColors } from '#/tui/theme/colors';
 
-const ANSI_SGR = /\u001B\[[0-9;]*m/g;
+const ANSI_SGR = /\[[0-9;]*m/g;
 
 function strip(text: string): string {
   return text.replaceAll(ANSI_SGR, '');
@@ -67,7 +67,7 @@ describe('ChoicePickerComponent', () => {
         },
       },
       currentValue: 'byf',
-      currentThinking: true,
+      currentThinkingEffort: 'high',
       colors: darkColors,
       onSelect,
       onCancel,
@@ -103,7 +103,7 @@ describe('ChoicePickerComponent', () => {
     expect(settingsOutput).toContain('    Switch the active model and thinking mode.');
   });
 
-  it('submits the selected model and inline thinking state', () => {
+  it('submits the selected model and inline thinking effort', () => {
     const onSelect = vi.fn();
     const picker = new ModelSelectorComponent({
       models: {
@@ -116,16 +116,16 @@ describe('ChoicePickerComponent', () => {
         },
       },
       currentValue: 'byf',
-      currentThinking: true,
+      currentThinkingEffort: 'high',
       colors: darkColors,
       onSelect,
       onCancel: vi.fn(),
     });
 
-    picker.handleInput('\u001B[C');
+    picker.handleInput('[C');
     picker.handleInput('\r');
 
-    expect(onSelect).toHaveBeenCalledWith({ alias: 'byf', thinking: false });
+    expect(onSelect).toHaveBeenCalledWith({ alias: 'byf', thinkingEffort: 'off' });
   });
 
   it('forces always-thinking models on and unsupported models off', () => {
@@ -148,22 +148,22 @@ describe('ChoicePickerComponent', () => {
         },
       },
       currentValue: 'always',
-      currentThinking: false,
+      currentThinkingEffort: 'off',
       colors: darkColors,
       onSelect,
       onCancel: vi.fn(),
     });
 
     expect(picker.render(120).map(strip)).toContain('  [ Always on ]');
-    picker.handleInput('\u001B[C');
+    picker.handleInput('[C');
     picker.handleInput('\r');
-    expect(onSelect).toHaveBeenLastCalledWith({ alias: 'always', thinking: true });
+    expect(onSelect).toHaveBeenLastCalledWith({ alias: 'always', thinkingEffort: 'high' });
 
-    picker.handleInput('\u001B[B');
+    picker.handleInput('[B');
     expect(picker.render(120).map(strip)).toContain('  [ Off ] unsupported');
-    picker.handleInput('\u001B[D');
+    picker.handleInput('[D');
     picker.handleInput('\r');
-    expect(onSelect).toHaveBeenLastCalledWith({ alias: 'plain', thinking: false });
+    expect(onSelect).toHaveBeenLastCalledWith({ alias: 'plain', thinkingEffort: 'off' });
   });
 
   it('keeps the thinking draft when moving across models', () => {
@@ -186,19 +186,89 @@ describe('ChoicePickerComponent', () => {
         },
       },
       currentValue: 'plain',
-      currentThinking: false,
+      currentThinkingEffort: 'off',
       colors: darkColors,
       onSelect,
       onCancel: vi.fn(),
     });
 
-    picker.handleInput('\u001B[B');
-    picker.handleInput('\u001B[D');
-    picker.handleInput('\u001B[A');
-    picker.handleInput('\u001B[B');
+    picker.handleInput('[B');
+    picker.handleInput('[D');
+    picker.handleInput('[A');
+    picker.handleInput('[B');
     picker.handleInput('\r');
 
-    expect(onSelect).toHaveBeenCalledWith({ alias: 'thinking', thinking: true });
+    expect(onSelect).toHaveBeenCalledWith({ alias: 'thinking', thinkingEffort: 'high' });
+  });
+
+  it('shows effort selector for models with thinking_effort capability', () => {
+    const onSelect = vi.fn();
+    const picker = new ModelSelectorComponent({
+      models: {
+        o3: {
+          provider: 'openai',
+          model: 'o3',
+          maxContextSize: 200_000,
+          displayName: 'OpenAI o3',
+          capabilities: ['thinking_effort'],
+        },
+      },
+      currentValue: 'o3',
+      currentThinkingEffort: 'medium',
+      colors: darkColors,
+      onSelect,
+      onCancel: vi.fn(),
+    });
+
+    const output = rendered(picker);
+    expect(output).toContain('Off');
+    expect(output).toContain('Low');
+    expect(output).toContain('[ Medium ]');
+    expect(output).toContain('High');
+
+    // Right arrow cycles to high
+    picker.handleInput('[C');
+    expect(rendered(picker)).toContain('[ High ]');
+
+    // Left arrow cycles back to medium, then low, then off
+    picker.handleInput('[D');
+    expect(rendered(picker)).toContain('[ Medium ]');
+
+    picker.handleInput('[D');
+    expect(rendered(picker)).toContain('[ Low ]');
+
+    picker.handleInput('[D');
+    expect(rendered(picker)).toContain('[ Off ]');
+
+    // Can't go below off
+    picker.handleInput('[D');
+    expect(rendered(picker)).toContain('[ Off ]');
+
+    // Enter submits the selected level
+    picker.handleInput('[C'); // low
+    picker.handleInput('\r');
+    expect(onSelect).toHaveBeenCalledWith({ alias: 'o3', thinkingEffort: 'low' });
+  });
+
+  it('cannot go above high in effort selector', () => {
+    const picker = new ModelSelectorComponent({
+      models: {
+        o3: {
+          provider: 'openai',
+          model: 'o3',
+          maxContextSize: 200_000,
+          capabilities: ['thinking_effort'],
+        },
+      },
+      currentValue: 'o3',
+      currentThinkingEffort: 'high',
+      colors: darkColors,
+      onSelect: vi.fn(),
+      onCancel: vi.fn(),
+    });
+
+    picker.handleInput('[C');
+    expect(rendered(picker)).toContain('[ High ]');
   });
 });
 
@@ -323,14 +393,14 @@ describe('ModelSelectorComponent search and pagination', () => {
     return models;
   }
 
-  function makeSelector(models: Record<string, ModelAlias>, currentThinking = true) {
+  function makeSelector(models: Record<string, ModelAlias>, currentThinkingEffort: ThinkingEffortLevel = 'high') {
     const onSelect = vi.fn();
     const onCancel = vi.fn();
     const firstAlias = Object.keys(models)[0] ?? '';
     const selector = new ModelSelectorComponent({
       models,
       currentValue: firstAlias,
-      currentThinking,
+      currentThinkingEffort,
       colors: darkColors,
       searchable: true,
       onSelect,

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -28,6 +28,7 @@ export const ProviderConfigSchema = z.object({
   apiKey: z.string().optional(),
   baseUrl: z.string().optional(),
   defaultModel: z.string().optional(),
+  thinkingEffortKey: z.string().optional(),
   oauth: OAuthRefSchema.optional(),
   env: StringRecordSchema.optional(),
   customHeaders: StringRecordSchema.optional(),

--- a/packages/agent-core/src/providers/runtime-provider.ts
+++ b/packages/agent-core/src/providers/runtime-provider.ts
@@ -262,6 +262,7 @@ function toKosongProviderConfig(
           type: 'openai-compat',
           model,
           baseUrl: providerValue(provider.baseUrl, provider.env, 'BYF_BASE_URL'),
+          thinkingEffortKey: provider.thinkingEffortKey,
           generationKwargs: {
             prompt_cache_key: promptCacheKey,
           },
@@ -272,6 +273,7 @@ function toKosongProviderConfig(
         type: 'openai-compat',
         model,
         baseUrl: providerValue(provider.baseUrl, provider.env, 'BYF_BASE_URL'),
+        thinkingEffortKey: provider.thinkingEffortKey,
         generationKwargs: {
           prompt_cache_key: promptCacheKey,
         },

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -356,6 +356,27 @@ describe('resolveRuntimeProvider Byf request headers', () => {
     });
   });
 
+  it('forwards provider thinkingEffortKey to openai-compat runtime config', () => {
+    const resolved = resolveRuntimeProvider({
+      config: {
+        ...BASE_CONFIG,
+        providers: {
+          'managed:byf': {
+            type: 'openai-compat',
+            apiKey: 'test-key',
+            baseUrl: 'https://api.example/v1',
+            thinkingEffortKey: 'thinking_effort',
+          },
+        },
+      },
+    });
+
+    expect(resolved.provider).toMatchObject({
+      type: 'openai-compat',
+      thinkingEffortKey: 'thinking_effort',
+    });
+  });
+
   it('lets provider customHeaders override byfRequestHeaders', () => {
     const resolved = resolveRuntimeProvider({
       config: {

--- a/packages/kosong/src/providers/openai-compat.ts
+++ b/packages/kosong/src/providers/openai-compat.ts
@@ -41,6 +41,7 @@ export interface OpenAICompatOptions {
   model: string;
   stream?: boolean;
   defaultHeaders?: Record<string, string>;
+  thinkingEffortKey?: string;
   generationKwargs?: GenerationKwargs;
   clientFactory?: (auth: ProviderRequestAuth) => OpenAI;
 }
@@ -65,6 +66,7 @@ export interface GenerationKwargs {
   reasoning_effort?: string | undefined;
   prompt_cache_key?: string | undefined;
   extra_body?: ExtraBody;
+  [key: string]: unknown;
 }
 
 export interface ThinkingConfig {
@@ -356,6 +358,7 @@ export class OpenAICompatChatProvider implements ChatProvider {
   private _baseUrl: string;
   private _defaultHeaders: Record<string, string> | undefined;
   private _generationKwargs: GenerationKwargs;
+  private _thinkingEffortKey: string;
   private _client: OpenAI | undefined;
   private _clientFactory: ((auth: ProviderRequestAuth) => OpenAI) | undefined;
   private _files: OpenAICompatFiles | undefined;
@@ -368,6 +371,11 @@ export class OpenAICompatChatProvider implements ChatProvider {
     this._clientFactory = options.clientFactory;
     this._model = options.model;
     this._stream = options.stream ?? true;
+    const normalizedThinkingEffortKey = options.thinkingEffortKey?.trim();
+    this._thinkingEffortKey =
+      normalizedThinkingEffortKey !== undefined && normalizedThinkingEffortKey.length > 0
+        ? normalizedThinkingEffortKey
+        : 'reasoning_effort';
     this._generationKwargs = { ...options.generationKwargs };
     this._client =
       this._apiKey === undefined
@@ -405,7 +413,12 @@ export class OpenAICompatChatProvider implements ChatProvider {
   }
 
   get thinkingEffort(): ThinkingEffort | null {
-    return reasoningEffortToThinkingEffort(this._generationKwargs.reasoning_effort);
+    const customValue = this._generationKwargs[this._thinkingEffortKey];
+    if (typeof customValue === 'string') {
+      return reasoningEffortToThinkingEffort(customValue);
+    }
+    const defaultValue = this._generationKwargs.reasoning_effort;
+    return reasoningEffortToThinkingEffort(defaultValue);
   }
 
   get modelParameters(): Record<string, unknown> {
@@ -513,7 +526,10 @@ export class OpenAICompatChatProvider implements ChatProvider {
         reasoningEffort = 'high';
         break;
     }
-    return this._withGenerationKwargs({ reasoning_effort: reasoningEffort }).withExtraBody({
+    const nextEffort: GenerationKwargs = {
+      [this._thinkingEffortKey]: reasoningEffort,
+    };
+    return this._withGenerationKwargs(nextEffort).withExtraBody({
       thinking,
     });
   }

--- a/packages/kosong/test/kimi.test.ts
+++ b/packages/kosong/test/kimi.test.ts
@@ -684,6 +684,24 @@ describe('OpenAICompatChatProvider', () => {
       expect(body['extra_body']).toBeUndefined();
     });
 
+    it('uses a custom thinking effort key when configured', async () => {
+      const provider = new OpenAICompatChatProvider({
+        model: 'byf-k2-turbo-preview',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.example.test/v1',
+        stream: false,
+        thinkingEffortKey: 'thinking_effort',
+      }).withThinking('high');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['thinking_effort']).toBe('high');
+      expect(body['reasoning_effort']).toBeUndefined();
+      expect(body['thinking']).toEqual({ type: 'enabled' });
+    });
+
     it('thinkingEffort property reflects current state', () => {
       const provider = createProvider();
       expect(provider.thinkingEffort).toBeNull();

--- a/packages/oauth/src/provider-config.ts
+++ b/packages/oauth/src/provider-config.ts
@@ -9,6 +9,8 @@ export interface ModelInfo {
   readonly id: string;
   readonly contextLength: number;
   readonly supportsReasoning: boolean;
+  readonly supportsReasoningEffort?: boolean | undefined;
+  readonly reasoningEffortKey?: string | undefined;
   readonly supportsImageIn: boolean;
   readonly supportsVideoIn: boolean;
   readonly supportsToolUse?: boolean | undefined;
@@ -75,17 +77,41 @@ function toModelInfo(item: unknown): ModelInfo | undefined {
   const supportsToolUse = Object.hasOwn(item, 'supports_tool_use')
     ? Boolean(item['supports_tool_use'])
     : true;
+  const reasoningEffortKey = firstNonEmptyString(item, [
+    'reasoning_effort_key',
+    'thinking_effort_key',
+    'reasoning_effort_param',
+    'thinking_effort_param',
+  ]);
+  const supportsReasoningEffort = Object.hasOwn(item, 'supports_reasoning_effort')
+    ? Boolean(item['supports_reasoning_effort'])
+    : reasoningEffortKey !== undefined;
   return {
     id: item['id'],
     contextLength,
     supportsReasoning: Object.hasOwn(item, 'supports_reasoning')
       ? Boolean(item['supports_reasoning'])
       : true,
+    supportsReasoningEffort,
+    reasoningEffortKey,
     supportsImageIn: Boolean(item['supports_image_in']),
     supportsVideoIn: Boolean(item['supports_video_in']),
     supportsToolUse,
     displayName: normalizedDisplayName,
   };
+}
+
+function firstNonEmptyString(
+  source: Record<string, unknown>,
+  keys: readonly string[],
+): string | undefined {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value !== 'string') continue;
+    const normalized = value.trim();
+    if (normalized.length > 0) return normalized;
+  }
+  return undefined;
 }
 
 export async function fetchModels(
@@ -138,6 +164,7 @@ export function filterModelsByPrefix(
 export function capabilitiesForModel(model: ModelInfo): string[] | undefined {
   const caps = new Set<string>();
   if (model.supportsReasoning) caps.add('thinking');
+  if (model.supportsReasoningEffort === true) caps.add('thinking_effort');
   if (model.supportsImageIn) caps.add('image_in');
   if (model.supportsVideoIn) caps.add('video_in');
   if (model.supportsToolUse ?? true) caps.add('tool_use');
@@ -171,6 +198,7 @@ export function applyProviderConfig(
     type: 'openai-compat',
     baseUrl: options.baseUrl,
     apiKey: options.apiKey,
+    thinkingEffortKey: options.selectedModel.reasoningEffortKey,
   };
 
   const existingModels = config.models ?? {};

--- a/packages/oauth/test/provider-config.test.ts
+++ b/packages/oauth/test/provider-config.test.ts
@@ -30,6 +30,8 @@ const SAMPLE_MODELS = [
     id: 'deepseek-reasoner',
     context_length: 65536,
     supports_reasoning: true,
+    supports_reasoning_effort: true,
+    reasoning_effort_key: 'thinking_effort',
     supports_image_in: false,
     supports_video_in: false,
     display_name: 'DeepSeek Reasoner',
@@ -66,6 +68,8 @@ describe('fetchModels', () => {
       id: 'deepseek-reasoner',
       contextLength: 65536,
       supportsReasoning: true,
+      supportsReasoningEffort: true,
+      reasoningEffortKey: 'thinking_effort',
       displayName: 'DeepSeek Reasoner',
     });
     expect(models[2]?.supportsToolUse).toBe(false);
@@ -135,7 +139,16 @@ describe('applyProviderConfig', () => {
   it('writes provider, models, and defaults', () => {
     const config: ConfigShape = { providers: {} };
     const models: ModelInfo[] = [
-      { id: 'deepseek-chat', contextLength: 65536, supportsReasoning: false, supportsImageIn: false, supportsVideoIn: false, displayName: 'DeepSeek Chat' },
+      {
+        id: 'deepseek-chat',
+        contextLength: 65536,
+        supportsReasoning: false,
+        supportsReasoningEffort: true,
+        reasoningEffortKey: 'thinking_effort',
+        supportsImageIn: false,
+        supportsVideoIn: false,
+        displayName: 'DeepSeek Chat',
+      },
       { id: 'deepseek-reasoner', contextLength: 65536, supportsReasoning: true, supportsImageIn: false, supportsVideoIn: false },
     ];
 
@@ -157,6 +170,7 @@ describe('applyProviderConfig', () => {
       type: 'openai-compat',
       baseUrl: 'https://api.deepseek.com/v1',
       apiKey: 'sk-test',
+      thinkingEffortKey: 'thinking_effort',
     });
     expect(config.models?.['deepseek/deepseek-chat']).toMatchObject({
       provider: 'deepseek',
@@ -208,9 +222,15 @@ describe('capabilitiesForModel', () => {
   it('returns all caps for a full-featured model', () => {
     const model: ModelInfo = {
       id: 'full', contextLength: 1000,
-      supportsReasoning: true, supportsImageIn: true, supportsVideoIn: true, supportsToolUse: true,
+      supportsReasoning: true, supportsReasoningEffort: true, supportsImageIn: true, supportsVideoIn: true, supportsToolUse: true,
     };
-    expect(capabilitiesForModel(model)).toEqual(['thinking', 'image_in', 'video_in', 'tool_use']);
+    expect(capabilitiesForModel(model)).toEqual([
+      'thinking',
+      'thinking_effort',
+      'image_in',
+      'video_in',
+      'tool_use',
+    ]);
   });
 });
 


### PR DESCRIPTION
Related issue: closes #21.

What changed:
- Upgraded CLI model selector and app state from binary thinking to effort levels (off/low/medium/high) for models exposing thinking_effort, with toggle/always-on fallback retained.
- Fixed /model, /login, and /connect wiring to use effort state during runtime switching and config persistence.
- Added effort-capable model detection and optional effort-parameter-key detection in @byf/oauth provider model parsing.
- Added provider-level thinking_effort_key support through config schema (@byf/agent-core), runtime provider resolution, and @byf/kosong openai-compat request mapping.
- Added updates in CLI/OAuth/Agent Core/Kosong tests and a changeset for @byf/cli, @byf/oauth, @byf/agent-core, and @byf/kosong.

Validation:
- pnpm --filter @byf/cli test --run test/tui/components/dialogs/choice-picker.test.ts test/tui/byf-tui-message-flow.test.ts
- pnpm --filter @byf/agent-core test --run test/harness/runtime-provider.test.ts
- pnpm --filter @byf/kosong test --run test/kimi.test.ts
- pnpm --filter @byf/oauth exec vitest run test/provider-config.test.ts