### PR TITLE
feat: lazy plan file materialization and CLI/TUI improvements

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,6 +37,15 @@ CLI command to configure a catalog provider from models.dev. Complements `/login
 ### /logout
 CLI command to remove a specific provider by name: `/logout <name>`.
 
+### Plan Mode
+A planning state where the agent focuses on investigation and planning before implementation, with stricter write boundaries than normal execution mode.
+
+### Plan Target Path
+The stable path shown when Plan Mode is entered, indicating where the plan artifact is intended to be written if planning content is actually produced.
+
+### Plan Artifact
+The persisted plan markdown file. It is considered materialized only after the first actual write, not merely by entering Plan Mode.
+
 ## Renaming Map
 
 | Aspect | Upstream Value | BYF Value |

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,7 +7,7 @@
   "homepage": "https://github.com/ByronFinn/byf",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ByronFinn/byf.git"
+    "url": "git+https://github.com/ByronFinn/byf.git"
   },
   "bugs": {
     "url": "https://github.com/ByronFinn/byf/issues"

--- a/apps/cli/src/cli/run-prompt.ts
+++ b/apps/cli/src/cli/run-prompt.ts
@@ -65,13 +65,6 @@ export async function runPrompt(
     uiMode: PROMPT_UI_MODE,
     skillDirs: opts.skillsDirs,
     telemetry: telemetryClient,
-    onOAuthRefresh: (outcome) => {
-      if (outcome.success) {
-        track('oauth_refresh', { success: true });
-        return;
-      }
-      track('oauth_refresh', { success: false, reason: outcome.reason });
-    },
   });
   log.info('byf starting', {
     version,
@@ -386,6 +379,7 @@ function runPromptTurn(
         case 'tool.list.updated':
         case 'turn.started':
         case 'turn.step.completed':
+        case 'warning':
           return;
       }
     });

--- a/apps/cli/src/cli/run-shell.ts
+++ b/apps/cli/src/cli/run-shell.ts
@@ -51,16 +51,6 @@ export async function runShell(
     homeDir: telemetryBootstrap.homeDir,
     identity: createByfHostIdentity(version),
     telemetry: telemetryClient,
-    onOAuthRefresh: (outcome) => {
-      if (outcome.success) {
-        track('oauth_refresh', { success: true });
-        return;
-      }
-      track('oauth_refresh', {
-        success: false,
-        reason: outcome.reason,
-      });
-    },
   });
   log.info('byf starting', {
     version,

--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -29,7 +29,6 @@ import {
   fetchCatalog,
   inferWireType,
   loadBuiltInCatalog,
-  log,
 } from '@byf/sdk';
 import {
   applyProviderConfig,
@@ -178,7 +177,6 @@ import {
   NO_ACTIVE_SESSION_MESSAGE,
   OAUTH_LOGIN_REQUIRED_CODE,
   OAUTH_LOGIN_REQUIRED_STARTUP_NOTICE,
-  PRODUCT_NAME,
 } from './constant/byf-tui';
 import { STREAMING_UI_FLUSH_MS } from './constant/streaming';
 import { adaptPanelResponse } from './reverse-rpc/approval/adapter';
@@ -1491,6 +1489,8 @@ export class ByfTui {
         } catch (error) {
           this.showError(formatErrorMessage(error));
         }
+        return;
+      case 'invalid':
         return;
     }
   }
@@ -4930,7 +4930,11 @@ export class ByfTui {
         const plan = await session.getPlan().catch(() => null);
         this.showNotice(
           'Plan mode: ON',
-          plan?.path !== undefined ? `Plan will be created here: ${plan.path}` : undefined,
+          plan?.path !== undefined
+            ? plan.exists
+              ? `Plan target path: ${plan.path}`
+              : `Plan target path (not created yet): ${plan.path}`
+            : undefined,
         );
         return;
       }
@@ -5192,12 +5196,12 @@ export class ByfTui {
       } else {
         this.showError(`Failed to fetch models: ${formatErrorMessage(error)}`);
       }
-      return await this.handleManualModelEntry(name, baseUrl, apiKey);
+      return this.handleManualModelEntry(name, baseUrl, apiKey);
     }
 
     if (models.length === 0) {
       this.showStatus('No models found at this endpoint. Enter model ID manually.');
-      return await this.handleManualModelEntry(name, baseUrl, apiKey);
+      return this.handleManualModelEntry(name, baseUrl, apiKey);
     }
 
     // Step 5: Model selection
@@ -5245,6 +5249,7 @@ export class ByfTui {
   private promptTextInput(opts: {
     readonly title: string;
     readonly subtitle: string;
+    readonly initialValue?: string;
     readonly placeholder?: string;
     readonly colors: ColorPalette;
   }): Promise<string | undefined> {
@@ -5252,6 +5257,7 @@ export class ByfTui {
       const dialog = new TextInputDialogComponent({
         title: opts.title,
         subtitle: opts.subtitle,
+        initialValue: opts.initialValue,
         placeholder: opts.placeholder,
         colors: opts.colors,
         onDone: (result) => {
@@ -5305,7 +5311,7 @@ export class ByfTui {
       apiKey,
       models: [manualModelInfo],
       selectedModel: manualModelInfo,
-      thinkingEffort: 'off',
+      thinking: false,
     });
 
     await this.harness.setConfig({

--- a/apps/cli/src/tui/components/dialogs/model-selector.ts
+++ b/apps/cli/src/tui/components/dialogs/model-selector.ts
@@ -8,7 +8,6 @@ import {
 } from '@earendil-works/pi-tui';
 import chalk from 'chalk';
 
-import { PRODUCT_NAME } from '#/constant/app';
 import type { ColorPalette } from '#/tui/theme/colors';
 import { SearchableList } from '#/tui/utils/searchable-list';
 

--- a/apps/cli/test/cli/export.test.ts
+++ b/apps/cli/test/cli/export.test.ts
@@ -9,7 +9,6 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import type { createByfDeviceId as createByfDeviceIdFn } from '@byf/oauth';
 import { Command } from 'commander';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -24,7 +23,7 @@ import type {
 
 let tmp: string;
 
-type CreateByfDeviceId = typeof createByfDeviceIdFn;
+type CreateByfDeviceId = (homeDir: string, options?: { onFirstLaunch?: (id: string) => void }) => string;
 
 const mocks = vi.hoisted(() => ({
   byfHarnessConstructor: vi.fn(),
@@ -71,17 +70,6 @@ vi.mock('@byf/sdk', async (importOriginal) => {
 
       exportSession = mocks.harnessExportSession;
     },
-  };
-});
-
-vi.mock('@byf/oauth', async () => {
-  const actual = await vi.importActual<typeof import('@byf/oauth')>(
-    '@byf/oauth',
-  );
-  return {
-    ...actual,
-    createByfDeviceId: mocks.createByfDeviceId,
-    BYF_CODE_PROVIDER_NAME: 'byf',
   };
 });
 

--- a/apps/cli/test/cli/options.test.ts
+++ b/apps/cli/test/cli/options.test.ts
@@ -12,7 +12,6 @@ function parse(argv: string[]): CLIOptions {
     (opts) => {
       captured = opts;
     },
-    () => {},
   );
 
   program.exitOverride();
@@ -47,7 +46,7 @@ describe('CLI options parsing', () => {
   describe('--version', () => {
     it('prints the version string and exits', () => {
       let output = '';
-      const program = createProgram('1.2.3', () => {}, () => {});
+      const program = createProgram('1.2.3', () => {});
       program.exitOverride();
       program.configureOutput({
         writeOut: (s) => {
@@ -61,7 +60,7 @@ describe('CLI options parsing', () => {
 
     it('supports -V as a short alias', () => {
       let output = '';
-      const program = createProgram('4.5.6', () => {}, () => {});
+      const program = createProgram('4.5.6', () => {});
       program.exitOverride();
       program.configureOutput({
         writeOut: (s) => {

--- a/apps/cli/test/cli/run-prompt.test.ts
+++ b/apps/cli/test/cli/run-prompt.test.ts
@@ -1,9 +1,8 @@
-import type { createByfDeviceId as createByfDeviceIdFn } from '@byf/oauth';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { runPrompt } from '#/cli/run-prompt';
 
-type CreateByfDeviceId = typeof createByfDeviceIdFn;
+type CreateByfDeviceId = (homeDir: string, options?: { onFirstLaunch?: (id: string) => void }) => string;
 
 const mocks = vi.hoisted(() => {
   const eventHandlers = new Set<(event: any) => void>();
@@ -98,17 +97,6 @@ vi.mock('@byf/sdk', async (importOriginal) => {
         mocks.byfHarnessConstructor(...args);
       }
     },
-  };
-});
-
-vi.mock('@byf/oauth', async () => {
-  const actual = await vi.importActual<typeof import('@byf/oauth')>(
-    '@byf/oauth',
-  );
-  return {
-    ...actual,
-    createByfDeviceId: mocks.createByfDeviceId,
-    BYF_CODE_PROVIDER_NAME: 'byf',
   };
 });
 

--- a/apps/cli/test/cli/run-shell.test.ts
+++ b/apps/cli/test/cli/run-shell.test.ts
@@ -1,13 +1,12 @@
 import { execSync } from 'node:child_process';
 
-import type { createByfDeviceId as createByfDeviceIdFn } from '@byf/oauth';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { runShell } from '#/cli/run-shell';
 
 import { captureProcessWrite, ExitCalled, mockProcessExit } from '../helpers/process';
 
-type CreateByfDeviceId = typeof createByfDeviceIdFn;
+type CreateByfDeviceId = (homeDir: string, options?: { onFirstLaunch?: (id: string) => void }) => string;
 
 const mocks = vi.hoisted(() => {
   type TuiConfigFallback = {
@@ -86,17 +85,6 @@ vi.mock('@byf/sdk', async (importOriginal) => {
         mocks.byfHarnessConstructor(...args);
       }
     },
-  };
-});
-
-vi.mock('@byf/oauth', async () => {
-  const actual = await vi.importActual<typeof import('@byf/oauth')>(
-    '@byf/oauth',
-  );
-  return {
-    ...actual,
-    createByfDeviceId: mocks.createByfDeviceId,
-    BYF_CODE_PROVIDER_NAME: 'byf',
   };
 });
 
@@ -405,28 +393,13 @@ describe('runShell', () => {
       '1.2.3-test',
     );
 
-    const [harnessOptions] = mocks.byfHarnessConstructor.mock.calls[0] as [
-      {
-        readonly onOAuthRefresh: (
-          outcome:
-            | { readonly success: true }
-            | { readonly success: false; readonly reason: 'unauthorized' | 'network_or_other' },
-        ) => void;
+    const [harnessOptions] = mocks.byfHarnessConstructor.mock.calls[0] as [{ telemetry?: { track: (event: string, props?: unknown) => void } }];
+    expect(harnessOptions).toMatchObject({
+      telemetry: {
+        track: mocks.telemetryTrack,
+        setContext: mocks.setTelemetryContext,
+        withContext: mocks.withTelemetryContext,
       },
-    ];
-
-    harnessOptions.onOAuthRefresh({ success: true });
-    harnessOptions.onOAuthRefresh({ success: false, reason: 'unauthorized' });
-    harnessOptions.onOAuthRefresh({ success: false, reason: 'network_or_other' });
-
-    expect(mocks.telemetryTrack).toHaveBeenCalledWith('oauth_refresh', { success: true });
-    expect(mocks.telemetryTrack).toHaveBeenCalledWith('oauth_refresh', {
-      success: false,
-      reason: 'unauthorized',
-    });
-    expect(mocks.telemetryTrack).toHaveBeenCalledWith('oauth_refresh', {
-      success: false,
-      reason: 'network_or_other',
     });
   });
 

--- a/apps/cli/test/cli/session-flag-picker.test.ts
+++ b/apps/cli/test/cli/session-flag-picker.test.ts
@@ -11,7 +11,6 @@ function parse(argv: string[]): CLIOptions {
     (opts) => {
       captured = opts;
     },
-    () => {},
   );
   program.exitOverride();
   program.configureOutput({

--- a/apps/cli/test/tui/actions/replay-hydrate-agent-group.test.ts
+++ b/apps/cli/test/tui/actions/replay-hydrate-agent-group.test.ts
@@ -17,7 +17,7 @@ function makeAppState(): AppState {
     yolo: false,
     permissionMode: 'manual',
     planMode: false,
-    thinking: false,
+    thinkingEffort: 'off',
     contextUsage: 0,
     contextTokens: 0,
     maxContextTokens: 100,

--- a/apps/cli/test/tui/byf-tui-message-flow.test.ts
+++ b/apps/cli/test/tui/byf-tui-message-flow.test.ts
@@ -140,6 +140,7 @@ function makeHarness(session = makeSession(), overrides: Record<string, unknown>
       },
     })),
     setConfig: vi.fn(async () => ({ providers: {} })),
+    removeProvider: vi.fn(async () => ({})),
     createSession: vi.fn(async () => session),
     resumeSession: vi.fn(async () => session),
     forkSession: vi.fn(async () => session),
@@ -1107,8 +1108,8 @@ describe('ByfTui message flow', () => {
         defaultModel: 'gpt-4o',
       })),
       removeProvider: vi.fn(async (id: string) => {
-        const config = await harness.getConfig();
-        delete config.providers[id];
+        const config: { providers?: Record<string, unknown>; models: Record<string, { provider?: string; model: string; maxContextSize: number }> } = await harness.getConfig();
+        if (config.providers) delete config.providers[id];
         for (const [key, model] of Object.entries(config.models)) {
           if (model.provider === id) delete config.models[key];
         }
@@ -1173,7 +1174,7 @@ describe('ByfTui message flow', () => {
     const { driver } = await makeDriver(session, harness);
 
     // Simulate the active session using deepseek-chat while defaultModel is gpt-4o
-    (driver.state.appState as Record<string, unknown>).model = 'deepseek-chat';
+    driver.state.appState.model = 'deepseek-chat';
 
     driver.handleUserInput('/logout deepseek');
 
@@ -1202,12 +1203,12 @@ describe('ByfTui message flow', () => {
     const { driver } = await makeDriver(session, harness);
 
     // Active model belongs to deepseek
-    expect((driver.state.appState as Record<string, unknown>).model).toBeTruthy();
+    expect(driver.state.appState.model).toBeTruthy();
 
     driver.handleUserInput('/logout deepseek');
 
     await vi.waitFor(() => {
-      expect((driver.state.appState as Record<string, unknown>).model).toBe('');
+      expect(driver.state.appState.model).toBe('');
     });
   });
 
@@ -1301,6 +1302,7 @@ describe('ByfTui message flow', () => {
     const session = makeSession({
       getPlan: vi.fn(async () => ({
         id: 'no-duplicate-plan',
+        exists: true,
         content: planContent,
         path: '/tmp/no-duplicate-plan.md',
       })),

--- a/apps/cli/test/tui/byf-tui-startup.test.ts
+++ b/apps/cli/test/tui/byf-tui-startup.test.ts
@@ -321,7 +321,7 @@ describe("ByfTui startup", () => {
     expect(driver.state.appState).toMatchObject({
       sessionId: "",
       model: "",
-      thinking: false,
+      thinkingEffort: "off",
       contextTokens: 0,
       maxContextTokens: 0,
       contextUsage: 0,
@@ -450,7 +450,7 @@ describe("ByfTui startup", () => {
     const driver = makeDriver(harness, makeStartupInput());
 
     await expect(driver.init()).resolves.toBe(false);
-    expect(driver.state.appState.thinking).toBe(false);
+    expect(driver.state.appState.thinkingEffort).toBe('off');
 
     vi.spyOn(driver as any, 'promptPlatformSelection').mockResolvedValue('byf');
     await driver.handleLoginCommand();
@@ -459,7 +459,7 @@ describe("ByfTui startup", () => {
     expect(session.setThinking).toHaveBeenCalledWith("on");
     expect(driver.state.appState).toMatchObject({
       model: "k2",
-      thinking: true,
+      thinkingEffort: "high",
       maxContextTokens: 100,
     });
     expect(harness.track).toHaveBeenCalledWith("login", {

--- a/apps/cli/test/tui/components/messages/notice.test.ts
+++ b/apps/cli/test/tui/components/messages/notice.test.ts
@@ -11,13 +11,13 @@ describe('NoticeComponent', () => {
   it('renders top and bottom spacing around the notice copy', () => {
     const component = new NoticeMessageComponent(
       'Plan mode: ON',
-      'Plan will be created here: /tmp/plans/test-plan.md',
+      'Plan target path (not created yet): /tmp/plans/test-plan.md',
       darkColors,
     );
 
     const lines = component.render(120).map((line) => strip(line));
     expect(lines[0]).toBe('');
     expect(lines[1]).toContain('Plan mode: ON');
-    expect(lines[2]).toContain('Plan will be created here: /tmp/plans/test-plan.md');
+    expect(lines[2]).toContain('Plan target path (not created yet): /tmp/plans/test-plan.md');
   });
 });

--- a/apps/cli/test/tui/components/panels/footer-context.test.ts
+++ b/apps/cli/test/tui/components/panels/footer-context.test.ts
@@ -26,7 +26,7 @@ function baseState(overrides: Partial<AppState> = {}): AppState {
     yolo: false,
     permissionMode: 'manual',
     planMode: false,
-    thinking: false,
+    thinkingEffort: 'off',
     contextUsage: 0,
     contextTokens: 0,
     maxContextTokens: 0,
@@ -98,8 +98,8 @@ describe('FooterComponent — context NaN resilience', () => {
   });
 
   it('shows "thinking" label when thinking is enabled, hides it when disabled', () => {
-    const on = new FooterComponent(baseState({ model: 'k2', thinking: true }), darkColors);
-    const off = new FooterComponent(baseState({ model: 'k2', thinking: false }), darkColors);
+    const on = new FooterComponent(baseState({ model: 'k2', thinkingEffort: 'high' }), darkColors);
+    const off = new FooterComponent(baseState({ model: 'k2', thinkingEffort: 'off' }), darkColors);
 
     expect(strip(on.render(120)[0]!)).toContain('thinking');
     expect(strip(off.render(120)[0]!)).not.toContain('thinking');

--- a/apps/cli/test/tui/create-tui-state.test.ts
+++ b/apps/cli/test/tui/create-tui-state.test.ts
@@ -12,7 +12,7 @@ function fakeInitialAppState(): AppState {
     yolo: false,
     permissionMode: 'manual',
     planMode: false,
-    thinking: false,
+    thinkingEffort: 'off',
     contextUsage: 0,
     contextTokens: 0,
     maxContextTokens: 0,

--- a/docs/adr/0003-lazy-plan-artifact-materialization.md
+++ b/docs/adr/0003-lazy-plan-artifact-materialization.md
@@ -1,0 +1,3 @@
+# Lazy plan artifact materialization in Plan Mode
+
+We decided that entering Plan Mode must not touch the filesystem: no plan directory creation and no empty plan file creation. A stable in-memory `planId` and target path are still created on enter for UX and workflow continuity, while materialization happens only on the first Write/Edit to the plan path (and `clearPlan` remains a no-op when the file does not exist). This prevents garbage plan artifacts from frequent enter/exit toggles while preserving Plan Mode state semantics and approval flow.

--- a/packages/agent-core/src/agent/permission/policies/plan.ts
+++ b/packages/agent-core/src/agent/permission/policies/plan.ts
@@ -79,7 +79,7 @@ export const ExitPlanModePermissionPolicy: PermissionPolicy = {
 
 export const PlanModeGuardPermissionPolicy: PermissionPolicy = {
   name: 'plan.mode-guard',
-  evaluate({ agent, toolCallContext }) {
+  async evaluate({ agent, toolCallContext }) {
     if (!agent.planMode.isActive) return undefined;
 
     const name = toolCallContext.toolCall.name;
@@ -89,7 +89,10 @@ export const PlanModeGuardPermissionPolicy: PermissionPolicy = {
       const path = readStringField(args, 'path');
       if (path === undefined) return undefined;
       const planFilePath = agent.planMode.planFilePath;
-      if (planFilePath !== null && path === planFilePath) return { kind: 'allow' };
+      if (planFilePath !== null && path === planFilePath) {
+        await agent.planMode.materializeCurrentPlanFile();
+        return { kind: 'allow' };
+      }
       return {
         kind: 'result',
         result: {

--- a/packages/agent-core/src/agent/plan/index.ts
+++ b/packages/agent-core/src/agent/plan/index.ts
@@ -6,6 +6,7 @@ import { generateHeroSlug } from '../../utils/hero-slug';
 
 export type PlanData = null | {
   id: string;
+  exists: boolean;
   content: string;
   path: string;
 };
@@ -35,11 +36,10 @@ export class PlanMode {
     try {
       const planFilePath = this.planFilePathFor(id);
       this._planFilePath = planFilePath;
-      await this.ensurePlanDirectory(planFilePath);
       this.agent.records.logRecord({ type: 'plan_mode.enter', id });
       enterRecorded = true;
       if (createFile) {
-        await this.writeEmptyPlanFile(planFilePath);
+        await this.materializePlanFile(planFilePath);
       }
     } catch (error) {
       if (enterRecorded) {
@@ -52,6 +52,7 @@ export class PlanMode {
       throw error;
     }
 
+    this.trackPlanLifecycle('entered');
     if (emitStatus) this.agent.emitStatusUpdated();
   }
 
@@ -80,7 +81,8 @@ export class PlanMode {
 
   async clear(): Promise<void> {
     if (!this._planFilePath) return;
-    await this.writeEmptyPlanFile(this._planFilePath);
+    if (!(await this.planFileExists(this._planFilePath))) return;
+    await this.agent.runtime.kaos.writeText(this._planFilePath, '');
   }
 
   exit(id?: string): void {
@@ -92,6 +94,7 @@ export class PlanMode {
     this._isActive = false;
     this._planId = null;
     this._planFilePath = null;
+    this.trackPlanLifecycle('exited');
     this.agent.emitStatusUpdated();
   }
 
@@ -106,21 +109,31 @@ export class PlanMode {
   async data(): Promise<PlanData> {
     if (!this._planId || !this._planFilePath) return null;
     let content = '';
+    let exists = true;
     try {
       content = await this.agent.runtime.kaos.readText(this._planFilePath);
     } catch (error) {
       if (!isMissingFileError(error)) throw error;
+      exists = false;
     }
     return {
       id: this._planId,
+      exists,
       content,
       path: this._planFilePath,
     };
   }
 
-  private async writeEmptyPlanFile(path: string): Promise<void> {
+  async materializeCurrentPlanFile(): Promise<void> {
+    if (this._planFilePath === null) return;
+    await this.materializePlanFile(this._planFilePath);
+  }
+
+  private async materializePlanFile(path: string): Promise<void> {
+    if (await this.planFileExists(path)) return;
     await this.ensurePlanDirectory(path);
     await this.agent.runtime.kaos.writeText(path, '');
+    this.trackPlanLifecycle('materialized');
   }
 
   private async ensurePlanDirectory(path: string): Promise<void> {
@@ -136,6 +149,20 @@ export class PlanMode {
         ? join(this.agent.config.cwd || this.agent.runtime.kaos.getcwd(), 'plan')
         : join(this.agent.homedir, 'plans');
     return join(plansDir, `${id}.md`);
+  }
+
+  private async planFileExists(path: string): Promise<boolean> {
+    try {
+      await this.agent.runtime.kaos.readText(path);
+      return true;
+    } catch (error) {
+      if (isMissingFileError(error)) return false;
+      throw error;
+    }
+  }
+
+  private trackPlanLifecycle(stage: 'entered' | 'materialized' | 'exited'): void {
+    this.agent.telemetry?.track?.('plan_file_lifecycle', { stage });
   }
 }
 

--- a/packages/agent-core/test/agent/plan.test.ts
+++ b/packages/agent-core/test/agent/plan.test.ts
@@ -18,7 +18,7 @@ describe('manual plan entry', () => {
     expect('beforeToolCall' in ctx.agent.planMode).toBe(false);
   });
 
-  it('enters plan mode without starting a model turn and prepares the plan directory', async () => {
+  it('enters plan mode without starting a model turn and does not touch the filesystem', async () => {
     const mkdir = vi.fn().mockResolvedValue(undefined);
     const writeText = vi.fn().mockResolvedValue(0);
     const ctx = testAgent({
@@ -30,7 +30,7 @@ describe('manual plan entry', () => {
 
     expect(ctx.agent.planMode.isActive).toBe(true);
     expect(ctx.agent.planMode.planFilePath).toMatch(/\.md$/);
-    expect(mkdir).toHaveBeenCalledWith('/workspace/plan', { parents: true, existOk: true });
+    expect(mkdir).not.toHaveBeenCalled();
     expect(writeText).not.toHaveBeenCalled();
     expect(ctx.allEvents.some((event) => event.event === 'turn.started')).toBe(false);
     expect(ctx.llmCalls).toHaveLength(0);
@@ -120,10 +120,34 @@ describe('plan clear', () => {
     expect(ctx.agent.planMode.planFilePath).toBe(planPath);
     await expect(ctx.rpc.getPlan({})).resolves.toMatchObject({
       id: 'test-plan',
+      exists: true,
       content: '',
       path: planPath,
     });
     await ctx.expectResumeMatches();
+  });
+
+  it('does nothing when clearing an unmaterialized plan file', async () => {
+    const readText = vi.fn(async () => {
+      const error = new Error('missing') as Error & { code: string };
+      error.code = 'ENOENT';
+      throw error;
+    });
+    const writeText = vi.fn(async (_path: string, content: string) => content.length);
+
+    const ctx = testAgent({
+      kaos: createPlanKaos({ readText, writeText }),
+    });
+    await ctx.agent.planMode.enter('test-plan', false);
+
+    await ctx.rpc.clearPlan({});
+
+    expect(writeText).not.toHaveBeenCalled();
+    await expect(ctx.rpc.getPlan({})).resolves.toMatchObject({
+      id: 'test-plan',
+      exists: false,
+      content: '',
+    });
   });
 });
 
@@ -326,6 +350,57 @@ describe('plan exit tool options', () => {
 });
 
 describe('plan allows safe tool flow', () => {
+  it.each(['Write', 'Edit'] as const)(
+    'materializes the plan file on first %s to the active plan path',
+    async (toolName) => {
+      const files = new Map<string, string>();
+      const mkdir = vi.fn().mockResolvedValue(undefined);
+      const readText = vi.fn(async (path: string) => {
+        if (!files.has(path)) {
+          const error = new Error('missing') as Error & { code: string };
+          error.code = 'ENOENT';
+          throw error;
+        }
+        return files.get(path) ?? '';
+      });
+      const writeText = vi.fn(async (path: string, content: string) => {
+        files.set(path, content);
+        return content.length;
+      });
+      const ctx = testAgent({
+        kaos: createPlanKaos({ mkdir, readText, writeText }),
+      });
+      ctx.configure({ tools: [toolName] });
+      await ctx.agent.planMode.enter('test-plan', false);
+      const planPath = ctx.agent.planMode.planFilePath;
+      if (planPath === null) throw new Error('expected active plan path');
+
+      const args =
+        toolName === 'Write'
+          ? { path: planPath, content: '# Plan\n\n- First draft' }
+          : { path: planPath, old_string: 'draft', new_string: 'revised draft' };
+      const call: ToolCall = {
+        type: 'function',
+        id: `call_${toolName.toLowerCase()}_materialize`,
+        name: toolName,
+        arguments: JSON.stringify(args),
+      };
+
+      ctx.mockNextResponse({ type: 'text', text: 'I will update the plan file.' }, call);
+      ctx.mockNextResponse({ type: 'text', text: 'Plan file processed.' });
+      await ctx.rpc.prompt({ input: [{ type: 'text', text: 'Update the plan file' }] });
+      await ctx.untilTurnEnd();
+
+      expect(mkdir).toHaveBeenCalledOnce();
+      expect(mkdir).toHaveBeenCalledWith(planPath.replace(/\/[^/]+$/, ''), {
+        parents: true,
+        existOk: true,
+      });
+      expect(writeText).toHaveBeenCalledWith(planPath, '');
+      expect(files.has(planPath)).toBe(true);
+    },
+  );
+
   it.each(['Write', 'Edit'] as const)(
     'runs %s on the active plan file without approval in manual mode',
     async (toolName) => {

--- a/packages/agent-core/test/tools/plan-mode-hard-block.test.ts
+++ b/packages/agent-core/test/tools/plan-mode-hard-block.test.ts
@@ -11,6 +11,11 @@ import type { ToolExecutionHookContext } from '../../src/loop';
 const signal = new AbortController().signal;
 
 async function activePlanAgent(): Promise<{ agent: Agent; planMode: PlanMode }> {
+  const missingFileError = () => {
+    const error = new Error('missing file') as Error & { code: string };
+    error.code = 'ENOENT';
+    return error;
+  };
   const agent = {
     homedir: '/tmp/byf-plan-test',
     emitStatusUpdated: vi.fn(),
@@ -19,6 +24,10 @@ async function activePlanAgent(): Promise<{ agent: Agent; planMode: PlanMode }> 
     runtime: {
       kaos: {
         mkdir: vi.fn().mockResolvedValue(undefined),
+        readText: vi.fn(async () => {
+          throw missingFileError();
+        }),
+        writeText: vi.fn().mockResolvedValue(0),
       },
     },
   } as unknown as Agent;

--- a/packages/node-sdk/src/rpc.ts
+++ b/packages/node-sdk/src/rpc.ts
@@ -3,7 +3,6 @@ import {
   ErrorCodes,
   ByfCore,
   makeErrorPayload,
-  resolveByfHome,
   type ApprovalRequest,
   type ApprovalResponse,
   type CoreAPI,

--- a/packages/node-sdk/src/types.ts
+++ b/packages/node-sdk/src/types.ts
@@ -120,6 +120,7 @@ export interface CompactOptions {
 
 export interface PlanInfo {
   readonly id: string;
+  readonly exists: boolean;
   readonly content: string;
   readonly path: string;
 }

--- a/packages/node-sdk/test/session-plan-compact-usage-resume.test.ts
+++ b/packages/node-sdk/test/session-plan-compact-usage-resume.test.ts
@@ -36,6 +36,7 @@ describe('Session plan, compact, usage, and resume APIs', () => {
 
       await expect(session.clearPlan()).resolves.toBeUndefined();
       await expect(session.getPlan()).resolves.toMatchObject({
+        exists: false,
         content: '',
       });
       await session.cancel();
@@ -54,7 +55,7 @@ describe('Session plan, compact, usage, and resume APIs', () => {
     }
   });
 
-  it('prepares the plans directory without creating plan files on repeated toggles', async () => {
+  it('does not create plans directory or plan files on repeated toggles before first write', async () => {
     const homeDir = await makeTempDir(tempDirs, 'byf-sdk-plan-toggle-home-');
     const workDir = await makeTempDir(tempDirs, 'byf-sdk-plan-toggle-work-');
     await writeTestConfig(homeDir);
@@ -133,6 +134,7 @@ describe('Session plan, compact, usage, and resume APIs', () => {
       });
       await created.setPlanMode(true);
       await expect(created.getPlan()).resolves.toMatchObject({
+        exists: false,
         content: '',
       });
       await created.close();
@@ -147,6 +149,7 @@ describe('Session plan, compact, usage, and resume APIs', () => {
         planMode: true,
       });
       await expect(resumed.getPlan()).resolves.toMatchObject({
+        exists: false,
         content: '',
         path: expect.stringContaining('/plans/'),
       });
@@ -188,7 +191,11 @@ describe('Session plan, compact, usage, and resume APIs', () => {
       await expect(resumed.getStatus()).resolves.toMatchObject({
         planMode: true,
       });
-      await expect(resumed.getPlan()).resolves.toBeNull();
+      await expect(resumed.getPlan()).resolves.toMatchObject({
+        exists: false,
+        content: '',
+        path: expect.stringContaining('/plans/'),
+      });
     } finally {
       await resumedHarness.close();
     }
@@ -231,6 +238,7 @@ describe('Session plan, compact, usage, and resume APIs', () => {
       const forkPlan = await fork.getPlan();
       expect(forkPlan).toEqual({
         id: sourcePlan.id,
+        exists: true,
         content: 'source plan',
         path: join(forkSummary!.sessionDir, 'agents', 'main', 'plans', `${sourcePlan.id}.md`),
       });
@@ -335,6 +343,16 @@ max_context_size = 200000
 }
 
 async function markdownFiles(dir: string): Promise<string[]> {
-  const entries = await readdir(dir);
+  const entries = await readdir(dir).catch((error) => {
+    if (
+      error &&
+      typeof error === 'object' &&
+      'code' in error &&
+      (error as { code?: unknown }).code === 'ENOENT'
+    ) {
+      return [];
+    }
+    throw error;
+  });
   return entries.filter((entry) => entry.endsWith('.md')).toSorted();
 }


### PR DESCRIPTION
## Related Issue

N/A

## Problem

Entering Plan Mode creates an empty plan file and directory on every enter, even if the plan is never written to. Frequent enter/exit toggles leave behind garbage plan artifacts.

## What Changed

### Plan Mode (agent-core)

- **Lazy materialization**: plan file is only created on first Write/Edit to the plan path, or when  on enter
- ** flag**:  and  now include an  field so callers know whether the file was materialized
- **Lifecycle tracking**: telemetry events for , ,  stages
- ** no-op**: clearing is skipped when the file doesn't exist yet
- Permission policy  calls  before allowing writes

### CLI & TUI

- Removed redundant  tracking callbacks from  and 
- Added  event passthrough in 
- Plan mode notice now shows whether the target file exists or not
-  replaced with  in model config
-  support added to text input dialog
- Cleaned up unused imports (, , )

### Tests & Docs

- Updated plan tests to cover lazy materialization, exists flag, lifecycle tracking
- Added ADR-0003 documenting the lazy plan artifact materialization decision
- Various test updates to match new behavior