### PR TITLE
feat: interactive provider selector for /logout command

### DIFF
--- a/.changeset/interactive-logout-selector.md
+++ b/.changeset/interactive-logout-selector.md
@@ -1,0 +1,5 @@
+---
+"@byfriends/cli": minor
+---
+
+`/logout` now opens an interactive provider selector instead of requiring a provider name argument. The provider associated with `defaultModel` is highlighted by default, so pressing Enter maintains the previous common-case behavior. The `/disconnect` alias behaves identically. This also fixes a bug where removing the default model's provider would incorrectly clear the active session model even when the current session was using a different provider.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,7 +38,7 @@ CLI command to add a custom OpenAI-compatible provider. Flow: name → base_url 
 CLI command to configure a catalog provider from models.dev. Complements `/login`.
 
 ### /logout
-CLI command to remove a specific provider by name: `/logout <name>`.
+CLI command to open an interactive selector to remove a configured provider. The provider for `defaultModel` is highlighted by default. The `/disconnect` alias behaves identically.
 
 ### Plan Mode
 A planning state where the agent focuses on investigation and planning before implementation, with stricter write boundaries than normal execution mode.

--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -226,6 +226,7 @@ import { detectTmuxKeyboardWarning } from './utils/tmux-keyboard';
 import { nextTranscriptId } from './utils/transcript-id';
 import { LoginFlow } from './flows/login-flow';
 import { ConnectFlow } from './flows/connect-flow';
+import { promptConfiguredProviderSelection } from './flows/dialog-prompts';
 
 export type { TUIState } from './types';
 
@@ -4181,23 +4182,22 @@ export class ByfTui implements DialogHost {
   }
 
 
