### PR TITLE
feat: add shellExec API and CLI shell command support

### DIFF
--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -18,6 +18,8 @@ import {
   Spacer,
   TUI,
 } from '@earendil-works/pi-tui';
+import { homedir } from 'node:os';
+import { resolve as resolvePath } from 'node:path';
 import {
   applyCatalogProvider,
   catalogBaseUrl,
@@ -64,6 +66,7 @@ import type {
   SessionMetaUpdatedEvent,
   SessionStatus,
   SessionUsage,
+  ShellExecResult,
   SkillActivatedEvent,
   SubagentCompletedEvent,
   SubagentFailedEvent,
@@ -98,6 +101,7 @@ import {
   BUILTIN_SLASH_COMMANDS,
   buildAutocompleteSlashCommands,
   buildSkillSlashCommands,
+  parseShellCommand,
   parseSlashInput,
   resolveSlashCommandInput,
   slashBusyMessage,
@@ -145,6 +149,7 @@ import { BackgroundAgentStatusComponent } from './components/messages/background
 import { buildMcpStatusReportLines } from './components/messages/mcp-status-panel';
 import { ReadGroupComponent } from './components/messages/read-group';
 import { SkillActivationComponent } from './components/messages/skill-activation';
+import { ShellExecutionComponent } from './components/messages/shell-execution';
 import {
   NoticeMessageComponent,
   StatusMessageComponent,
@@ -389,6 +394,7 @@ function createInitialAppState(input: ByfTuiStartupInput): AppState {
   return {
     model: '',
     workDir: input.workDir,
+    shellWorkDir: input.workDir,
     sessionId: '',
     yolo: input.cliOptions.yolo,
     permissionMode: startupPermission,
@@ -501,6 +507,27 @@ function combineStartupNotice(
     return `${existing}\n${next}`;
   }
   return existing ?? next;
+}
+
+const SIMPLE_CD_ONLY = /^cd(?:\s+(.+))?$/;
+
+function parseSimpleCdTarget(command: string): string | null {
+  if (command.includes('&&') || command.includes('||') || command.includes('|') || command.includes(';')) {
+    return null;
+  }
+  const match = SIMPLE_CD_ONLY.exec(command.trim());
+  if (match === null) return null;
+  const target = match[1]?.trim();
+  if (target === undefined || target.length === 0) return '~';
+  return target;
+}
+
+function resolveShellCdTarget(cwd: string, target: string): string | null {
+  if (target === '-') return null;
+  const home = homedir();
+  if (target === '~') return home;
+  if (target.startsWith('~/')) return resolvePath(home, target.slice(2));
+  return resolvePath(cwd, target);
 }
 
 function isOAuthLoginRequiredError(error: unknown): boolean {
@@ -1343,6 +1370,11 @@ export class ByfTui {
   // Routes submitted editor text to slash command handling or normal prompting.
   private handleUserInput(text: string): void {
     if (text.trim().length === 0) return;
+    const shellCommand = parseShellCommand(text);
+    if (shellCommand !== null) {
+      void this.handleShellExecution(shellCommand, text);
+      return;
+    }
     if (this.state.appState.isReplaying) {
       this.showError('Cannot send input while session history is replaying.');
       return;
@@ -1354,6 +1386,52 @@ export class ByfTui {
     }
 
     this.sendNormalUserInput(text);
+  }
+
+  private async handleShellExecution(command: string, rawInput: string): Promise<void> {
+    if (this.state.appState.isReplaying) {
+      this.showError('Cannot execute shell commands while session history is replaying.');
+      return;
+    }
+    const session = this.session;
+    if (session === undefined) {
+      this.showError(NO_ACTIVE_SESSION_MESSAGE);
+      return;
+    }
+    await this.persistInputHistory(rawInput);
+    const cwd = this.state.appState.shellWorkDir ?? session.workDir;
+    let result: ShellExecResult;
+    try {
+      result = await session.shellExec(command, { cwd });
+    } catch (error) {
+      this.showError(error instanceof Error ? error.message : 'Shell execution failed.');
+      return;
+    }
+    this.appendShellExecTranscriptEntry(command, result);
+    await this.maybeUpdateShellWorkDirAfterCd(session, command, cwd, result);
+  }
+
+  private async maybeUpdateShellWorkDirAfterCd(
+    session: Session,
+    command: string,
+    cwd: string,
+    result: ShellExecResult,
+  ): Promise<void> {
+    if (result.timedOut || result.exitCode !== 0) return;
+    const target = parseSimpleCdTarget(command);
+    if (target === null) return;
+    const resolved = resolveShellCdTarget(cwd, target);
+    if (resolved === null) return;
+    try {
+      const check = await session.shellExec('pwd', { cwd: resolved });
+      if (check.timedOut || check.exitCode !== 0) return;
+      const nextCwd = check.stdout.trim();
+      if (nextCwd.length > 0) {
+        this.setAppState({ shellWorkDir: nextCwd });
+      }
+    } catch (error) {
+      this.showError(error instanceof Error ? error.message : 'Failed to update shell working directory.');
+    }
   }
 
   // Parses and executes a slash command intent.
@@ -1651,6 +1729,24 @@ export class ByfTui {
     void session.activateSkill(skillName, skillArgs).catch((error: unknown) => {
       const message = formatErrorMessage(error);
       this.failSessionRequest(`Skill "${skillName}" failed: ${message}`);
+    });
+  }
+
+  private appendShellExecTranscriptEntry(command: string, result: ShellExecResult): void {
+    const entryId = nextTranscriptId();
+    const toolCallId = `shell_exec:${entryId}`;
+    const resultData = toShellExecTranscriptResult(command, result, toolCallId);
+    this.appendTranscriptEntry({
+      id: entryId,
+      kind: 'shell_exec',
+      renderMode: 'plain',
+      content: command,
+      toolCallData: {
+        id: toolCallId,
+        name: 'ShellExec',
+        args: { command },
+        result: resultData,
+      },
     });
   }
 
@@ -1965,6 +2061,7 @@ export class ByfTui {
     const previous = this.unloadCurrentSession('switching session');
     await previous?.close();
     this.session = session;
+    this.setAppState({ shellWorkDir: session.workDir });
     this.harness.setTelemetryContext({ sessionId: session.id });
     this.registerSessionHandlers(session);
   }
@@ -3485,6 +3582,14 @@ export class ByfTui {
         return entry.renderMode === 'notice'
           ? new NoticeMessageComponent(entry.content, entry.detail, this.state.theme.colors)
           : new StatusMessageComponent(entry.content, this.state.theme.colors, entry.color);
+      case 'shell_exec':
+        return new ShellExecutionComponent({
+          command: entry.content,
+          result: entry.toolCallData?.result,
+          colors: this.state.theme.colors,
+          expanded: this.state.toolOutputExpanded,
+          showCommand: true,
+        });
       case 'status':
         if (entry.backgroundAgentStatus !== undefined) {
           return new BackgroundAgentStatusComponent(
@@ -5469,4 +5574,27 @@ function formatHookResultTitle(event: HookResultEvent): string {
 function formatHookResultBody(event: HookResultEvent): string {
   const content = event.content.trim();
   return content.length === 0 ? '(empty)' : content;
+}
+
+function toShellExecTranscriptResult(
+  command: string,
+  result: ShellExecResult,
+  toolCallId: string,
+): ToolResultBlockData {
+  const sections: string[] = [];
+  if (result.stdout.length > 0) {
+    sections.push(result.stdout);
+  }
+  if (result.stderr.length > 0) {
+    sections.push(result.stderr);
+  }
+  if (result.timedOut) {
+    sections.push(`Command timed out: ${command}`);
+  }
+  const output = sections.join('\n').trim();
+  return {
+    tool_call_id: toolCallId,
+    output: output.length > 0 ? output : '(no output)',
+    is_error: result.exitCode !== 0 || result.timedOut,
+  };
 }

--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -511,6 +511,19 @@ function combineStartupNotice(
 
 const SIMPLE_CD_ONLY = /^cd(?:\s+(.+))?$/;
 
+function parseSimpleCdPathToken(target: string): string | null {
+  if (target.length === 0) return null;
+  const first = target[0];
+  if (first !== '"' && first !== "'") {
+    if (target.includes('"') || target.includes("'")) return null;
+    return target;
+  }
+  if (target[target.length - 1] !== first || target.length < 2) return null;
+  const inner = target.slice(1, -1);
+  if (inner.includes(first)) return null;
+  return inner;
+}
+
 function parseSimpleCdTarget(command: string): string | null {
   if (command.includes('&&') || command.includes('||') || command.includes('|') || command.includes(';')) {
     return null;
@@ -519,7 +532,7 @@ function parseSimpleCdTarget(command: string): string | null {
   if (match === null) return null;
   const target = match[1]?.trim();
   if (target === undefined || target.length === 0) return '~';
-  return target;
+  return parseSimpleCdPathToken(target);
 }
 
 function resolveShellCdTarget(cwd: string, target: string): string | null {

--- a/apps/cli/src/tui/commands/index.ts
+++ b/apps/cli/src/tui/commands/index.ts
@@ -1,4 +1,5 @@
 export * from './parse';
+export * from './parse-shell-command';
 export * from './registry';
 export * from './resolve';
 export * from './skills';

--- a/apps/cli/src/tui/commands/parse-shell-command.ts
+++ b/apps/cli/src/tui/commands/parse-shell-command.ts
@@ -1,0 +1,8 @@
+const SHELL_PREFIX = /^!\s+([\s\S]+)$/;
+
+export function parseShellCommand(input: string): string | null {
+  const matched = SHELL_PREFIX.exec(input);
+  if (matched === null) return null;
+  const command = matched[1]?.trim() ?? '';
+  return command.length > 0 ? command : null;
+}

--- a/apps/cli/src/tui/components/chrome/footer.ts
+++ b/apps/cli/src/tui/components/chrome/footer.ts
@@ -132,16 +132,21 @@ export class FooterComponent implements Component {
     this.state = state;
     this.colors = colors;
     this.onGitStatusChange = onGitStatusChange;
-    this.gitCacheWorkDir = state.workDir;
-    this.gitCache = createGitStatusCache(state.workDir, { onChange: this.onGitStatusChange });
+    this.gitCacheWorkDir = this.getDisplayedWorkDir(state);
+    this.gitCache = createGitStatusCache(this.gitCacheWorkDir, { onChange: this.onGitStatusChange });
   }
 
   setState(state: AppState): void {
-    if (state.workDir !== this.gitCacheWorkDir) {
-      this.gitCacheWorkDir = state.workDir;
-      this.gitCache = createGitStatusCache(state.workDir, { onChange: this.onGitStatusChange });
+    const displayedWorkDir = this.getDisplayedWorkDir(state);
+    if (displayedWorkDir !== this.gitCacheWorkDir) {
+      this.gitCacheWorkDir = displayedWorkDir;
+      this.gitCache = createGitStatusCache(displayedWorkDir, { onChange: this.onGitStatusChange });
     }
     this.state = state;
+  }
+
+  private getDisplayedWorkDir(state: AppState): string {
+    return state.shellWorkDir ?? state.workDir;
   }
 
   setColors(colors: ColorPalette): void {
@@ -202,7 +207,7 @@ export class FooterComponent implements Component {
       );
     }
 
-    const cwd = shortenCwd(state.workDir);
+    const cwd = shortenCwd(this.getDisplayedWorkDir(state));
     if (cwd) left.push(chalk.hex(colors.status)(cwd));
 
     const git = this.gitCache.getStatus();

--- a/apps/cli/src/tui/components/editor/custom-editor.ts
+++ b/apps/cli/src/tui/components/editor/custom-editor.ts
@@ -16,6 +16,7 @@ const ANSI_SGR = /\u001B\[[0-9;]*m/g;
 // `ctrl+<LETTER>` with caps_lock into `ctrl+<letter>` without caps_lock.
 // oxlint-disable-next-line no-control-regex -- ESC (\x1b) is required to match CSI
 const KITTY_CSI_U = /^\u001B\[(\d+);(\d+)((?::\d+)*)u$/;
+const SHELL_MODE_PREFIX = /^!\s+/;
 // Kitty modifier bit layout: shift=1, alt=2, ctrl=4, super=8, hyper=16,
 // meta=32, caps_lock=64, num_lock=128. Reported value is `mask + 1`.
 const CAPS_LOCK_BIT = 64;
@@ -159,8 +160,9 @@ export class CustomEditor extends Editor {
     const lines = super.render(width);
     if (lines.length < 3) return lines;
     const firstContentIdx = 1;
-    const text = this.getText().trimStart();
-    if (text.startsWith('/')) {
+    const text = this.getText();
+    const shellMode = SHELL_MODE_PREFIX.test(text);
+    if (!shellMode && text.trimStart().startsWith('/')) {
       // Paint only the FIRST editor content line; multi-line slash commands
       // are not a thing in practice.
       const original = lines[firstContentIdx];
@@ -173,7 +175,10 @@ export class CustomEditor extends Editor {
     }
     const firstContent = lines[firstContentIdx];
     if (firstContent !== undefined) {
-      const withPrompt = injectPromptSymbol(firstContent);
+      const withPrompt = injectPromptSymbol(firstContent, {
+        symbol: shellMode ? '$' : '>',
+        colorHex: shellMode ? this.colors.success : undefined,
+      });
       if (withPrompt !== undefined) {
         lines[firstContentIdx] = withPrompt;
       }
@@ -320,12 +325,17 @@ export function highlightFirstSlashToken(line: string, hex: string): string | un
  * default foreground colour renders the symbol. Returns `undefined` if the
  * line is too short or doesn't begin with the expected padding.
  */
-export function injectPromptSymbol(line: string): string | undefined {
+export function injectPromptSymbol(
+  line: string,
+  options: { symbol?: '>' | '$'; colorHex?: string } = {},
+): string | undefined {
   if (line.length < 4) return undefined;
   for (let i = 0; i < 4; i++) {
     if (line[i] !== ' ') return undefined;
   }
-  return '  > ' + line.slice(4);
+  const symbol = options.symbol ?? '>';
+  const prompt = options.colorHex ? chalk.hex(options.colorHex).bold(symbol) : symbol;
+  return `  ${prompt} ${line.slice(4)}`;
 }
 
 /**

--- a/apps/cli/src/tui/components/editor/custom-editor.ts
+++ b/apps/cli/src/tui/components/editor/custom-editor.ts
@@ -175,7 +175,8 @@ export class CustomEditor extends Editor {
     }
     const firstContent = lines[firstContentIdx];
     if (firstContent !== undefined) {
-      const withPrompt = injectPromptSymbol(firstContent, {
+      const shellAdjusted = shellMode ? stripShellModePrefix(firstContent) : firstContent;
+      const withPrompt = injectPromptSymbol(shellAdjusted, {
         symbol: shellMode ? '$' : '>',
         colorHex: shellMode ? this.colors.success : undefined,
       });
@@ -336,6 +337,35 @@ export function injectPromptSymbol(
   const symbol = options.symbol ?? '>';
   const prompt = options.colorHex ? chalk.hex(options.colorHex).bold(symbol) : symbol;
   return `  ${prompt} ${line.slice(4)}`;
+}
+
+export function stripShellModePrefix(line: string): string {
+  if (line.length < 4 || !line.startsWith('    ')) return line;
+  const content = line.slice(4);
+  const stripped = stripVisiblePrefix(content, '! ');
+  if (stripped === null) return line;
+  return `    ${stripped}`;
+}
+
+function stripVisiblePrefix(input: string, expected: string): string | null {
+  let i = 0;
+  let matched = 0;
+  let preservedAnsi = '';
+  while (i < input.length && matched < expected.length) {
+    const char = input[i];
+    if (char === '\u001B' && input[i + 1] === '[') {
+      const ansiEnd = input.indexOf('m', i + 2);
+      if (ansiEnd === -1) return null;
+      preservedAnsi += input.slice(i, ansiEnd + 1);
+      i = ansiEnd + 1;
+      continue;
+    }
+    if (char !== expected[matched]) return null;
+    matched += 1;
+    i += 1;
+  }
+  if (matched !== expected.length) return null;
+  return preservedAnsi + input.slice(i);
 }
 
 /**

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -23,6 +23,7 @@ export function parseThinkingEffort(value: string | undefined): ThinkingEffortLe
 export interface AppState {
   model: string;
   workDir: string;
+  shellWorkDir?: string;
   sessionId: string;
   yolo: boolean;
   permissionMode: PermissionMode;
@@ -111,6 +112,7 @@ export type TranscriptEntryKind =
   | 'user'
   | 'assistant'
   | 'tool_call'
+  | 'shell_exec'
   | 'thinking'
   | 'status'
   | 'skill_activation';

--- a/apps/cli/test/tui/byf-tui-message-flow.test.ts
+++ b/apps/cli/test/tui/byf-tui-message-flow.test.ts
@@ -77,9 +77,16 @@ function makeStartupInput(): ByfTuiStartupInput {
 function makeSession(overrides: Record<string, unknown> = {}) {
   return {
     id: 'ses-1',
+    workDir: '/tmp/proj-a',
     model: 'k2',
     summary: { title: null },
     prompt: vi.fn(async () => {}),
+    shellExec: vi.fn(async () => ({
+      stdout: '',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+    })),
     steer: vi.fn(async () => {}),
     init: vi.fn(async () => {}),
     cancel: vi.fn(async () => {}),
@@ -554,6 +561,76 @@ describe('ByfTui message flow', () => {
     expect(driver.state.queuedMessages).toEqual([{ text: 'queued message', agentId: 'main' }]);
     expect(driver.state.queueContainer.children.length).toBeGreaterThan(0);
     expect(harness.track).toHaveBeenCalledWith('input_queue', undefined);
+  });
+
+  it('routes ! commands to shell execution before slash-command dispatch and renders output', async () => {
+    const shellExec = vi.fn(async () => ({
+      stdout: 'hi\n',
+      stderr: '',
+      exitCode: 0,
+      timedOut: false,
+    }));
+    const session = makeSession({ shellExec, workDir: '/tmp/shell-session' });
+    const { driver } = await makeDriver(session);
+
+    driver.handleUserInput('! echo hi');
+
+    await vi.waitFor(() => {
+      expect(shellExec).toHaveBeenCalledWith('echo hi', { cwd: '/tmp/shell-session' });
+    });
+    expect(session.prompt).not.toHaveBeenCalled();
+    expect(driver.persistInputHistory).toHaveBeenCalledWith('! echo hi');
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('$ echo hi');
+    expect(transcript).toContain('hi');
+  });
+
+  it('updates shell cwd after successful `! cd` and uses it for subsequent shell commands', async () => {
+    const shellExec = vi.fn(async (command: string, options?: { cwd?: string }) => {
+      if (command === 'pwd' && options?.cwd === '/tmp') {
+        return {
+          stdout: '/tmp\n',
+          stderr: '',
+          exitCode: 0,
+          timedOut: false,
+        };
+      }
+      return {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      };
+    });
+    const session = makeSession({ shellExec, workDir: '/tmp/proj-a' });
+    const { driver } = await makeDriver(session);
+
+    driver.handleUserInput('! cd ..');
+    await vi.waitFor(() => {
+      expect(shellExec).toHaveBeenCalledWith('cd ..', { cwd: '/tmp/proj-a' });
+    });
+    await vi.waitFor(() => {
+      expect(shellExec).toHaveBeenCalledWith('pwd', { cwd: '/tmp' });
+    });
+    expect(driver.state.appState.shellWorkDir).toBe('/tmp');
+
+    driver.handleUserInput('! pwd');
+    await vi.waitFor(() => {
+      expect(shellExec).toHaveBeenCalledWith('pwd', { cwd: '/tmp' });
+    });
+  });
+
+  it('rejects ! commands while replaying session history', async () => {
+    const session = makeSession();
+    const { driver } = await makeDriver(session);
+    driver.state.appState.isReplaying = true;
+
+    driver.handleUserInput('! ls -la');
+
+    expect(session.shellExec).not.toHaveBeenCalled();
+    expect(driver.state.transcriptContainer.render(120).join('\n')).toContain(
+      'Cannot execute shell commands while session history is replaying.',
+    );
   });
 
   it('cancels active streaming from Escape and Ctrl-C editor shortcuts', async () => {

--- a/apps/cli/test/tui/byf-tui-message-flow.test.ts
+++ b/apps/cli/test/tui/byf-tui-message-flow.test.ts
@@ -620,6 +620,49 @@ describe('ByfTui message flow', () => {
     });
   });
 
+  it('updates shell cwd after successful `! cd "a b"` and uses it for subsequent shell commands', async () => {
+    const shellExec = vi.fn(async (command: string, options?: { cwd?: string }) => {
+      if (command === 'pwd' && options?.cwd === '/tmp/proj-a/a b') {
+        return {
+          stdout: '/tmp/proj-a/a b\n',
+          stderr: '',
+          exitCode: 0,
+          timedOut: false,
+        };
+      }
+      if (command === 'pwd') {
+        return {
+          stdout: '',
+          stderr: 'missing',
+          exitCode: 1,
+          timedOut: false,
+        };
+      }
+      return {
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+        timedOut: false,
+      };
+    });
+    const session = makeSession({ shellExec, workDir: '/tmp/proj-a' });
+    const { driver } = await makeDriver(session);
+
+    driver.handleUserInput('! cd "a b"');
+    await vi.waitFor(() => {
+      expect(shellExec).toHaveBeenCalledWith('cd "a b"', { cwd: '/tmp/proj-a' });
+    });
+    await vi.waitFor(() => {
+      expect(shellExec).toHaveBeenCalledWith('pwd', { cwd: '/tmp/proj-a/a b' });
+    });
+    expect(driver.state.appState.shellWorkDir).toBe('/tmp/proj-a/a b');
+
+    driver.handleUserInput('! pwd');
+    await vi.waitFor(() => {
+      expect(shellExec).toHaveBeenCalledWith('pwd', { cwd: '/tmp/proj-a/a b' });
+    });
+  });
+
   it('rejects ! commands while replaying session history', async () => {
     const session = makeSession();
     const { driver } = await makeDriver(session);

--- a/apps/cli/test/tui/commands/registry.test.ts
+++ b/apps/cli/test/tui/commands/registry.test.ts
@@ -2,6 +2,7 @@ import {
   BUILTIN_SLASH_COMMANDS,
   buildAutocompleteSlashCommands,
   findBuiltInSlashCommand,
+  parseShellCommand,
   parseSlashInput,
   resolveSlashCommandAvailability,
   sortSlashCommands,
@@ -24,6 +25,22 @@ describe('parseSlashInput', () => {
     expect(parseSlashInput('/   ')).toBeNull();
     expect(parseSlashInput('/some/path')).toBeNull();
     expect(parseSlashInput('/some/path with args')).toBeNull();
+  });
+
+  describe('parseShellCommand', () => {
+    it('parses shell commands prefixed with exclamation and whitespace', () => {
+      expect(parseShellCommand('! ls -la')).toBe('ls -la');
+      expect(parseShellCommand('!\tgrep foo src/')).toBe('grep foo src/');
+      expect(parseShellCommand('!   echo ok   ')).toBe('echo ok');
+    });
+
+    it('returns null for non-shell input or empty commands', () => {
+      expect(parseShellCommand('/help')).toBeNull();
+      expect(parseShellCommand('hello world')).toBeNull();
+      expect(parseShellCommand('!')).toBeNull();
+      expect(parseShellCommand('!   ')).toBeNull();
+      expect(parseShellCommand('!echo')).toBeNull();
+    });
   });
 });
 

--- a/apps/cli/test/tui/components/editor/prompt-symbol.test.ts
+++ b/apps/cli/test/tui/components/editor/prompt-symbol.test.ts
@@ -34,4 +34,9 @@ describe('injectPromptSymbol', () => {
     expect(injectPromptSymbol('  x hello')).toBeUndefined();
     expect(injectPromptSymbol('   xhello')).toBeUndefined();
   });
+
+  it('supports shell-mode prompt symbol with color', () => {
+    const out = injectPromptSymbol('    ls', { symbol: '$', colorHex: '#00ff00' });
+    expect(out).toBe('  $ ls');
+  });
 });

--- a/apps/cli/test/tui/components/editor/prompt-symbol.test.ts
+++ b/apps/cli/test/tui/components/editor/prompt-symbol.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 
-import { injectPromptSymbol } from '#/tui/components/editor/custom-editor';
+import { injectPromptSymbol, stripShellModePrefix } from '#/tui/components/editor/custom-editor';
 
 describe('injectPromptSymbol', () => {
   it('places a "> " prompt at columns 2-3 (col 0 = border, col 1 = single-space gap)', () => {
@@ -38,5 +38,20 @@ describe('injectPromptSymbol', () => {
   it('supports shell-mode prompt symbol with color', () => {
     const out = injectPromptSymbol('    ls', { symbol: '$', colorHex: '#00ff00' });
     expect(out).toBe('  $ ls');
+  });
+});
+
+describe('stripShellModePrefix', () => {
+  it('hides leading `! ` from shell-mode content line', () => {
+    expect(stripShellModePrefix('    ! ls -la')).toBe('    ls -la');
+  });
+
+  it('preserves ANSI markers around hidden prefix', () => {
+    const line = '    \u001B[7m!\u001B[0m \u001B[7ml\u001B[0ms';
+    expect(stripShellModePrefix(line)).toBe('    \u001B[7m\u001B[0m\u001B[7ml\u001B[0ms');
+  });
+
+  it('leaves non-shell lines untouched', () => {
+    expect(stripShellModePrefix('    /help')).toBe('    /help');
   });
 });

--- a/packages/agent-core/src/rpc/core-api.ts
+++ b/packages/agent-core/src/rpc/core-api.ts
@@ -214,6 +214,20 @@ export interface RemoveByfProviderPayload {
   readonly providerId: string;
 }
 
+export interface ShellExecPayload {
+  readonly sessionId: string;
+  readonly command: string;
+  readonly cwd?: string;
+  readonly timeout?: number;
+}
+
+export interface ShellExecResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+  readonly timedOut: boolean;
+}
+
 export interface AgentAPI {
   prompt: (payload: PromptPayload) => void;
   steer: (payload: SteerPayload) => void;
@@ -255,6 +269,7 @@ export interface SessionAPI extends AgentAPIWithId {
   getMcpStartupMetrics: (payload: EmptyPayload) => McpStartupMetrics;
   reconnectMcpServer: (payload: ReconnectMcpServerPayload) => void;
   generateAgentsMd: (payload: EmptyPayload) => void;
+  shellExec: (payload: Omit<ShellExecPayload, 'sessionId'>) => Promise<ShellExecResult>;
 }
 
 type SessionAPIWithId = WithSessionId<SessionAPI>;

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -34,6 +34,8 @@ import type {
   RenameSessionPayload,
   ResumeSessionPayload,
   RegisterToolPayload,
+  ShellExecPayload,
+  ShellExecResult,
   SetByfConfigPayload,
   SetActiveToolsPayload,
   SetModelPayload,
@@ -534,6 +536,13 @@ export class ByfCore implements PromisableMethods<CoreAPI> {
 
   generateAgentsMd({ sessionId, ...payload }: SessionScopedPayload<EmptyPayload>): Promise<void> {
     return this.sessionApi(sessionId).generateAgentsMd(payload);
+  }
+
+  shellExec({
+    sessionId,
+    ...payload
+  }: SessionScopedPayload<Omit<ShellExecPayload, 'sessionId'>>): Promise<ShellExecResult> {
+    return this.sessionApi(sessionId).shellExec(payload);
   }
 
   private async resolveRuntime(config: ByfConfig): Promise<RuntimeConfig> {

--- a/packages/agent-core/src/session/rpc.ts
+++ b/packages/agent-core/src/session/rpc.ts
@@ -1,4 +1,7 @@
 import { ErrorCodes, ByfError } from '#/errors';
+import type { KaosProcess } from '@byf/kaos';
+import { StringDecoder } from 'node:string_decoder';
+import type { Readable } from 'node:stream';
 import type {
   ActivateSkillPayload,
   AgentAPI,
@@ -19,6 +22,7 @@ import type {
   SetActiveToolsPayload,
   SetModelPayload,
   SetPermissionPayload,
+  ShellExecResult,
   SetThinkingPayload,
   SkillSummary,
   SteerPayload,
@@ -86,6 +90,42 @@ export class SessionAPIImpl implements PromisableMethods<SessionAPI> {
 
   generateAgentsMd(_payload: EmptyPayload): Promise<void> {
     return this.session.generateAgentsMd();
+  }
+
+  async shellExec(payload: {
+    readonly command: string;
+    readonly cwd?: string;
+    readonly timeout?: number;
+  }): Promise<ShellExecResult> {
+    const environment = this.session.config.runtime.osEnv;
+    const isWindowsBash = environment.osKind === 'Windows';
+    const defaultCwd = this.session.config.cwd ?? process.cwd();
+    const effectiveCwd = payload.cwd ?? defaultCwd;
+    const shellCwd = isWindowsBash ? windowsPathToPosixPath(effectiveCwd) : effectiveCwd;
+    const command = isWindowsBash ? rewriteWindowsNullRedirect(payload.command) : payload.command;
+    const shellCommand = `cd ${shellQuote(shellCwd)} && ${command}`;
+    const shellArgs = [environment.shellPath, '-c', shellCommand];
+    const timeoutMs = normalizeShellTimeoutMs(payload.timeout);
+
+    const noninteractiveEnv: Record<string, string> = {
+      NO_COLOR: '1',
+      TERM: 'dumb',
+      GIT_TERMINAL_PROMPT: process.env['GIT_TERMINAL_PROMPT'] ?? '0',
+      SHELL: environment.shellPath,
+    };
+    const mergedEnv: Record<string, string> = {
+      ...(process.env as Record<string, string>),
+      ...noninteractiveEnv,
+    };
+    const proc = await this.session.config.runtime.kaos.execWithEnv(shellArgs, mergedEnv);
+
+    try {
+      proc.stdin.end();
+    } catch {
+      // stdin may already be closed by process termination
+    }
+
+    return waitForShellExecution(proc, timeoutMs);
   }
 
   async prompt({ agentId, ...payload }: AgentScopedPayload<PromptPayload>) {
@@ -258,4 +298,107 @@ function isUntitled(title: unknown): boolean {
 function hasCustomTitle(metadata: SessionMeta): boolean {
   if (metadata.isCustomTitle) return true;
   return typeof (metadata as SessionMeta & { customTitle?: unknown }).customTitle === 'string';
+}
+
+const SHELL_DEFAULT_TIMEOUT_MS = 30_000;
+const SHELL_SIGTERM_GRACE_MS = 5_000;
+const WINDOWS_NUL_REDIRECT = /(\d?&?>+\s*)[Nn][Uu][Ll](?=\s|$|[|&;)\n])/g;
+
+function normalizeShellTimeoutMs(timeout: number | undefined): number {
+  if (timeout === undefined) return SHELL_DEFAULT_TIMEOUT_MS;
+  if (!Number.isFinite(timeout) || timeout <= 0) {
+    throw new ByfError(ErrorCodes.REQUEST_INVALID, 'Shell timeout must be a positive number.');
+  }
+  return Math.floor(timeout);
+}
+
+async function waitForShellExecution(proc: KaosProcess, timeoutMs: number): Promise<ShellExecResult> {
+  let timedOut = false;
+  let killed = false;
+
+  const killProc = async (): Promise<void> => {
+    if (killed) return;
+    killed = true;
+    try {
+      await proc.kill('SIGTERM');
+    } catch {
+      // process already gone
+    }
+    const exited = proc
+      .wait()
+      .then(() => true)
+      .catch(() => true);
+    const raced = await Promise.race([
+      exited,
+      new Promise<false>((resolve) => {
+        setTimeout(() => {
+          resolve(false);
+        }, SHELL_SIGTERM_GRACE_MS);
+      }),
+    ]);
+    if (!raced && proc.exitCode === null) {
+      try {
+        await proc.kill('SIGKILL');
+      } catch {
+        // ignore
+      }
+    }
+  };
+
+  const timeoutHandle = setTimeout(() => {
+    timedOut = true;
+    void killProc();
+  }, timeoutMs);
+
+  const stdoutPromise = readStreamText(proc.stdout);
+  const stderrPromise = readStreamText(proc.stderr);
+  let exitCode = 1;
+  try {
+    exitCode = await proc.wait();
+  } finally {
+    clearTimeout(timeoutHandle);
+    if (timedOut) {
+      await killProc();
+    }
+  }
+
+  const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
+  return {
+    stdout,
+    stderr,
+    exitCode,
+    timedOut,
+  };
+}
+
+async function readStreamText(stream: Readable): Promise<string> {
+  const decoder = new StringDecoder('utf8');
+  let text = '';
+  for await (const chunk of stream) {
+    const buffer = typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : (chunk as Buffer);
+    text += decoder.write(buffer);
+  }
+  text += decoder.end();
+  return text;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function windowsPathToPosixPath(path: string): string {
+  if (path.startsWith('\\\\')) {
+    return path.replaceAll('\\', '/');
+  }
+  const driveMatch = /^([A-Za-z]):(?:[\\/]|$)/.exec(path);
+  if (driveMatch !== null) {
+    const drive = driveMatch[1]!.toLowerCase();
+    const rest = path.slice(2).replaceAll('\\', '/');
+    return `/${drive}${rest.startsWith('/') ? rest : `/${rest}`}`;
+  }
+  return path.replaceAll('\\', '/');
+}
+
+function rewriteWindowsNullRedirect(command: string): string {
+  return command.replace(WINDOWS_NUL_REDIRECT, '$1/dev/null');
 }

--- a/packages/agent-core/src/session/rpc.ts
+++ b/packages/agent-core/src/session/rpc.ts
@@ -97,12 +97,18 @@ export class SessionAPIImpl implements PromisableMethods<SessionAPI> {
     readonly cwd?: string;
     readonly timeout?: number;
   }): Promise<ShellExecResult> {
+    const normalizedCommand = payload.command.trim();
+    if (normalizedCommand.length === 0) {
+      throw new ByfError(ErrorCodes.REQUEST_INVALID, 'Shell command cannot be empty');
+    }
     const environment = this.session.config.runtime.osEnv;
     const isWindowsBash = environment.osKind === 'Windows';
     const defaultCwd = this.session.config.cwd ?? process.cwd();
     const effectiveCwd = payload.cwd ?? defaultCwd;
     const shellCwd = isWindowsBash ? windowsPathToPosixPath(effectiveCwd) : effectiveCwd;
-    const command = isWindowsBash ? rewriteWindowsNullRedirect(payload.command) : payload.command;
+    const command = isWindowsBash
+      ? rewriteWindowsNullRedirect(normalizedCommand)
+      : normalizedCommand;
     const shellCommand = `cd ${shellQuote(shellCwd)} && ${command}`;
     const shellArgs = [environment.shellPath, '-c', shellCommand];
     const timeoutMs = normalizeShellTimeoutMs(payload.timeout);

--- a/packages/agent-core/test/session/init.test.ts
+++ b/packages/agent-core/test/session/init.test.ts
@@ -7,6 +7,7 @@ import { localKaos } from '@byf/kaos';
 import type { ProviderConfig } from '@byf/kosong';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { ErrorCodes } from '../../src/errors';
 import { ProviderManager } from '../../src/providers/provider-manager';
 import type { ResolvedAgentProfile } from '../../src/profile';
 import type { SDKSessionRPC } from '../../src/rpc';
@@ -41,6 +42,28 @@ afterEach(async () => {
 });
 
 describe('Session.init', () => {
+  it('rejects empty shell command payloads on the server side', async () => {
+    const workDir = await makeTempDir();
+    const sessionDir = await makeTempDir();
+    const session = new Session({
+      id: 'test-shell-empty-command',
+      runtime: { kaos: localKaos, osEnv: OS_ENV },
+      homedir: sessionDir,
+      cwd: workDir,
+      rpc: createSessionRpc([]),
+      providerManager: testProviderManager(),
+    });
+
+    try {
+      const api = new SessionAPIImpl(session);
+      await expect(api.shellExec({ command: '   ' })).rejects.toMatchObject({
+        code: ErrorCodes.REQUEST_INVALID,
+      });
+    } finally {
+      await session.close();
+    }
+  });
+
   it('runs an isolated system-trigger turn and records the latest AGENTS as a system reminder', async () => {
     const workDir = await makeTempDir();
     const sessionDir = await makeTempDir();

--- a/packages/node-sdk/src/byf-harness.ts
+++ b/packages/node-sdk/src/byf-harness.ts
@@ -28,6 +28,7 @@ import type {
   ListSessionsOptions,
   RenameSessionInput,
   ResumeSessionInput,
+  ShellExecResult,
   SessionSummary,
 } from '#/types';
 
@@ -194,6 +195,30 @@ export class ByfHarness {
     return this.rpc.removeProvider(providerId);
   }
 
+  async shellExec(
+    command: string,
+    options: { cwd?: string; timeout?: number } = {},
+  ): Promise<ShellExecResult> {
+    const normalizedCommand = command.trim();
+    if (normalizedCommand.length === 0) {
+      throw new ByfError(ErrorCodes.REQUEST_INVALID, 'Shell command cannot be empty.');
+    }
+    const session = this.firstActiveSession();
+    if (session === undefined) {
+      throw new ByfError(
+        ErrorCodes.SESSION_NOT_FOUND,
+        'No active session. Start or resume a session first.',
+      );
+    }
+    const cwd = options.cwd ?? session.workDir;
+    return this.rpc.shellExec({
+      sessionId: session.id,
+      command: normalizedCommand,
+      cwd,
+      timeout: options.timeout,
+    });
+  }
+
   async close(): Promise<void> {
     await Promise.all(Array.from(this.activeSessions.values(), (session) => session.close()));
     try {
@@ -214,6 +239,10 @@ export class ByfHarness {
       ui_mode: this.uiMode,
       resumed,
     });
+  }
+
+  private firstActiveSession(): Session | undefined {
+    return this.activeSessions.values().next().value;
   }
 }
 

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -32,6 +32,8 @@ import type {
   McpStartupMetrics,
   PermissionMode,
   CompactOptions,
+  ShellExecPayload,
+  ShellExecResult,
   SessionPlan,
   SessionStatus,
   SessionUsage,
@@ -90,6 +92,12 @@ export interface ActivateSkillRpcInput extends SessionIdRpcInput {
 
 export interface ReconnectMcpServerRpcInput extends SessionIdRpcInput {
   readonly name: string;
+}
+
+export interface SessionShellExecRpcInput extends SessionIdRpcInput {
+  readonly command: string;
+  readonly cwd?: string;
+  readonly timeout?: number;
 }
 
 type ResolvedCoreAPI = Awaited<ReturnType<SDKRPCClient>>;
@@ -417,6 +425,17 @@ export class SDKRpcClient {
       name: input.name,
       args: input.args,
     });
+  }
+
+  async shellExec(input: SessionShellExecRpcInput): Promise<ShellExecResult> {
+    const rpc = await this.getRpc();
+    const payload: ShellExecPayload = {
+      sessionId: input.sessionId,
+      command: input.command,
+      cwd: input.cwd,
+      timeout: input.timeout,
+    };
+    return rpc.shellExec(payload);
   }
 
   onEvent(listener: (event: Event) => void): Unsubscribe {

--- a/packages/node-sdk/src/session.ts
+++ b/packages/node-sdk/src/session.ts
@@ -9,6 +9,7 @@ import type {
   PermissionMode,
   PromptInput,
   ResumedSessionState,
+  ShellExecResult,
   SessionPlan,
   SessionStatus,
   SessionSummary,
@@ -76,6 +77,24 @@ export class Session {
     await this.rpc.prompt({
       sessionId: this.id,
       input: normalizePromptInput(input),
+    });
+  }
+
+  async shellExec(
+    command: string,
+    options: { cwd?: string; timeout?: number } = {},
+  ): Promise<ShellExecResult> {
+    this.ensureOpen();
+    const normalizedCommand = normalizeRequiredString(
+      command,
+      'Shell command cannot be empty',
+      ErrorCodes.REQUEST_INVALID,
+    );
+    return this.rpc.shellExec({
+      sessionId: this.id,
+      command: normalizedCommand,
+      cwd: options.cwd,
+      timeout: options.timeout,
     });
   }
 

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -39,6 +39,8 @@ export type {
   ProviderType,
   ResumedAgentState,
   ServicesConfig,
+  ShellExecPayload,
+  ShellExecResult,
   SkillSummary,
   ThinkingConfig,
   ToolInfo,

--- a/packages/node-sdk/test/create-session-transport.test.ts
+++ b/packages/node-sdk/test/create-session-transport.test.ts
@@ -316,6 +316,34 @@ effort = "medium"
     }
   });
 
+  it('runs harness.shellExec in first active session workDir by default', async () => {
+    const homeDir = await makeTempDir();
+    const firstWorkDir = await makeTempDir();
+    const secondWorkDir = await makeTempDir();
+    const harness = new ByfHarness({
+      identity: TEST_IDENTITY,
+      homeDir,
+    });
+
+    try {
+      await harness.createSession({ id: 'ses_shell_default_cwd_1', workDir: firstWorkDir });
+      await harness.createSession({ id: 'ses_shell_default_cwd_2', workDir: secondWorkDir });
+
+      await expect(harness.shellExec('pwd')).resolves.toMatchObject({
+        stdout: `${firstWorkDir}\n`,
+        exitCode: 0,
+        timedOut: false,
+      });
+      await expect(harness.shellExec('pwd', { cwd: secondWorkDir })).resolves.toMatchObject({
+        stdout: `${secondWorkDir}\n`,
+        exitCode: 0,
+        timedOut: false,
+      });
+    } finally {
+      await harness.close();
+    }
+  });
+
   it('requires a non-empty workDir on createSession', async () => {
     const homeDir = await makeTempDir();
     const harness = new ByfHarness({ homeDir, identity: TEST_IDENTITY });

--- a/packages/node-sdk/test/session-background-tasks.test.ts
+++ b/packages/node-sdk/test/session-background-tasks.test.ts
@@ -29,6 +29,66 @@ describe('Session.listBackgroundTasks / getBackgroundTaskOutput / getBackgroundT
     }
   });
 
+  describe('Session.shellExec', () => {
+    it('executes shell commands and returns stdout/stderr/exit info', async () => {
+      const homeDir = await makeTempDir(tempDirs, 'byf-sdk-shell-home-');
+      const workDir = await makeTempDir(tempDirs, 'byf-sdk-shell-work-');
+      const harness = new ByfHarness({ homeDir, identity: TEST_IDENTITY });
+
+      try {
+        const session = await harness.createSession({ id: 'ses_shell_exec', workDir });
+        await expect(session.shellExec('printf "ok"')).resolves.toMatchObject({
+          stdout: 'ok',
+          stderr: '',
+          exitCode: 0,
+          timedOut: false,
+        });
+        await expect(session.shellExec('echo err >&2; exit 7')).resolves.toMatchObject({
+          stdout: '',
+          stderr: 'err\n',
+          exitCode: 7,
+          timedOut: false,
+        });
+      } finally {
+        await harness.close();
+      }
+    });
+
+    it('supports timeout and reports timedOut=true', async () => {
+      const homeDir = await makeTempDir(tempDirs, 'byf-sdk-shell-home-');
+      const workDir = await makeTempDir(tempDirs, 'byf-sdk-shell-work-');
+      const harness = new ByfHarness({ homeDir, identity: TEST_IDENTITY });
+
+      try {
+        const session = await harness.createSession({ id: 'ses_shell_timeout', workDir });
+        await expect(
+          session.shellExec('node -e "setTimeout(() => {}, 2000)"', { timeout: 100 }),
+        ).resolves.toMatchObject({
+          timedOut: true,
+        });
+      } finally {
+        await harness.close();
+      }
+    });
+
+    it('rejects after session is closed', async () => {
+      const homeDir = await makeTempDir(tempDirs, 'byf-sdk-shell-home-');
+      const workDir = await makeTempDir(tempDirs, 'byf-sdk-shell-work-');
+      const harness = new ByfHarness({ homeDir, identity: TEST_IDENTITY });
+
+      try {
+        const session = await harness.createSession({ id: 'ses_shell_closed', workDir });
+        await session.close();
+        await expect(session.shellExec('echo hi')).rejects.toMatchObject({
+          name: 'ByfError',
+          code: 'session.closed',
+        } satisfies Partial<ByfError>);
+      } finally {
+        await harness.close();
+      }
+    });
+  });
+
   it('returns empty output and undefined path for an unknown task id', async () => {
     const homeDir = await makeTempDir(tempDirs, 'byf-sdk-bgtask-home-');
     const workDir = await makeTempDir(tempDirs, 'byf-sdk-bgtask-work-');


### PR DESCRIPTION
## Related Issue

Closes #24

## Problem

Issue #24 要求在 SDK 和 agent-core 层新增  API，允许调用方绕过 agent 循环直接执行 shell 命令，同时在 CLI 端支持通过  前缀执行 shell 命令。

## What Changed

### agent-core (server side)
- ****: Added  method signature to  interface with  /  types
- ****: Registered  handler in the core implementation
- ****: Implemented shell command execution with:
  - Default 30s timeout (configurable)
  - Non-interactive env vars (, )
  - Two-phase termination: SIGTERM → 5s grace → SIGKILL
  - stdin closed immediately

### @byf/sdk (client side)
- ****: Added  method to 
- ****: Exposed  public method; defaults  to active session's 
- ****: Wired shellExec through session transport
- ****: Exported  and  types

### CLI / TUI
- ****: New file — parses  prefix shell commands from user input
- ****: Exported shell command parser
- ****: Integrated shell execution into message flow, dispatching  inputs to shellExec
- ****: Updated footer to indicate shell command support
- ****: Prompt symbol updates for shell mode
- ****: Added shell-related type definitions

### Tests
- ****: Tests for shell command message flow
- ****: Shell command parsing in registry
- ****: Prompt symbol updates
- ****: shellExec RPC transport tests
- ****: Background tasks with shellExec

## Acceptance Criteria

- [x]  和  类型定义正确，从  可导出
- [x]  接口包含  方法签名
- [x] agent-core 侧 handler 正确执行命令并返回结果
- [x]  包含  方法，调用正确路由到 RPC
- [x]  暴露  公共方法， 默认使用 session 的 
- [x] 命令超时正确处理（默认 30s，可自定义）
- [x] 非交互环境变量正确设置
- [x] 两阶段终止（SIGTERM → 5s grace → SIGKILL）已实现