### PR TITLE
feat: add unified openai-completions provider

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,7 +23,10 @@ BYF is a hard fork. No future merges or cherry-picks from upstream. All upstream
 ## Glossary
 
 ### Provider
-A named OpenAI-compatible API endpoint configured by the user. Each provider has a user-chosen name (e.g. "deepseek"), a `base_url`, an `api_key`, and an optional `allowedPrefixes` for model filtering. Stored in config under `providers[name]`.
+A named API endpoint configured by the user. Each provider has a user-chosen name (e.g. "deepseek"), a `type` (e.g. `openai-completions`, `anthropic`, `google-genai`), a `base_url`, an `api_key`, and an optional `allowedPrefixes` for model filtering. Stored in config under `providers[name]`.
+
+### openai-completions
+The unified provider type for any OpenAI Chat Completions-compatible API (OpenAI, DeepSeek, Ollama, etc.). Replaces the former `openai` and `openai-compat` types. _Avoid_: openai (deprecated), openai-compat (deprecated).
 
 ### Catalog Provider
 A well-known provider (OpenAI, Anthropic, etc.) configured through `/connect`, which fetches metadata from the models.dev catalog. Distinct from user-configured providers from `/login`.

--- a/docs/adr/0004-merge-openai-providers.md
+++ b/docs/adr/0004-merge-openai-providers.md
@@ -1,0 +1,38 @@
+# Merge `openai` and `openai-compat` into `openai-completions`
+
+The codebase had two nearly identical provider types for OpenAI Chat Completions API: `openai` (hardcoded to OpenAI official) and `openai-compat` (flexible, for any compatible endpoint). Both use the same OpenAI SDK, same streaming protocol, same message format. The differences are small but scattered: reasoning key scanning, tool message handling, max_tokens normalization, file uploads, etc. We merge them into a single `openai-completions` type that takes the best of both implementations.
+
+## Status
+
+Accepted
+
+## Considered Options
+
+1. **Keep separate** — Maintain two providers, each with its own edge-case handling
+2. **Merge into `openai-compat`** — Keep the compat name, fold `openai` features in
+3. **Merge into `openai-completions`** — New name reflecting the API protocol used (Chat Completions)
+
+## Decision
+
+Option 3. A single `openai-completions` provider with these design choices:
+
+- **Default base URL**: empty string, user must configure explicitly. No hardcoded OpenAI default.
+- **Reasoning extraction**: multi-key scan (`reasoning_content` > `reasoning_details` > `reasoning`), configurable via `reasoningKey`
+- **Tool messages**: preserve multimodal protection (force `extract_text` for non-text content)
+- **Empty content omission**: skip `content` field on assistant messages with tool_calls and whitespace-only text
+- **Model capability**: registry-based lookup for known models, `UNKNOWN_CAPABILITY` fallback
+- **File uploads**: include `OpenAICompatFiles` for video upload via `/files` endpoint
+- **Tool schema**: normalize via `normalizeOpenAICompatToolSchema`, support `$`-prefix builtin functions
+- **Thinking**: dual config of `reasoning_effort` parameter + `extra_body.thinking`
+- **Thinking effort key**: configurable via `thinkingEffortKey`, default `reasoning_effort`
+- **Max tokens**: normalize `max_tokens` to `max_completion_tokens` on the wire
+- **Usage extraction**: read both top-level `usage` and `choices[0].usage`
+- **Tool call extras**: preserve `extras` field on tool calls
+- **Auto reasoning_effort**: when ThinkParts detected in history without explicit reasoning_effort, auto-set to `high`
+
+No backward compatibility aliases needed — project is in development with no external users.
+
+## Consequences
+
+- **Positive**: One implementation to maintain, one set of features for all OpenAI-compatible APIs. Less code, fewer divergent bug fixes.
+- **Negative**: Users must explicitly set `base_url` even for OpenAI official (no default shortcut).

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -7,6 +7,7 @@ export const ProviderTypeSchema = z.enum([
   'anthropic',
   'openai',
   'openai-compat',
+  'openai-completions',
   'google-genai',
   'openai_responses',
   'vertexai',

--- a/packages/kosong/src/providers/index.ts
+++ b/packages/kosong/src/providers/index.ts
@@ -1,10 +1,13 @@
 import type { ChatProvider } from '../provider';
 import { AnthropicChatProvider, type AnthropicOptions } from './anthropic';
 import { GoogleGenAIChatProvider, type GoogleGenAIOptions } from './google-genai';
-import { OpenAICompatChatProvider, type OpenAICompatOptions } from './openai-compat';
+import { OpenAICompletionsChatProvider, type OpenAICompletionsOptions } from './openai-completions';
 import { OpenAILegacyChatProvider, type OpenAILegacyOptions } from './openai-legacy';
 import { OpenAIResponsesChatProvider, type OpenAIResponsesOptions } from './openai-responses';
+import { OpenAICompatChatProvider, type OpenAICompatOptions } from './openai-compat';
 
+export { OpenAICompletionsChatProvider } from './openai-completions';
+export type { OpenAICompletionsOptions } from './openai-completions';
 export { OpenAICompatChatProvider } from './openai-compat';
 export type { OpenAICompatOptions } from './openai-compat';
 
@@ -12,6 +15,7 @@ export type ProviderConfig =
   | ({ type: 'anthropic' } & AnthropicOptions)
   | ({ type: 'openai' } & OpenAILegacyOptions)
   | ({ type: 'openai-compat' } & OpenAICompatOptions)
+  | ({ type: 'openai-completions' } & OpenAICompletionsOptions)
   | ({ type: 'google-genai' } & GoogleGenAIOptions)
   | ({ type: 'openai_responses' } & OpenAIResponsesOptions)
   | ({ type: 'vertexai' } & GoogleGenAIOptions);
@@ -26,6 +30,8 @@ export function createProvider(config: ProviderConfig): ChatProvider {
       return new OpenAILegacyChatProvider(config);
     case 'openai-compat':
       return new OpenAICompatChatProvider(config);
+    case 'openai-completions':
+      return new OpenAICompletionsChatProvider(config);
     case 'google-genai':
       return new GoogleGenAIChatProvider(config);
     case 'openai_responses':

--- a/packages/kosong/src/providers/openai-completions.ts
+++ b/packages/kosong/src/providers/openai-completions.ts
@@ -1,0 +1,631 @@
+import { UNKNOWN_CAPABILITY, type ModelCapability } from '#/capability';
+import { normalizeOpenAICompatToolSchema } from './openai-compat-schema';
+import type { ContentPart, Message, StreamedMessagePart, ToolCall } from '#/message';
+import type {
+  ChatProvider,
+  FinishReason,
+  GenerateOptions,
+  ProviderRequestAuth,
+  StreamedMessage,
+  ThinkingEffort,
+  VideoUploadInput,
+} from '#/provider';
+import type { Tool } from '#/tool';
+import type { TokenUsage } from '#/usage';
+import OpenAI from 'openai';
+
+import { OpenAICompatFiles } from './openai-compat-files';
+import {
+  convertChatCompletionStreamToolCall,
+  type BufferedChatCompletionToolCall,
+} from './chat-completions-stream';
+import { getOpenAILegacyModelCapability } from './capability-registry';
+import {
+  convertContentPart,
+  convertOpenAIError,
+  convertToolMessageContent,
+  extractUsage,
+  isFunctionToolCall,
+  normalizeOpenAIFinishReason,
+  type OpenAIContentPart,
+  type OpenAIToolParam,
+  reasoningEffortToThinkingEffort,
+  thinkingEffortToReasoningEffort,
+  toolToOpenAI,
+  type ToolMessageConversion,
+} from './openai-common';
+import {
+  mergeRequestHeaders,
+  requireProviderApiKey,
+  resolveAuthBackedClient,
+} from './request-auth';
+
+// Inbound: scan in priority order; first string value wins. Outbound: the first
+// entry doubles as the default field we serialize ThinkPart back into. Both
+// arms can be overridden by an explicit `reasoningKey` on the provider config.
+const KNOWN_REASONING_KEYS = ['reasoning_content', 'reasoning_details', 'reasoning'] as const;
+const DEFAULT_OUTBOUND_REASONING_KEY = KNOWN_REASONING_KEYS[0];
+
+function extractReasoningContent(
+  source: unknown,
+  explicitKey: string | undefined,
+): string | undefined {
+  if (typeof source !== 'object' || source === null) return undefined;
+  const record = source as Record<string, unknown>;
+  const keys: readonly string[] = explicitKey !== undefined ? [explicitKey] : KNOWN_REASONING_KEYS;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+export interface OpenAICompletionsOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  model: string;
+  stream?: boolean;
+  defaultHeaders?: Record<string, string>;
+  thinkingEffortKey?: string;
+  reasoningKey?: string;
+  toolMessageConversion?: ToolMessageConversion;
+  generationKwargs?: GenerationKwargs;
+  clientFactory?: (auth: ProviderRequestAuth) => OpenAI;
+}
+
+export interface GenerationKwargs {
+  max_tokens?: number | undefined;
+  max_completion_tokens?: number | undefined;
+  temperature?: number | undefined;
+  top_p?: number | undefined;
+  n?: number | undefined;
+  presence_penalty?: number | undefined;
+  frequency_penalty?: number | undefined;
+  stop?: string | string[] | undefined;
+  reasoning_effort?: string | undefined;
+  prompt_cache_key?: string | undefined;
+  extra_body?: ExtraBody;
+  [key: string]: unknown;
+}
+
+export interface ThinkingConfig {
+  type?: 'enabled' | 'disabled';
+  keep?: unknown;
+  [key: string]: unknown;
+}
+
+export interface ExtraBody {
+  thinking?: ThinkingConfig;
+  [key: string]: unknown;
+}
+
+interface OpenAIMessage {
+  role: string;
+  content?: string | OpenAIContentPart[] | undefined;
+  tool_calls?: OpenAIToolCallOut[] | undefined;
+  tool_call_id?: string | undefined;
+  name?: string | undefined;
+  [key: string]: unknown;
+}
+
+interface OpenAIToolCallOut {
+  type: string;
+  id: string;
+  function: { name: string; arguments: string | null };
+  extras?: Record<string, unknown> | undefined;
+}
+
+function isEffectivelyEmptyContent(parts: ContentPart[]): boolean {
+  for (const part of parts) {
+    if (part.type !== 'text') return false;
+    if (part.text.trim() !== '') return false;
+  }
+  return true;
+}
+
+function convertMessage(
+  message: Message,
+  reasoningKey: string | undefined,
+  toolMessageConversion: ToolMessageConversion,
+): OpenAIMessage {
+  let reasoningContent = '';
+  const nonThinkParts: ContentPart[] = [];
+
+  for (const part of message.content) {
+    if (part.type === 'think') {
+      reasoningContent += part.think;
+    } else {
+      nonThinkParts.push(part);
+    }
+  }
+
+  const result: OpenAIMessage = { role: message.role };
+  const hasToolCalls = message.toolCalls.length > 0;
+  const shouldOmitContent =
+    message.role === 'assistant' && hasToolCalls && isEffectivelyEmptyContent(nonThinkParts);
+
+  if (message.role === 'tool') {
+    // OpenAI Chat Completions `tool` messages only accept text content.
+    // Any non-text content parts (image_url, audio_url, video_url) would be
+    // rejected by the API with a 400. Detect multimodal tool output and
+    // force the `extract_text` path in that case, regardless of the caller's
+    // `toolMessageConversion` setting.
+    const hasNonTextPart = message.content.some((p) => p.type !== 'text' && p.type !== 'think');
+    const effectiveConversion: ToolMessageConversion = hasNonTextPart
+      ? 'extract_text'
+      : toolMessageConversion;
+
+    if (effectiveConversion !== null) {
+      result.content = convertToolMessageContent(message, effectiveConversion);
+    } else if (!shouldOmitContent) {
+      const firstPart = nonThinkParts[0];
+      if (nonThinkParts.length === 1 && firstPart?.type === 'text') {
+        result.content = firstPart.text;
+      } else if (nonThinkParts.length > 0) {
+        result.content = nonThinkParts
+          .map((p) => convertContentPart(p))
+          .filter((p): p is OpenAIContentPart => p !== null);
+      }
+    }
+  } else if (!shouldOmitContent) {
+    const firstPart = nonThinkParts[0];
+    if (nonThinkParts.length === 1 && firstPart?.type === 'text') {
+      result.content = firstPart.text;
+    } else if (nonThinkParts.length > 0) {
+      result.content = nonThinkParts
+        .map((p) => convertContentPart(p))
+        .filter((p): p is OpenAIContentPart => p !== null);
+    }
+  }
+
+  if (message.name !== undefined) {
+    result.name = message.name;
+  }
+
+  if (hasToolCalls) {
+    result.tool_calls = message.toolCalls.map((tc) => {
+      const mapped: OpenAIToolCallOut = {
+        type: tc.type,
+        id: tc.id,
+        function: { name: tc.name, arguments: tc.arguments },
+      };
+      if (tc.extras !== undefined) {
+        mapped.extras = tc.extras;
+      }
+      return mapped;
+    });
+  }
+
+  if (message.toolCallId !== undefined) {
+    result.tool_call_id = message.toolCallId;
+  }
+
+  if (reasoningContent) {
+    result[reasoningKey ?? DEFAULT_OUTBOUND_REASONING_KEY] = reasoningContent;
+  }
+
+  return result;
+}
+
+function convertTool(tool: Tool): OpenAIToolParam {
+  if (tool.name.startsWith('$')) {
+    return {
+      type: 'builtin_function',
+      function: { name: tool.name },
+    };
+  }
+  const converted = toolToOpenAI(tool);
+  return {
+    ...converted,
+    function: {
+      ...converted.function,
+      parameters: normalizeOpenAICompatToolSchema(tool.parameters),
+    },
+  };
+}
+
+export function extractUsageFromChunk(
+  chunk: Record<string, unknown>,
+): Record<string, unknown> | null {
+  if (
+    chunk['usage'] !== null &&
+    chunk['usage'] !== undefined &&
+    typeof chunk['usage'] === 'object'
+  ) {
+    return chunk['usage'] as Record<string, unknown>;
+  }
+  const choices = chunk['choices'];
+  if (!Array.isArray(choices) || choices.length === 0) {
+    return null;
+  }
+  const firstChoice = choices[0] as Record<string, unknown> | undefined;
+  if (firstChoice === undefined) {
+    return null;
+  }
+  const choiceUsage = firstChoice['usage'];
+  if (choiceUsage !== null && choiceUsage !== undefined && typeof choiceUsage === 'object') {
+    return choiceUsage as Record<string, unknown>;
+  }
+  return null;
+}
+
+class OpenAICompletionsStreamedMessage implements StreamedMessage {
+  private _id: string | null = null;
+  private _usage: TokenUsage | null = null;
+  private _finishReason: FinishReason | null = null;
+  private _rawFinishReason: string | null = null;
+  private readonly _iter: AsyncGenerator<StreamedMessagePart>;
+
+  constructor(
+    response: OpenAI.Chat.ChatCompletion | AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
+    isStream: boolean,
+    reasoningKey: string | undefined,
+  ) {
+    if (isStream) {
+      this._iter = this._convertStreamResponse(
+        response as AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
+        reasoningKey,
+      );
+    } else {
+      this._iter = this._convertNonStreamResponse(
+        response as OpenAI.Chat.ChatCompletion,
+        reasoningKey,
+      );
+    }
+  }
+
+  get id(): string | null {
+    return this._id;
+  }
+
+  get usage(): TokenUsage | null {
+    return this._usage;
+  }
+
+  get finishReason(): FinishReason | null {
+    return this._finishReason;
+  }
+
+  get rawFinishReason(): string | null {
+    return this._rawFinishReason;
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<StreamedMessagePart> {
+    yield* this._iter;
+  }
+
+  private _captureFinishReason(raw: string | null | undefined): void {
+    const normalized = normalizeOpenAIFinishReason(raw);
+    this._finishReason = normalized.finishReason;
+    this._rawFinishReason = normalized.rawFinishReason;
+  }
+
+  private async *_convertNonStreamResponse(
+    response: OpenAI.Chat.ChatCompletion,
+    reasoningKey: string | undefined,
+  ): AsyncGenerator<StreamedMessagePart> {
+    this._id = response.id;
+    if (response.usage) {
+      this._usage = extractUsage(response.usage) ?? null;
+    }
+    this._captureFinishReason(response.choices[0]?.finish_reason ?? null);
+
+    const message = response.choices[0]?.message;
+    if (!message) return;
+
+    const reasoning = extractReasoningContent(message, reasoningKey);
+    if (reasoning) {
+      yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
+    }
+
+    if (message.content) {
+      yield { type: 'text', text: message.content } satisfies StreamedMessagePart;
+    }
+
+    if (message.tool_calls) {
+      for (const toolCall of message.tool_calls) {
+        if (!isFunctionToolCall(toolCall)) continue;
+        yield {
+          type: 'function',
+          id: toolCall.id || crypto.randomUUID(),
+          name: toolCall.function.name,
+          arguments: toolCall.function.arguments,
+        } satisfies ToolCall;
+      }
+    }
+  }
+
+  private async *_convertStreamResponse(
+    response: AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
+    reasoningKey: string | undefined,
+  ): AsyncGenerator<StreamedMessagePart> {
+    const bufferedToolCalls = new Map<number | string, BufferedChatCompletionToolCall>();
+
+    try {
+      for await (const chunk of response) {
+        if (chunk.id) {
+          this._id = chunk.id;
+        }
+
+        const rawChunk = chunk as unknown as Record<string, unknown>;
+        const rawUsage = extractUsageFromChunk(rawChunk);
+        if (rawUsage) {
+          this._usage = extractUsage(rawUsage) ?? null;
+        }
+
+        if (!chunk.choices || chunk.choices.length === 0) {
+          continue;
+        }
+
+        const choice = chunk.choices[0];
+        if (!choice) continue;
+
+        if (choice.finish_reason !== null && choice.finish_reason !== undefined) {
+          this._captureFinishReason(choice.finish_reason);
+        }
+
+        const delta = choice.delta;
+
+        const reasoning = extractReasoningContent(delta, reasoningKey);
+        if (reasoning) {
+          yield { type: 'think', think: reasoning } satisfies StreamedMessagePart;
+        }
+
+        if (delta.content) {
+          yield { type: 'text', text: delta.content } satisfies StreamedMessagePart;
+        }
+
+        for (const toolCall of delta.tool_calls ?? []) {
+          for (const part of convertChatCompletionStreamToolCall(toolCall, bufferedToolCalls)) {
+            yield part;
+          }
+        }
+      }
+    } catch (error: unknown) {
+      throw convertOpenAIError(error);
+    }
+  }
+}
+
+export class OpenAICompletionsChatProvider implements ChatProvider {
+  readonly name: string = 'openai-completions';
+
+  private _model: string;
+  private _stream: boolean;
+  private _apiKey: string | undefined;
+  private _baseUrl: string;
+  private _defaultHeaders: Record<string, string> | undefined;
+  private _generationKwargs: GenerationKwargs;
+  private _thinkingEffortKey: string;
+  private _reasoningKey: string | undefined;
+  private _toolMessageConversion: ToolMessageConversion;
+  private _client: OpenAI | undefined;
+  private _clientFactory: ((auth: ProviderRequestAuth) => OpenAI) | undefined;
+  private _files: OpenAICompatFiles | undefined;
+
+  constructor(options: OpenAICompletionsOptions) {
+    const apiKey = options.apiKey;
+    this._apiKey = apiKey === undefined || apiKey.length === 0 ? undefined : apiKey;
+    this._baseUrl = options.baseUrl ?? '';
+    this._defaultHeaders = options.defaultHeaders;
+    this._clientFactory = options.clientFactory;
+    this._model = options.model;
+    this._stream = options.stream ?? true;
+    const normalizedThinkingEffortKey = options.thinkingEffortKey?.trim();
+    this._thinkingEffortKey =
+      normalizedThinkingEffortKey !== undefined && normalizedThinkingEffortKey.length > 0
+        ? normalizedThinkingEffortKey
+        : 'reasoning_effort';
+    const normalizedReasoningKey = options.reasoningKey?.trim();
+    this._reasoningKey =
+      normalizedReasoningKey !== undefined && normalizedReasoningKey.length > 0
+        ? normalizedReasoningKey
+        : undefined;
+    this._generationKwargs = { ...options.generationKwargs };
+    this._toolMessageConversion = options.toolMessageConversion ?? null;
+    this._client =
+      this._apiKey === undefined
+        ? undefined
+        : new OpenAI({
+            apiKey: this._apiKey,
+            baseURL: this._baseUrl,
+            defaultHeaders: this._defaultHeaders,
+          });
+  }
+
+  get modelName(): string {
+    return this._model;
+  }
+
+  get thinkingEffort(): ThinkingEffort | null {
+    const customValue = this._generationKwargs[this._thinkingEffortKey];
+    if (typeof customValue === 'string') {
+      return reasoningEffortToThinkingEffort(customValue);
+    }
+    const defaultValue = this._generationKwargs.reasoning_effort;
+    return reasoningEffortToThinkingEffort(defaultValue);
+  }
+
+  get files(): OpenAICompatFiles {
+    this._files ??= new OpenAICompatFiles({
+      apiKey: this._apiKey,
+      baseUrl: this._baseUrl,
+      defaultHeaders: this._defaultHeaders,
+      clientFactory: this._clientFactory,
+    });
+    return this._files;
+  }
+
+  uploadVideo(input: string | VideoUploadInput, options?: GenerateOptions) {
+    return this.files.uploadVideo(input, options);
+  }
+
+  get modelParameters(): Record<string, unknown> {
+    return {
+      model: this._model,
+      baseUrl: this._baseUrl,
+      ...this._generationKwargs,
+    };
+  }
+
+  getCapability(model?: string): ModelCapability {
+    return getOpenAILegacyModelCapability(model ?? this._model);
+  }
+
+  async generate(
+    systemPrompt: string,
+    tools: Tool[],
+    history: Message[],
+    options?: GenerateOptions,
+  ): Promise<StreamedMessage> {
+    const messages: OpenAIMessage[] = [];
+    if (systemPrompt) {
+      messages.push({ role: 'system', content: systemPrompt });
+    }
+    for (const msg of history) {
+      messages.push(convertMessage(msg, this._reasoningKey, this._toolMessageConversion));
+    }
+
+    const kwargs: Record<string, unknown> = {
+      ...this._generationKwargs,
+    };
+
+    // Auto-enable reasoning_effort when the history contains ThinkPart but
+    // reasoning was not explicitly configured. Skip when the caller already
+    // pinned reasoning_effort via withGenerationKwargs.
+    if (kwargs[this._thinkingEffortKey] === undefined && kwargs['reasoning_effort'] === undefined) {
+      const hasThinkPart = history.some((message) =>
+        message.content.some((part) => part.type === 'think'),
+      );
+      if (hasThinkPart) {
+        kwargs[this._thinkingEffortKey] = 'high';
+      }
+    }
+
+    // Remove undefined values from kwargs
+    for (const key of Object.keys(kwargs)) {
+      if (kwargs[key] === undefined) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete kwargs[key];
+      }
+    }
+
+    // Normalize legacy max_tokens → max_completion_tokens
+    if (
+      kwargs['max_completion_tokens'] === undefined &&
+      kwargs['max_tokens'] !== undefined
+    ) {
+      kwargs['max_completion_tokens'] = kwargs['max_tokens'];
+    }
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete kwargs['max_tokens'];
+
+    const { extra_body: extraBody, ...requestKwargs } = kwargs;
+
+    const createParams: Record<string, unknown> = {
+      model: this._model,
+      messages,
+      stream: this._stream,
+      ...requestKwargs,
+      ...(extraBody as Record<string, unknown> | undefined),
+    };
+
+    if (tools.length > 0) {
+      createParams['tools'] = tools.map((t) => convertTool(t));
+    }
+
+    if (this._stream) {
+      createParams['stream_options'] = { include_usage: true };
+    }
+
+    try {
+      const client = this._createClient(options?.auth);
+      const response = (await client.chat.completions.create(
+        createParams as unknown as OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
+        options?.signal ? { signal: options.signal } : undefined,
+      )) as unknown as OpenAI.Chat.ChatCompletion | AsyncIterable<OpenAI.Chat.ChatCompletionChunk>;
+      return new OpenAICompletionsStreamedMessage(response, this._stream, this._reasoningKey);
+    } catch (error: unknown) {
+      throw convertOpenAIError(error);
+    }
+  }
+
+  withThinking(effort: ThinkingEffort): OpenAICompletionsChatProvider {
+    const thinking: ThinkingConfig = {
+      type: effort === 'off' ? 'disabled' : 'enabled',
+    };
+    let reasoningEffort: string | undefined;
+    switch (effort) {
+      case 'off':
+        reasoningEffort = undefined;
+        break;
+      case 'low':
+        reasoningEffort = 'low';
+        break;
+      case 'medium':
+        reasoningEffort = 'medium';
+        break;
+      case 'high':
+      case 'xhigh':
+      case 'max':
+        reasoningEffort = 'high';
+        break;
+    }
+    const nextEffort: GenerationKwargs = {
+      [this._thinkingEffortKey]: reasoningEffort,
+    };
+    return this._withGenerationKwargs(nextEffort).withExtraBody({
+      thinking,
+    });
+  }
+
+  withGenerationKwargs(kwargs: GenerationKwargs): OpenAICompletionsChatProvider {
+    return this._withGenerationKwargs(kwargs);
+  }
+
+  withMaxCompletionTokens(maxCompletionTokens: number): OpenAICompletionsChatProvider {
+    return this._withGenerationKwargs({ max_completion_tokens: maxCompletionTokens });
+  }
+
+  withExtraBody(extraBody: ExtraBody): OpenAICompletionsChatProvider {
+    const oldExtra = this._generationKwargs.extra_body ?? {};
+    const merged: ExtraBody = { ...oldExtra, ...extraBody };
+    const oldThinking = oldExtra.thinking;
+    const newThinking = extraBody.thinking;
+    if (oldThinking !== undefined && newThinking !== undefined) {
+      merged.thinking = { ...oldThinking, ...newThinking };
+    }
+    return this._withGenerationKwargs({ extra_body: merged });
+  }
+
+  private _createClient(auth: ProviderRequestAuth | undefined): OpenAI {
+    return resolveAuthBackedClient(
+      { cachedClient: this._client, clientFactory: this._clientFactory },
+      auth,
+      (a) => {
+        const defaultHeaders = mergeRequestHeaders(this._defaultHeaders, a?.headers);
+        return new OpenAI({
+          apiKey: requireProviderApiKey('OpenAICompletionsChatProvider', a, this._apiKey),
+          baseURL: this._baseUrl,
+          defaultHeaders,
+        });
+      },
+    );
+  }
+
+  private _withGenerationKwargs(kwargs: GenerationKwargs): OpenAICompletionsChatProvider {
+    const clone = this._clone();
+    clone._generationKwargs = { ...clone._generationKwargs, ...kwargs };
+    return clone;
+  }
+
+  private _clone(): OpenAICompletionsChatProvider {
+    const clone = Object.assign(
+      Object.create(Object.getPrototypeOf(this) as object) as OpenAICompletionsChatProvider,
+      this,
+    );
+    clone._generationKwargs = { ...this._generationKwargs };
+    clone._files = undefined;
+    return clone;
+  }
+}

--- a/packages/kosong/test/openai-completions.test.ts
+++ b/packages/kosong/test/openai-completions.test.ts
@@ -1,0 +1,992 @@
+import { generate } from '#/generate';
+import { UNKNOWN_CAPABILITY } from '#/capability';
+import type { ContentPart, Message, StreamedMessagePart, ToolCall } from '#/message';
+import { OpenAICompletionsChatProvider, extractUsageFromChunk } from '#/providers/openai-completions';
+import { extractUsage } from '#/providers/openai-common';
+import type { Tool } from '#/tool';
+import { describe, it, expect, vi } from 'vitest';
+
+function makeChatCompletionResponse(model: string = 'test-model') {
+  return {
+    id: 'chatcmpl-test123',
+    object: 'chat.completion',
+    created: 1234567890,
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: 'Hello' },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+  };
+}
+
+function createProvider(
+  options?: Partial<{
+    stream: boolean;
+    reasoningKey: string;
+    model: string;
+    toolMessageConversion: 'extract_text';
+  }>,
+): OpenAICompletionsChatProvider {
+  return new OpenAICompletionsChatProvider({
+    model: options?.model ?? 'test-model',
+    apiKey: 'test-key',
+    baseUrl: 'https://api.example.test/v1',
+    stream: options?.stream ?? false,
+    reasoningKey: options?.reasoningKey,
+    toolMessageConversion: options?.toolMessageConversion,
+  });
+}
+
+async function captureRequestBody(
+  provider: OpenAICompletionsChatProvider,
+  systemPrompt: string,
+  tools: Tool[],
+  history: Message[],
+): Promise<Record<string, unknown>> {
+  let capturedBody: Record<string, unknown> | undefined;
+
+  (provider as any)._client.chat.completions.create = vi
+    .fn()
+    .mockImplementation((params: unknown) => {
+      capturedBody = params as Record<string, unknown>;
+      return Promise.resolve(makeChatCompletionResponse());
+    });
+
+  const stream = await provider.generate(systemPrompt, tools, history);
+  for await (const part of stream) {
+    void part;
+  }
+
+  if (capturedBody === undefined) {
+    throw new Error('Expected provider.generate() to call chat.completions.create');
+  }
+  return capturedBody;
+}
+
+const ADD_TOOL: Tool = {
+  name: 'add',
+  description: 'Add two integers.',
+  parameters: {
+    type: 'object',
+    properties: {
+      a: { type: 'integer', description: 'First number' },
+      b: { type: 'integer', description: 'Second number' },
+    },
+    required: ['a', 'b'],
+  },
+};
+
+const MUL_TOOL: Tool = {
+  name: 'multiply',
+  description: 'Multiply two integers.',
+  parameters: {
+    type: 'object',
+    properties: {
+      a: { type: 'integer', description: 'First number' },
+      b: { type: 'integer', description: 'Second number' },
+    },
+    required: ['a', 'b'],
+  },
+};
+
+const BUILTIN_TOOL: Tool = {
+  name: '$web_search',
+  description: 'Search the web',
+  parameters: { type: 'object', properties: {} },
+};
+
+describe('OpenAICompletionsChatProvider', () => {
+  describe('provider identity', () => {
+    it('has name openai-completions and exposes modelName', () => {
+      const provider = createProvider();
+      expect(provider.name).toBe('openai-completions');
+      expect(provider.modelName).toBe('test-model');
+    });
+
+    it('default base URL is empty string when not configured', () => {
+      const provider = new OpenAICompletionsChatProvider({
+        model: 'test',
+        apiKey: 'key',
+      });
+      expect(provider.modelParameters['baseUrl']).toBe('');
+    });
+  });
+
+  describe('message conversion', () => {
+    it('simple user message with system prompt', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Hello!' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, 'You are helpful.', [], history);
+
+      expect(body['messages']).toEqual([
+        { role: 'system', content: 'You are helpful.' },
+        { role: 'user', content: 'Hello!' },
+      ]);
+    });
+
+    it('multi-turn conversation', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'What is 2+2?' }], toolCalls: [] },
+        { role: 'assistant', content: [{ type: 'text', text: '2+2 equals 4.' }], toolCalls: [] },
+        { role: 'user', content: [{ type: 'text', text: 'And 3+3?' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['messages']).toEqual([
+        { role: 'user', content: 'What is 2+2?' },
+        { role: 'assistant', content: '2+2 equals 4.' },
+        { role: 'user', content: 'And 3+3?' },
+      ]);
+    });
+
+    it('image url content', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: "What's in this image?" },
+            { type: 'image_url', imageUrl: { url: 'https://example.com/image.png' } },
+          ] satisfies ContentPart[],
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['messages']).toEqual([
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: "What's in this image?" },
+            { type: 'image_url', image_url: { url: 'https://example.com/image.png' } },
+          ],
+        },
+      ]);
+    });
+
+    it('tool definitions', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Add 2 and 3' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [ADD_TOOL, MUL_TOOL], history);
+
+      expect(body['tools']).toEqual([
+        {
+          type: 'function',
+          function: {
+            name: 'add',
+            description: 'Add two integers.',
+            parameters: {
+              type: 'object',
+              properties: {
+                a: { type: 'integer', description: 'First number' },
+                b: { type: 'integer', description: 'Second number' },
+              },
+              required: ['a', 'b'],
+            },
+          },
+        },
+        {
+          type: 'function',
+          function: {
+            name: 'multiply',
+            description: 'Multiply two integers.',
+            parameters: {
+              type: 'object',
+              properties: {
+                a: { type: 'integer', description: 'First number' },
+                b: { type: 'integer', description: 'Second number' },
+              },
+              required: ['a', 'b'],
+            },
+          },
+        },
+      ]);
+    });
+
+    it('builtin tool ($web_search) serialized as builtin_function', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Search' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [BUILTIN_TOOL], history);
+
+      expect(body['tools']).toEqual([
+        {
+          type: 'builtin_function',
+          function: { name: '$web_search' },
+        },
+      ]);
+    });
+
+    it('tool call and tool result', async () => {
+      const provider = createProvider();
+      const toolCall: ToolCall = {
+        type: 'function',
+        id: 'call_abc123',
+        name: 'add',
+        arguments: '{"a": 2, "b": 3}',
+      };
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Add 2 and 3' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: "I'll add those numbers for you." }],
+          toolCalls: [toolCall],
+        },
+        {
+          role: 'tool',
+          content: [{ type: 'text', text: '5' }],
+          toolCallId: 'call_abc123',
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['messages']).toEqual([
+        { role: 'user', content: 'Add 2 and 3' },
+        {
+          role: 'assistant',
+          content: "I'll add those numbers for you.",
+          tool_calls: [
+            {
+              type: 'function',
+              id: 'call_abc123',
+              function: { name: 'add', arguments: '{"a": 2, "b": 3}' },
+            },
+          ],
+        },
+        { role: 'tool', content: '5', tool_call_id: 'call_abc123' },
+      ]);
+    });
+
+    it('tool call extras are preserved in serialization', async () => {
+      const provider = createProvider();
+      const toolCall: ToolCall = {
+        type: 'function',
+        id: 'call_abc123',
+        name: 'add',
+        arguments: '{"a": 2, "b": 3}',
+        extras: { custom_field: 'custom_value' },
+      };
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Add' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: 'ok' }],
+          toolCalls: [toolCall],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const assistantMsg = (body['messages'] as Record<string, unknown>[])[1]!;
+      const serializedToolCall = (assistantMsg['tool_calls'] as Record<string, unknown>[])[0]!;
+
+      expect(serializedToolCall['extras']).toEqual({ custom_field: 'custom_value' });
+    });
+  });
+
+  describe('tool message multimodal protection', () => {
+    it('forces extract_text when tool result contains image_url', async () => {
+      const provider = createProvider();
+      const toolCall: ToolCall = {
+        type: 'function',
+        id: 'call_img',
+        name: 'add',
+        arguments: '{}',
+      };
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Add' }], toolCalls: [] },
+        { role: 'assistant', content: [{ type: 'text', text: 'ok' }], toolCalls: [toolCall] },
+        {
+          role: 'tool',
+          content: [
+            { type: 'text', text: '5' },
+            { type: 'image_url', imageUrl: { url: 'https://example.com/img.png' } },
+          ] satisfies ContentPart[],
+          toolCallId: 'call_img',
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const toolMsg = (body['messages'] as Record<string, unknown>[])[2]!;
+
+      expect(typeof toolMsg['content']).toBe('string');
+      expect(toolMsg['content']).toContain('5');
+      expect(Array.isArray(toolMsg['content'])).toBe(false);
+    });
+
+    it('forces extract_text when tool result contains audio_url', async () => {
+      const provider = createProvider();
+      const toolCall: ToolCall = {
+        type: 'function',
+        id: 'call_audio',
+        name: 'fetch_audio',
+        arguments: '{}',
+      };
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Play' }], toolCalls: [] },
+        { role: 'assistant', content: [{ type: 'text', text: 'ok' }], toolCalls: [toolCall] },
+        {
+          role: 'tool',
+          content: [
+            { type: 'text', text: 'audio result' },
+            { type: 'audio_url', audioUrl: { url: 'https://example.com/a.mp3' } },
+          ] satisfies ContentPart[],
+          toolCallId: 'call_audio',
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const toolMsg = (body['messages'] as Record<string, unknown>[])[2]!;
+
+      expect(typeof toolMsg['content']).toBe('string');
+    });
+
+    it('forces extract_text when tool result contains video_url', async () => {
+      const provider = createProvider();
+      const toolCall: ToolCall = {
+        type: 'function',
+        id: 'call_video',
+        name: 'fetch_video',
+        arguments: '{}',
+      };
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Show' }], toolCalls: [] },
+        { role: 'assistant', content: [{ type: 'text', text: 'ok' }], toolCalls: [toolCall] },
+        {
+          role: 'tool',
+          content: [
+            { type: 'text', text: 'video result' },
+            { type: 'video_url', videoUrl: { url: 'https://example.com/v.mp4' } },
+          ] satisfies ContentPart[],
+          toolCallId: 'call_video',
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const toolMsg = (body['messages'] as Record<string, unknown>[])[2]!;
+
+      expect(typeof toolMsg['content']).toBe('string');
+    });
+
+    it('flattens tool message content to string when toolMessageConversion is extract_text', async () => {
+      const provider = createProvider({ toolMessageConversion: 'extract_text' });
+      const toolCall: ToolCall = {
+        type: 'function',
+        id: 'call_abc',
+        name: 'add',
+        arguments: '{}',
+      };
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Add' }], toolCalls: [] },
+        { role: 'assistant', content: [{ type: 'text', text: 'ok' }], toolCalls: [toolCall] },
+        {
+          role: 'tool',
+          content: [
+            { type: 'text', text: 'part-1' },
+            { type: 'text', text: 'part-2' },
+          ],
+          toolCallId: 'call_abc',
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const toolMsg = (body['messages'] as Record<string, unknown>[])[2]!;
+
+      expect(typeof toolMsg['content']).toBe('string');
+      expect(toolMsg['content']).toBe('part-1part-2');
+    });
+
+    it('keeps default text-only tool message as plain string', async () => {
+      const provider = createProvider();
+      const toolCall: ToolCall = {
+        type: 'function',
+        id: 'call_text',
+        name: 'add',
+        arguments: '{}',
+      };
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Add' }], toolCalls: [] },
+        { role: 'assistant', content: [{ type: 'text', text: 'ok' }], toolCalls: [toolCall] },
+        {
+          role: 'tool',
+          content: [{ type: 'text', text: '3' }],
+          toolCallId: 'call_text',
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const toolMsg = (body['messages'] as Record<string, unknown>[])[2]!;
+
+      expect(toolMsg['content']).toBe('3');
+    });
+  });
+
+  describe('assistant tool call content omission', () => {
+    const toolCall: ToolCall = {
+      type: 'function',
+      id: 'call_xyz',
+      name: 'add',
+      arguments: '{}',
+    };
+
+    it('omits content when assistant tool call content is empty', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Add' }], toolCalls: [] },
+        { role: 'assistant', content: [], toolCalls: [toolCall] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const assistantMessage = (body['messages'] as Record<string, unknown>[])[1];
+
+      expect(assistantMessage).toEqual({
+        role: 'assistant',
+        tool_calls: [
+          { type: 'function', id: 'call_xyz', function: { name: 'add', arguments: '{}' } },
+        ],
+      });
+    });
+
+    it('omits content when assistant tool call content is whitespace-only', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Add' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: '   \n  ' }],
+          toolCalls: [toolCall],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const assistantMessage = (body['messages'] as Record<string, unknown>[])[1];
+
+      expect(assistantMessage).toEqual({
+        role: 'assistant',
+        tool_calls: [
+          { type: 'function', id: 'call_xyz', function: { name: 'add', arguments: '{}' } },
+        ],
+      });
+    });
+
+    it('keeps real assistant content alongside tool calls', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Add' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [{ type: 'text', text: "I'll add those." }],
+          toolCalls: [toolCall],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const assistantMessage = (body['messages'] as Record<string, unknown>[])[1];
+
+      expect(assistantMessage).toEqual({
+        role: 'assistant',
+        content: "I'll add those.",
+        tool_calls: [
+          { type: 'function', id: 'call_xyz', function: { name: 'add', arguments: '{}' } },
+        ],
+      });
+    });
+  });
+
+  describe('reasoning content', () => {
+    it('serializes ThinkPart to reasoning_content by default', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'What is 2+2?' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'Let me think...' },
+            { type: 'text', text: '4.' },
+          ],
+          toolCalls: [],
+        },
+        { role: 'user', content: [{ type: 'text', text: 'Thanks!' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['messages']).toEqual([
+        { role: 'user', content: 'What is 2+2?' },
+        { role: 'assistant', content: '4.', reasoning_content: 'Let me think...' },
+        { role: 'user', content: 'Thanks!' },
+      ]);
+    });
+
+    it('uses configured reasoningKey for outbound serialization', async () => {
+      const provider = createProvider({ reasoningKey: 'reasoning_details' });
+      const history: Message[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'thinking' },
+            { type: 'text', text: 'reply' },
+          ],
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const messages = body['messages'] as Record<string, unknown>[];
+
+      expect(messages[0]).toEqual({
+        role: 'assistant',
+        content: 'reply',
+        reasoning_details: 'thinking',
+      });
+      expect(messages[0]).not.toHaveProperty('reasoning_content');
+    });
+
+    it('treats blank reasoningKey as unset', async () => {
+      const provider = createProvider({ reasoningKey: '' });
+      const history: Message[] = [
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'thinking' },
+            { type: 'text', text: 'answer' },
+          ],
+          toolCalls: [],
+        },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+      const messages = body['messages'] as Record<string, unknown>[];
+
+      expect(messages[0]).toEqual({
+        role: 'assistant',
+        content: 'answer',
+        reasoning_content: 'thinking',
+      });
+    });
+  });
+
+  describe('multi-key reasoning extraction (inbound)', () => {
+    it('reads reasoning_content from non-stream response', async () => {
+      const provider = createProvider();
+      (provider as any)._client.chat.completions.create = vi.fn().mockResolvedValue({
+        id: 'chatcmpl-1',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'answer',
+              reasoning_content: 'thinking via reasoning_content',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      });
+
+      const stream = await provider.generate('', [], [
+        { role: 'user', content: [{ type: 'text', text: 'q' }], toolCalls: [] },
+      ]);
+      const parts: StreamedMessagePart[] = [];
+      for await (const part of stream) parts.push(part);
+
+      expect(parts).toEqual([
+        { type: 'think', think: 'thinking via reasoning_content' },
+        { type: 'text', text: 'answer' },
+      ]);
+    });
+
+    it('reads reasoning_details when reasoning_content is absent', async () => {
+      const provider = createProvider();
+      (provider as any)._client.chat.completions.create = vi.fn().mockResolvedValue({
+        id: 'chatcmpl-2',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'answer',
+              reasoning_details: 'thinking via reasoning_details',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      });
+
+      const stream = await provider.generate('', [], [
+        { role: 'user', content: [{ type: 'text', text: 'q' }], toolCalls: [] },
+      ]);
+      const parts: StreamedMessagePart[] = [];
+      for await (const part of stream) parts.push(part);
+
+      expect(parts).toEqual([
+        { type: 'think', think: 'thinking via reasoning_details' },
+        { type: 'text', text: 'answer' },
+      ]);
+    });
+
+    it('reads reasoning when only that field is present', async () => {
+      const provider = createProvider();
+      (provider as any)._client.chat.completions.create = vi.fn().mockResolvedValue({
+        id: 'chatcmpl-3',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'answer',
+              reasoning: 'thinking via reasoning',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      });
+
+      const stream = await provider.generate('', [], [
+        { role: 'user', content: [{ type: 'text', text: 'q' }], toolCalls: [] },
+      ]);
+      const parts: StreamedMessagePart[] = [];
+      for await (const part of stream) parts.push(part);
+
+      expect(parts).toEqual([
+        { type: 'think', think: 'thinking via reasoning' },
+        { type: 'text', text: 'answer' },
+      ]);
+    });
+
+    it('prioritizes reasoning_content over reasoning_details', async () => {
+      const provider = createProvider();
+      (provider as any)._client.chat.completions.create = vi.fn().mockResolvedValue({
+        id: 'chatcmpl-4',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'answer',
+              reasoning_content: 'primary',
+              reasoning_details: 'secondary',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      });
+
+      const stream = await provider.generate('', [], [
+        { role: 'user', content: [{ type: 'text', text: 'q' }], toolCalls: [] },
+      ]);
+      const parts: StreamedMessagePart[] = [];
+      for await (const part of stream) parts.push(part);
+
+      expect(parts[0]).toEqual({ type: 'think', think: 'primary' });
+    });
+
+    it('explicit reasoningKey limits scan to that single field', async () => {
+      const provider = createProvider({ reasoningKey: 'reasoning_details' });
+      (provider as any)._client.chat.completions.create = vi.fn().mockResolvedValue({
+        id: 'chatcmpl-5',
+        choices: [
+          {
+            message: {
+              role: 'assistant',
+              content: 'answer',
+              reasoning_content: 'should be ignored',
+            },
+            finish_reason: 'stop',
+          },
+        ],
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      });
+
+      const stream = await provider.generate('', [], [
+        { role: 'user', content: [{ type: 'text', text: 'q' }], toolCalls: [] },
+      ]);
+      const parts: StreamedMessagePart[] = [];
+      for await (const part of stream) parts.push(part);
+
+      expect(parts).toEqual([{ type: 'text', text: 'answer' }]);
+    });
+
+    it('extracts reasoning from streaming response', async () => {
+      const provider = new OpenAICompletionsChatProvider({
+        model: 'test',
+        apiKey: 'test-key',
+        stream: true,
+        baseUrl: 'https://api.example.test/v1',
+      });
+
+      async function* mockedStream(): AsyncIterable<Record<string, unknown>> {
+        yield { id: 'c1', choices: [{ index: 0, delta: { reasoning_content: 'think 1' } }] };
+        yield { id: 'c1', choices: [{ index: 0, delta: { reasoning_content: ' think 2' } }] };
+        yield { id: 'c1', choices: [{ index: 0, delta: { content: 'final' } }] };
+        yield { id: 'c1', choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] };
+      }
+
+      (provider as any)._client.chat.completions.create = vi
+        .fn()
+        .mockResolvedValue(mockedStream());
+
+      const stream = await provider.generate('', [], [
+        { role: 'user', content: [{ type: 'text', text: 'q' }], toolCalls: [] },
+      ]);
+      const parts: StreamedMessagePart[] = [];
+      for await (const part of stream) parts.push(part);
+
+      expect(parts).toEqual([
+        { type: 'think', think: 'think 1' },
+        { type: 'think', think: ' think 2' },
+        { type: 'text', text: 'final' },
+      ]);
+    });
+  });
+
+  describe('generation kwargs', () => {
+    it('normalizes max_tokens to max_completion_tokens on the wire', async () => {
+      const provider = createProvider().withGenerationKwargs({
+        temperature: 0.7,
+        max_tokens: 2048,
+      });
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Hi' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['temperature']).toBe(0.7);
+      expect(body['max_completion_tokens']).toBe(2048);
+      expect(body['max_tokens']).toBeUndefined();
+    });
+
+    it('sends no completion-token cap by default', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Hi' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['max_tokens']).toBeUndefined();
+      expect(body['max_completion_tokens']).toBeUndefined();
+    });
+
+    it('prefers max_completion_tokens when both fields are set', async () => {
+      const provider = createProvider().withGenerationKwargs({
+        max_completion_tokens: 2048,
+        max_tokens: 4096,
+      });
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Hi' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['max_completion_tokens']).toBe(2048);
+      expect(body['max_tokens']).toBeUndefined();
+    });
+  });
+
+  describe('with thinking', () => {
+    it('.withThinking("high") sets reasoning_effort and thinking config', async () => {
+      const provider = createProvider().withThinking('high');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning_effort']).toBe('high');
+      expect(body['thinking']).toEqual({ type: 'enabled' });
+    });
+
+    it('.withThinking("off") disables thinking', async () => {
+      const provider = createProvider().withThinking('off');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['thinking']).toEqual({ type: 'disabled' });
+    });
+
+    it('uses custom thinkingEffortKey when configured', async () => {
+      const provider = new OpenAICompletionsChatProvider({
+        model: 'test',
+        apiKey: 'test-key',
+        baseUrl: 'https://api.example.test/v1',
+        stream: false,
+        thinkingEffortKey: 'thinking_effort',
+      }).withThinking('high');
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Think' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['thinking_effort']).toBe('high');
+      expect(body['reasoning_effort']).toBeUndefined();
+    });
+
+    it('thinkingEffort property reflects current state', () => {
+      const provider = createProvider();
+      expect(provider.thinkingEffort).toBeNull();
+
+      const withHigh = provider.withThinking('high');
+      expect(withHigh.thinkingEffort).toBe('high');
+    });
+
+    it('returns a new instance without mutating the original', () => {
+      const provider = createProvider();
+      const newProvider = provider.withThinking('high');
+      expect(newProvider).toBeInstanceOf(OpenAICompletionsChatProvider);
+      expect(newProvider).not.toBe(provider);
+      expect(provider.thinkingEffort).toBeNull();
+    });
+  });
+
+  describe('auto reasoning_effort', () => {
+    it('auto-injects reasoning_effort=high when history has ThinkPart', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'Let me think...' },
+            { type: 'text', text: 'Hi!' },
+          ],
+          toolCalls: [],
+        },
+        { role: 'user', content: [{ type: 'text', text: 'How are you?' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning_effort']).toBe('high');
+    });
+
+    it('does not auto-inject reasoning_effort when history has no ThinkPart', async () => {
+      const provider = createProvider();
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }], toolCalls: [] },
+        { role: 'assistant', content: [{ type: 'text', text: 'Hi!' }], toolCalls: [] },
+        { role: 'user', content: [{ type: 'text', text: 'How are you?' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning_effort']).toBeUndefined();
+    });
+
+    it('does not overwrite reasoning_effort pinned via withGenerationKwargs', async () => {
+      const provider = createProvider().withGenerationKwargs({
+        reasoning_effort: 'low',
+      });
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'Hello' }], toolCalls: [] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'think', think: 'thinking' },
+            { type: 'text', text: 'Hi!' },
+          ],
+          toolCalls: [],
+        },
+        { role: 'user', content: [{ type: 'text', text: 'Again?' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['reasoning_effort']).toBe('low');
+    });
+  });
+
+  describe('model capability', () => {
+    it('returns registry capability for known models', () => {
+      const provider = createProvider({ model: 'gpt-4o' });
+      const cap = provider.getCapability('gpt-4o');
+      // Known model should have non-UNKNOWN capability
+      expect(cap).not.toEqual(UNKNOWN_CAPABILITY);
+    });
+
+    it('returns UNKNOWN_CAPABILITY for unknown models', () => {
+      const provider = createProvider({ model: 'some-unknown-model' });
+      const cap = provider.getCapability('some-unknown-model');
+      expect(cap).toEqual(UNKNOWN_CAPABILITY);
+    });
+  });
+
+  describe('usage extraction', () => {
+    it('extracts top-level usage from streaming chunk', () => {
+      const chunk = {
+        usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      };
+      expect(extractUsageFromChunk(chunk)).toEqual({
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+      });
+    });
+
+    it('extracts choices[0].usage from streaming chunk', () => {
+      const chunk = {
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            usage: { prompt_tokens: 8, completion_tokens: 11, total_tokens: 19 },
+          },
+        ],
+      };
+      expect(extractUsageFromChunk(chunk)).toEqual({
+        prompt_tokens: 8,
+        completion_tokens: 11,
+        total_tokens: 19,
+      });
+    });
+
+    it('returns null when no usage is present', () => {
+      expect(extractUsageFromChunk({ choices: [] })).toBeNull();
+      expect(extractUsageFromChunk({ id: 'test' })).toBeNull();
+    });
+  });
+
+  describe('withExtraBody', () => {
+    it('hoists thinking to request top level', async () => {
+      const provider = createProvider().withExtraBody({ thinking: { keep: 'all' } });
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['thinking']).toEqual({ keep: 'all' });
+      expect(body['extra_body']).toBeUndefined();
+    });
+
+    it('merges thinking when called after withThinking', async () => {
+      const provider = createProvider()
+        .withThinking('high')
+        .withExtraBody({ thinking: { keep: 'all' } });
+      const history: Message[] = [
+        { role: 'user', content: [{ type: 'text', text: 'hi' }], toolCalls: [] },
+      ];
+      const body = await captureRequestBody(provider, '', [], history);
+
+      expect(body['thinking']).toEqual({ type: 'enabled', keep: 'all' });
+    });
+  });
+
+  describe('clone client sharing', () => {
+    function getInternalClient(provider: OpenAICompletionsChatProvider): unknown {
+      return Reflect.get(provider, '_client');
+    }
+
+    it('withGenerationKwargs clone shares the same OpenAI client', () => {
+      const original = createProvider();
+      const clone = original.withGenerationKwargs({ max_completion_tokens: 1024 });
+      expect(getInternalClient(clone)).not.toBeUndefined();
+      expect(Object.is(getInternalClient(clone), getInternalClient(original))).toBe(true);
+    });
+
+    it('withThinking clone shares the same OpenAI client', () => {
+      const original = createProvider();
+      const clone = original.withThinking('high');
+      expect(getInternalClient(clone)).not.toBeUndefined();
+      expect(Object.is(getInternalClient(clone), getInternalClient(original))).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Create `OpenAICompletionsChatProvider` merging `openai` and `openai-compat` providers per ADR 0004
- Add `openai-completions` type to schema and provider factory
- 46 unit tests covering all 20 acceptance criteria

## Key design decisions (ADR 0004)

- **Default base URL**: empty string, no hardcoded OpenAI default
- **Reasoning extraction**: multi-key scan (`reasoning_content` > `reasoning_details` > `reasoning`)
- **Configurable `reasoningKey`**: for outbound serialization
- **Tool message multimodal protection**: forces `extract_text` for non-text tool content
- **Model capability**: registry-based for known models, UNKNOWN fallback
- **Auto reasoning_effort**: `high` when ThinkParts detected in history
- All compat features preserved: empty content omission, max_tokens normalization, choices[0].usage, tool schema normalization, builtin functions, extras, extra_body, file uploads, thinkingEffortKey

## Test plan

- [x] 46 new unit tests in `openai-completions.test.ts` covering all ADR 0004 decisions
- [x] All 1068 kosong tests pass (1022 existing + 46 new, zero regressions)
- [x] All 20 agent-core config tests pass
- [ ] Runtime provider mapping update (issue #36)
- [ ] CLI/OAuth update (issue #36)

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)