-  private async handleLogoutCommand(args: string | undefined): Promise<void> {
-    const providerName = args?.trim();
-    if (!providerName) {
-      this.showError('Usage: /logout <provider-name>');
-      return;
-    }
-
+  private async handleLogoutCommand(_args: string | undefined): Promise<void> {
     const config = await this.harness.getConfig();
-    if (config.providers?.[providerName] === undefined) {
-      this.showError(`Provider "${providerName}" not found.`);
+
+    const providerName = await promptConfiguredProviderSelection(
+      this,
+      this.state.theme.colors,
+      config,
+      (msg) => this.showError(msg),
+    );
+    if (providerName === undefined) {
       return;
     }
 
     const activeModel = this.state.appState.model;
     const activeProvider = this.state.appState.availableModels[activeModel]?.provider;
-    const defaultProvider = config.models?.[config.defaultModel ?? '']?.provider;
-    const wasActiveModel = activeProvider === providerName || defaultProvider === providerName;
+    const wasActiveModel = activeProvider === providerName;
 
     await this.harness.removeProvider(providerName);
     await this.refreshConfigAfterLogin();

--- a/apps/cli/src/tui/commands/registry.ts
+++ b/apps/cli/src/tui/commands/registry.ts
@@ -130,7 +130,7 @@ export const BUILTIN_SLASH_COMMANDS = [
   {
     name: 'logout',
     aliases: ['disconnect'],
-    description: 'Log out of a configured provider',
+    description: 'Open selector to remove a configured provider',
     priority: 40,
   },
   {

--- a/apps/cli/src/tui/flows/dialog-prompts.ts
+++ b/apps/cli/src/tui/flows/dialog-prompts.ts
@@ -54,6 +54,45 @@ export function promptApiKey(
   });
 }
 
+export function promptConfiguredProviderSelection(
+  host: DialogHost,
+  colors: ColorPalette,
+  config: { providers?: Record<string, unknown> | undefined; models?: Record<string, { provider?: string }> | undefined; defaultModel?: string | undefined },
+  showError: (msg: string) => void,
+): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    const providerIds = Object.keys(config.providers ?? {});
+    if (providerIds.length === 0) {
+      showError('No providers configured. Run /login or /connect first.');
+      resolve(undefined);
+      return;
+    }
+
+    const options: ChoiceOption[] = providerIds
+      .toSorted((a, b) => a.localeCompare(b))
+      .map((id) => ({ value: id, label: id }));
+
+    const defaultProvider = config.models?.[config.defaultModel ?? '']?.provider;
+
+    const picker = new ChoicePickerComponent({
+      title: 'Select a provider to log out',
+      options,
+      currentValue: defaultProvider,
+      colors,
+      searchable: false,
+      onSelect: (value) => {
+        host.close();
+        resolve(value);
+      },
+      onCancel: () => {
+        host.close();
+        resolve(undefined);
+      },
+    });
+    host.show(picker);
+  });
+}
+
 export function promptProviderSelection(
   host: DialogHost,
   colors: ColorPalette,

--- a/apps/cli/test/tui/byf-tui-message-flow.test.ts
+++ b/apps/cli/test/tui/byf-tui-message-flow.test.ts
@@ -10,6 +10,7 @@ import {
 import type { ApprovalRequest, ApprovalResponse, Event } from '@byfriends/sdk';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { ChoicePickerComponent } from '#/tui/components/dialogs/choice-picker';
 import { ModelSelectorComponent } from '#/tui/components/dialogs/model-selector';
 import { ByfTui, type ByfTuiStartupInput, type TUIState } from '#/tui/byf-tui';
 import type { QueuedMessage } from '#/tui/types';
@@ -1018,31 +1019,51 @@ describe('ByfTui message flow', () => {
     expect(transcript, '/login should not say "removed"').not.toContain('removed');
   });
 
-  it('/logout with no argument shows usage hint', async () => {
+  it('/logout opens provider selector with configured providers', async () => {
+    const session = makeSession();
+    const harness = makeHarness(session, {
+      getConfig: vi.fn(async () => ({
+        providers: {
+          deepseek: { baseUrl: 'https://api.deepseek.com/v1', apiKey: 'key-ds' },
+          openai: { baseUrl: 'https://api.openai.com/v1', apiKey: 'key-oai' },
+        },
+        models: {
+          'deepseek-chat': { provider: 'deepseek', model: 'deepseek-chat', maxContextSize: 64000 },
+          'gpt-4o': { provider: 'openai', model: 'gpt-4o', maxContextSize: 128000 },
+        },
+        defaultModel: 'gpt-4o',
+      })),
+    });
+    const { driver } = await makeDriver(session, harness);
+
+    driver.handleUserInput('/logout');
+
+    await vi.waitFor(() => {
+      const picker = driver.state.editorContainer.children[0];
+      expect(picker).toBeInstanceOf(ChoicePickerComponent);
+    });
+
+    const picker = driver.state.editorContainer.children[0] as ChoicePickerComponent;
+    const output = stripSgr(picker.render(120).join('\n'));
+    expect(output).toContain('deepseek');
+    expect(output).toContain('openai');
+    expect(output).toContain('openai ← current');
+  });
+
+  it('/logout with no configured providers shows error', async () => {
     const { driver } = await makeDriver();
 
     driver.handleUserInput('/logout');
 
     await vi.waitFor(() => {
       const transcript = stripSgr(renderTranscript(driver));
-      expect(transcript).toContain('Usage');
-      expect(transcript).toContain('/logout');
-      expect(transcript).toContain('<provider-name>');
+      expect(transcript).toContain('No providers configured');
+      expect(transcript).toContain('/login');
+      expect(transcript).toContain('/connect');
     });
   });
 
-  it('/logout with non-existent provider shows error', async () => {
-    const { driver } = await makeDriver();
-
-    driver.handleUserInput('/logout xyz');
-
-    await vi.waitFor(() => {
-      const transcript = stripSgr(renderTranscript(driver));
-      expect(transcript).toContain('Provider "xyz" not found');
-    });
-  });
-
-  it('/logout removes a provider and its models', async () => {
+  it('/logout selecting a provider removes it and its models', async () => {
     const session = makeSession();
     const harness = makeHarness(session, {
       getConfig: vi.fn(async () => ({
@@ -1061,7 +1082,19 @@ describe('ByfTui message flow', () => {
     });
     const { driver } = await makeDriver(session, harness);
 
-    driver.handleUserInput('/logout deepseek');
+    driver.handleUserInput('/logout');
+
+    await vi.waitFor(() => {
+      const picker = driver.state.editorContainer.children[0];
+      expect(picker).toBeInstanceOf(ChoicePickerComponent);
+    });
+
+    const picker = driver.state.editorContainer.children[0] as ChoicePickerComponent;
+    // List is sorted alphabetically: deepseek, openai
+    // defaultModel is gpt-4o (openai), so openai is highlighted at index 1
+    // Navigate up to deepseek (index 0)
+    picker.handleInput('\u001B[A');
+    picker.handleInput('\r');
 
     await vi.waitFor(() => {
       expect(harness.removeProvider).toHaveBeenCalledWith('deepseek');
@@ -1070,7 +1103,7 @@ describe('ByfTui message flow', () => {
     expect(transcript).toContain('Provider "deepseek" removed');
   });
 
-  it('/logout clears defaultModel and shows hint when active model removed', async () => {
+  it('/logout clears appState.model when active model is removed', async () => {
     const session = makeSession();
     const harness = makeHarness(session, {
       getConfig: vi.fn(async () => ({
@@ -1087,7 +1120,18 @@ describe('ByfTui message flow', () => {
     });
     const { driver } = await makeDriver(session, harness);
 
-    driver.handleUserInput('/logout deepseek');
+    // Simulate active session model belonging to deepseek
+    driver.state.appState.model = 'deepseek-chat';
+
+    driver.handleUserInput('/logout');
+
+    await vi.waitFor(() => {
+      const picker = driver.state.editorContainer.children[0];
+      expect(picker).toBeInstanceOf(ChoicePickerComponent);
+    });
+
+    const picker = driver.state.editorContainer.children[0] as ChoicePickerComponent;
+    picker.handleInput('\r');
 
     await vi.waitFor(() => {
       const transcript = stripSgr(renderTranscript(driver));
@@ -1123,7 +1167,17 @@ describe('ByfTui message flow', () => {
     });
     const { driver } = await makeDriver(session, harness);
 
-    driver.handleUserInput('/logout deepseek');
+    driver.handleUserInput('/logout');
+
+    await vi.waitFor(() => {
+      const picker = driver.state.editorContainer.children[0];
+      expect(picker).toBeInstanceOf(ChoicePickerComponent);
+    });
+
+    const picker = driver.state.editorContainer.children[0] as ChoicePickerComponent;
+    // Navigate to deepseek (index 0, default is openai at index 1)
+    picker.handleInput('\u001B[A');
+    picker.handleInput('\r');
 
     await vi.waitFor(() => {
       expect(harness.removeProvider).toHaveBeenCalledWith('deepseek');
@@ -1133,7 +1187,7 @@ describe('ByfTui message flow', () => {
     expect(transcript).not.toContain('No active model');
   });
 
-  it('/disconnect alias removes provider like /logout', async () => {
+  it('/disconnect alias opens selector and removes provider like /logout', async () => {
     const session = makeSession();
     const harness = makeHarness(session, {
       getConfig: vi.fn(async () => ({
@@ -1149,7 +1203,15 @@ describe('ByfTui message flow', () => {
     });
     const { driver } = await makeDriver(session, harness);
 
-    driver.handleUserInput('/disconnect deepseek');
+    driver.handleUserInput('/disconnect');
+
+    await vi.waitFor(() => {
+      const picker = driver.state.editorContainer.children[0];
+      expect(picker).toBeInstanceOf(ChoicePickerComponent);
+    });
+
+    const picker = driver.state.editorContainer.children[0] as ChoicePickerComponent;
+    picker.handleInput('\r');
 
     await vi.waitFor(() => {
       expect(harness.removeProvider).toHaveBeenCalledWith('deepseek');
@@ -1158,7 +1220,7 @@ describe('ByfTui message flow', () => {
     expect(transcript).toContain('Provider "deepseek" removed');
   });
 
-  it('/logout detects active session model even when defaultModel differs', async () => {
+  it('/logout removes active model provider even when defaultModel differs', async () => {
     const session = makeSession();
     const harness = makeHarness(session, {
       getConfig: vi.fn(async () => ({
@@ -1177,10 +1239,20 @@ describe('ByfTui message flow', () => {
     });
     const { driver } = await makeDriver(session, harness);
 
-    // Simulate the active session using deepseek-chat while defaultModel is gpt-4o
+    // Active session uses deepseek-chat while defaultModel is gpt-4o (openai)
     driver.state.appState.model = 'deepseek-chat';
 
-    driver.handleUserInput('/logout deepseek');
+    driver.handleUserInput('/logout');
+
+    await vi.waitFor(() => {
+      const picker = driver.state.editorContainer.children[0];
+      expect(picker).toBeInstanceOf(ChoicePickerComponent);
+    });
+
+    const picker = driver.state.editorContainer.children[0] as ChoicePickerComponent;
+    // Navigate to deepseek (index 0, default highlight is openai at index 1)
+    picker.handleInput('\u001B[A');
+    picker.handleInput('\r');
 
     await vi.waitFor(() => {
       const transcript = stripSgr(renderTranscript(driver));
@@ -1207,13 +1279,100 @@ describe('ByfTui message flow', () => {
     const { driver } = await makeDriver(session, harness);
 
     // Active model belongs to deepseek
+    driver.state.appState.model = 'deepseek-chat';
     expect(driver.state.appState.model).toBeTruthy();
 
-    driver.handleUserInput('/logout deepseek');
+    driver.handleUserInput('/logout');
+
+    await vi.waitFor(() => {
+      const picker = driver.state.editorContainer.children[0];
+      expect(picker).toBeInstanceOf(ChoicePickerComponent);
+    });
+
+    const picker = driver.state.editorContainer.children[0] as ChoicePickerComponent;
+    picker.handleInput('\r');
 
     await vi.waitFor(() => {
       expect(driver.state.appState.model).toBe('');
     });
+  });
+
+  it('/logout cancelling with Escape makes no state changes', async () => {
+    const session = makeSession();
+    const harness = makeHarness(session, {
+      getConfig: vi.fn(async () => ({
+        providers: {
+          deepseek: { baseUrl: 'https://api.deepseek.com/v1', apiKey: 'key-ds' },
+        },
+        models: {
+          'deepseek-chat': { provider: 'deepseek', model: 'deepseek-chat', maxContextSize: 64000 },
+        },
+        defaultModel: 'deepseek-chat',
+      })),
+      removeProvider: vi.fn(async () => ({})),
+    });
+    const { driver } = await makeDriver(session, harness);
+    driver.state.appState.model = 'deepseek-chat';
+
+    driver.handleUserInput('/logout');
+
+    await vi.waitFor(() => {
+      const picker = driver.state.editorContainer.children[0];
+      expect(picker).toBeInstanceOf(ChoicePickerComponent);
+    });
+
+    const picker = driver.state.editorContainer.children[0] as ChoicePickerComponent;
+    picker.handleInput('\u001B'); // Escape
+
+    await vi.waitFor(() => {
+      expect(driver.state.editorContainer.children[0]).not.toBeInstanceOf(ChoicePickerComponent);
+    });
+
+    expect(harness.removeProvider).not.toHaveBeenCalled();
+    expect(driver.state.appState.model).toBe('deepseek-chat');
+  });
+
+  it('/logout removing non-active provider preserves appState.model', async () => {
+    const session = makeSession();
+    const harness = makeHarness(session, {
+      getConfig: vi.fn(async () => ({
+        providers: {
+          deepseek: { baseUrl: 'https://api.deepseek.com/v1', apiKey: 'key-ds' },
+          openai: { baseUrl: 'https://api.openai.com/v1', apiKey: 'key-oai' },
+        },
+        models: {
+          'deepseek-chat': { provider: 'deepseek', model: 'deepseek-chat', maxContextSize: 64000 },
+          'gpt-4o': { provider: 'openai', model: 'gpt-4o', maxContextSize: 128000 },
+        },
+        defaultModel: 'gpt-4o',
+      })),
+      removeProvider: vi.fn(async () => ({})),
+      setConfig: vi.fn(async () => ({})),
+    });
+    const { driver } = await makeDriver(session, harness);
+
+    // Active session uses deepseek-chat; defaultModel is gpt-4o (openai)
+    driver.state.appState.model = 'deepseek-chat';
+
+    driver.handleUserInput('/logout');
+
+    await vi.waitFor(() => {
+      const picker = driver.state.editorContainer.children[0];
+      expect(picker).toBeInstanceOf(ChoicePickerComponent);
+    });
+
+    const picker = driver.state.editorContainer.children[0] as ChoicePickerComponent;
+    // defaultModel is gpt-4o (openai), so openai is highlighted at index 1
+    // Press Enter to select openai — this is NOT the active model's provider
+    picker.handleInput('\r');
+
+    await vi.waitFor(() => {
+      expect(harness.removeProvider).toHaveBeenCalledWith('openai');
+    });
+
+    const transcript = stripSgr(renderTranscript(driver));
+    expect(transcript).toContain('Provider "openai" removed');
+    expect(transcript).not.toContain('No active model');
   });
 
   it('does not run /init when no model is selected', async () => {


### PR DESCRIPTION
Closes #70, closes #71

## Problem

The `/logout` command required users to type a provider name argument (`/logout <provider-name>`). This was inconvenient because users had to remember exact names, and a missing or typo'd name showed a usage error instead of helping.

## Changes

- **Interactive selector**: `/logout` (and `/disconnect` alias) now opens a `ChoicePickerComponent` listing all configured providers, sorted alphabetically.
- **Default highlight**: The provider for `config.defaultModel` is pre-selected with `← current`, so pressing Enter matches the old most-common-case behavior.
- **No arguments**: Any trailing text is ignored. The command always opens the selector.
- **Cancel**: Escape closes the selector with no state change.
- **`wasActiveModel` fix**: Clearing `appState.model` now only happens when the removed provider is the one for the currently active session model, not the default model's provider. This prevents interrupting an active session with a different provider.
- **Registry**: Updated `/logout` command description.
- **Tests**: All 8 existing `/logout` tests rewritten to the selector-interaction pattern; 2 new tests added (cancel and non-active provider removal). 61/61 message-flow tests pass.
- **Changeset**: `.changeset/interactive-logout-selector.md` (minor bump for `@byfriends/cli`).

## Verification

- `npx vitest run test/tui/byf-tui-message-flow.test.ts`: 61/61 passing
- `npx vitest run test/tui/commands/registry.test.ts`: 10/10 passing