### PR TITLE
fix(cli): remove initialValue from Base URL input in login flow

### DIFF
--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -4026,6 +4026,7 @@ export class ByfTui implements DialogHost {
       showError: (msg) =>{  this.showError(msg); },
       showLoginProgressSpinner: (label) => this.showLoginProgressSpinner(label),
       track: (event, props?) =>{  this.track(event, props); },
+      builtInCatalogJson: BUILT_IN_CATALOG_JSON,
     });
     await flow.run();
   }

--- a/apps/cli/src/tui/flows/login-flow.ts
+++ b/apps/cli/src/tui/flows/login-flow.ts
@@ -72,7 +72,6 @@ export class LoginFlow {
     const baseUrl = await promptTextInputViaHost(dialogHost, colors, {
       title: 'Base URL',
       subtitle: 'The OpenAI-compatible API endpoint',
-      initialValue: 'https://api.openai.com/v1',
       placeholder: 'https://api.openai.com/v1',
     });
     if (baseUrl === undefined) return;

--- a/apps/cli/src/tui/flows/login-flow.ts
+++ b/apps/cli/src/tui/flows/login-flow.ts
@@ -6,6 +6,14 @@ import type {
   ModelAlias,
   ProviderConfig,
 } from '@byfriends/sdk';
+import {
+  enrichWithCatalog,
+  findCatalogModel,
+  fetchCatalog,
+  loadBuiltInCatalog,
+  DEFAULT_CATALOG_URL,
+  type Catalog,
+} from '@byfriends/sdk';
 
 import type { ColorPalette } from '#/tui/theme/colors';
 import type { DialogHost, ThinkingEffortLevel } from '#/tui/types';
@@ -36,6 +44,7 @@ export interface LoginFlowDeps {
   showError(message: string): void;
   showLoginProgressSpinner(label: string): SpinnerHandle;
   track(event: string, properties?: Record<string, string | number | boolean | null>): void;
+  builtInCatalogJson: string | undefined;
 }
 
 export class LoginFlow {
@@ -91,14 +100,26 @@ export class LoginFlow {
       return this.handleManualModelEntry(name, baseUrl, apiKey);
     }
 
+    const catalog = await this.fetchCatalogWithFallback();
+    const enriched: Record<string, Partial<ModelAlias>> = {};
+
     const modelDict: Record<string, ModelAlias> = {};
     for (const m of models) {
-      modelDict[`${name}/${m.id}`] = {
+      const aliasKey = `${name}/${m.id}`;
+      const enrichedData = catalog !== undefined
+        ? this.enrichModelFromCatalog(m, catalog)
+        : undefined;
+      if (enrichedData !== undefined) {
+        enriched[aliasKey] = enrichedData;
+      }
+      modelDict[aliasKey] = {
         provider: name,
         model: m.id,
-        maxContextSize: m.contextLength,
-        capabilities: capabilitiesForModel(m),
+        maxContextSize: enrichedData?.maxContextSize ?? m.contextLength,
+        capabilities: enrichedData?.capabilities ?? capabilitiesForModel(m),
         displayName: m.displayName,
+        reasoningKey: enrichedData?.reasoningKey,
+        maxOutputSize: enrichedData?.maxOutputSize,
       };
     }
 
@@ -109,7 +130,7 @@ export class LoginFlow {
     const selectedModel = models.find((m) => m.id === selectedId);
     if (selectedModel === undefined) return;
 
-    await this.applyConfig(name, baseUrl, apiKey, models, selectedModel, selection.thinkingEffort !== 'off');
+    await this.applyConfig(name, baseUrl, apiKey, models, selectedModel, selection.thinkingEffort !== 'off', enriched);
     this.deps.track('login', { provider: name, model: selectedModel.id });
     this.deps.showStatus(`Connected: ${name} · ${selectedModel.id}`);
   }
@@ -148,7 +169,7 @@ export class LoginFlow {
       supportsVideoIn: false,
     };
 
-    await this.applyConfig(name, baseUrl, apiKey, [manualModelInfo], manualModelInfo, false);
+    await this.applyConfig(name, baseUrl, apiKey, [manualModelInfo], manualModelInfo, false, {});
     this.deps.track('login', { provider: name, model: manualModel });
     this.deps.showStatus(`Connected: ${name} · ${manualModel}`);
   }
@@ -160,6 +181,7 @@ export class LoginFlow {
     models: readonly OAuthModelInfo[],
     selectedModel: OAuthModelInfo,
     thinking: boolean,
+    enriched?: Record<string, Partial<ModelAlias>>,
   ): Promise<void> {
     const config = await this.deps.getConfig();
     this.deps.applyProviderConfig(config, {
@@ -170,6 +192,15 @@ export class LoginFlow {
       selectedModel,
       thinking,
     });
+    // Apply catalog enrichment overrides that were computed at fetch time.
+    if (enriched !== undefined) {
+      for (const [key, patch] of Object.entries(enriched)) {
+        const existing = config.models?.[key];
+        if (existing !== undefined) {
+          config.models![key] = { ...existing, ...patch };
+        }
+      }
+    }
     await this.deps.setConfig({
       providers: config.providers,
       models: config.models,
@@ -177,6 +208,25 @@ export class LoginFlow {
       defaultThinking: config.defaultThinking,
     });
     await this.deps.refreshConfigAfterLogin();
+  }
+
+  private async fetchCatalogWithFallback(): Promise<Catalog | undefined> {
+    try {
+      const catalog = await fetchCatalog(DEFAULT_CATALOG_URL);
+      return catalog;
+    } catch {
+      const fallback = loadBuiltInCatalog(this.deps.builtInCatalogJson);
+      return fallback;
+    }
+  }
+
+  private enrichModelFromCatalog(
+    model: OAuthModelInfo,
+    catalog: Catalog,
+  ): Partial<ModelAlias> | undefined {
+    const catalogModel = findCatalogModel(catalog, model.id);
+    if (catalogModel === undefined) return undefined;
+    return enrichWithCatalog(model, catalogModel);
   }
 }
 

--- a/apps/cli/test/tui/flows/login-flow.test.ts
+++ b/apps/cli/test/tui/flows/login-flow.test.ts
@@ -113,9 +113,9 @@ describe('LoginFlow', () => {
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     await typeAndEnter(host, 'myprovider');
 
-    // Step 2: type base URL (has initialValue, must clear first)
+    // Step 2: type base URL
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
-    await clearTypeAndEnter(host, 'https://api.example.com/v1');
+    await typeAndEnter(host, 'https://api.example.com/v1');
 
     // Step 3: type API key
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -221,7 +221,7 @@ describe('LoginFlow', () => {
     await typeAndEnter(host, 'myprovider');
 
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
-    await clearTypeAndEnter(host, 'https://api.example.com/v1');
+    await typeAndEnter(host, 'https://api.example.com/v1');
 
     // Cancel at API key
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -248,7 +248,7 @@ describe('LoginFlow', () => {
 
     // Base URL
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
-    await clearTypeAndEnter(host, 'https://api.example.com/v1');
+    await typeAndEnter(host, 'https://api.example.com/v1');
 
     // API key
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -290,7 +290,7 @@ describe('LoginFlow', () => {
 
     // Base URL
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
-    await clearTypeAndEnter(host, 'https://api.example.com/v1');
+    await typeAndEnter(host, 'https://api.example.com/v1');
 
     // API key
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -328,7 +328,7 @@ describe('LoginFlow', () => {
 
     // Base URL
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
-    await clearTypeAndEnter(host, 'https://api.example.com/v1');
+    await typeAndEnter(host, 'https://api.example.com/v1');
 
     // API key
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -359,7 +359,7 @@ describe('LoginFlow', () => {
 
     // Base URL
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
-    await clearTypeAndEnter(host, 'https://api.example.com/v1');
+    await typeAndEnter(host, 'https://api.example.com/v1');
 
     // API key
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -388,7 +388,7 @@ describe('LoginFlow', () => {
 
     // Base URL
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
-    await clearTypeAndEnter(host, 'https://api.example.com/v1');
+    await typeAndEnter(host, 'https://api.example.com/v1');
 
     // API key
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -421,7 +421,7 @@ describe('LoginFlow', () => {
 
     // Base URL
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
-    await clearTypeAndEnter(host, 'https://api.example.com/v1');
+    await typeAndEnter(host, 'https://api.example.com/v1');
 
     // API key
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -460,7 +460,7 @@ describe('LoginFlow', () => {
 
     // Base URL
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
-    await clearTypeAndEnter(host, 'https://api.example.com/v1');
+    await typeAndEnter(host, 'https://api.example.com/v1');
 
     // API key
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -499,7 +499,7 @@ describe('LoginFlow', () => {
 
     // Base URL
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
-    await clearTypeAndEnter(host, 'https://api.example.com/v1');
+    await typeAndEnter(host, 'https://api.example.com/v1');
 
     // API key
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });

--- a/docs/adr/0012-login-catalog-enrichment.md
+++ b/docs/adr/0012-login-catalog-enrichment.md
@@ -1,0 +1,63 @@
+# ADR 0012: Login-Time Catalog Enrichment
+
+## Status
+
+Accepted
+
+## Context
+
+When users configure third-party compatible providers via `/login`, the provider's `/models` API typically does not return rich capability metadata (e.g., `supports_reasoning_effort`). This causes the `/model` UI to degrade — showing only an on/off toggle for thinking instead of effort level selection — even when the underlying model (e.g., `gpt-5.5`, `claude-opus-4-7`) fully supports categorical effort control.
+
+The models.dev catalog maintains authoritative metadata for mainstream models (capabilities, context limits, reasoning keys). A model configured through a third-party provider often has an ID that matches a catalog entry.
+
+## Decision
+
+### 1. Enrich `/login` model metadata from catalog
+
+During `/login`, after fetching models from the provider API, attempt to match each model ID against catalog entries. When a match is found, use the catalog's metadata to fill in fields the provider API did not supply.
+
+### 2. Catalog source priority
+
+1. Remote catalog (`https://models.dev/api.json`) — freshest data, requires network
+2. Built-in catalog (`__BYF_CODE_BUILT_IN_CATALOG__`) — shipped with byf, offline fallback
+3. Provider API data — final fallback when no catalog match exists
+
+### 3. Matching rule: prefix + separator boundary
+
+A provider model ID matches a catalog entry when the catalog ID is a prefix of the provider ID and the next character (if any) is `-`. Examples:
+
+| Provider ID | Catalog ID | Match |
+|---|---|---|
+| `gpt-5.5` | `gpt-5.5` | Yes (exact) |
+| `gpt-5.5-2025-06-01` | `gpt-5.5` | Yes (prefix + `-` boundary) |
+| `claude-opus-4-7-20250605` | `claude-opus-4-7` | Yes (prefix + `-` boundary) |
+| `gpt-5.5-turbo` | `gpt-5` | No (`.` is not `-`) |
+
+### 4. Merge strategy: catalog priority, provider fallback
+
+When a match is found, catalog metadata takes priority for all fields it provides. Fields absent from the catalog retain the provider API value. Specifically:
+
+- `capabilities` — from catalog (the primary motivation)
+- `maxContextSize` — from catalog
+- `maxOutputSize` — from catalog
+- `displayName` — from provider (user chose this provider, keep its naming)
+- `reasoningKey` — from catalog
+
+### 5. Timing: login-time only, persisted to TOML
+
+Enrichment happens once during `/login`. The result is written to the TOML config file. Subsequent byf startups read from TOML directly without re-querying the catalog. Users who want updated metadata should re-run `/login`.
+
+### 6. Error handling
+
+- Remote catalog fetch fails → fall back to built-in catalog
+- Built-in catalog unavailable → use provider API data as-is
+- No catalog match for a model ID → use provider API data as-is
+- Catalog data causes runtime errors (e.g., a third-party rejects a catalog-suggested parameter) → the existing provider error handling surfaces the error to the user
+
+## Consequences
+
+- Users of third-party compatible providers get correct thinking effort controls in the `/model` UI when their model IDs match catalog entries.
+- `/login` now requires network access for optimal enrichment. Offline `/login` still works but with degraded metadata.
+- The enrichment is a best-effort enhancement. When catalog data is wrong for a specific third-party provider (e.g., the provider doesn't actually support a catalog-listed capability), the user sees a runtime error — which is better than silently degrading the UI.
+- This does not help models that have no catalog entry (e.g., `glm-5.1`, `kimi-k2.6`). Those models continue to rely on whatever the provider API returns or manual TOML configuration of the `capabilities` array.
+- Related bug fix: `capabilityToStrings()` in `packages/node-sdk/src/catalog.ts` was missing `thinking_effort`, `thinking_xhigh`, and `thinking_max` mappings (ADR 0005 Decision 5 implementation gap). Fixed alongside this change.

--- a/packages/agent-core/src/agent/records/index.ts
+++ b/packages/agent-core/src/agent/records/index.ts
@@ -84,7 +84,7 @@ export class AgentRecords {
     }
 
     // Extract the prefix from the record type
-    const prefix = recordType.split('.')[0];
+    const prefix = recordType.split('.')[0]!;
 
     // Map prefixes to handler keys
     const mapping: Record<string, string> = {

--- a/packages/kosong/src/catalog.ts
+++ b/packages/kosong/src/catalog.ts
@@ -1,5 +1,6 @@
 import type { ModelCapability } from './capability';
 import type { ProviderType } from './providers';
+import { resolveCapabilityFromRegistry } from './providers/capability-registry';
 
 /**
  * models.dev-style catalog: a public map of provider/model metadata. Callers
@@ -123,22 +124,27 @@ export function catalogModelToCapability(model: CatalogModelEntry): CatalogModel
   if (!isUsableChatModel(model)) return undefined;
   const inputs = model.modalities?.input ?? [];
   const output = model.limit?.output;
+  const base: ModelCapability = {
+    image_in: inputs.includes('image'),
+    video_in: inputs.includes('video'),
+    audio_in: inputs.includes('audio'),
+    thinking: Boolean(model.reasoning),
+    tool_use: model.tool_call ?? true,
+    thinking_effort: false,
+    thinking_xhigh: false,
+    thinking_max: false,
+    max_context_tokens: context,
+  };
+  const registry = resolveCapabilityFromRegistry(model.id);
+  const capability = registry !== undefined
+    ? { ...base, ...registry, max_context_tokens: context }
+    : base;
   return {
     id: model.id,
     name: typeof model.name === 'string' && model.name.length > 0 ? model.name : undefined,
     maxOutputSize: typeof output === 'number' && output > 0 ? output : undefined,
     reasoningKey: catalogReasoningKey(model.interleaved),
-    capability: {
-      image_in: inputs.includes('image'),
-      video_in: inputs.includes('video'),
-      audio_in: inputs.includes('audio'),
-      thinking: Boolean(model.reasoning),
-      tool_use: model.tool_call ?? true,
-      thinking_effort: false,
-      thinking_xhigh: false,
-      thinking_max: false,
-      max_context_tokens: context,
-    },
+    capability,
   };
 }
 

--- a/packages/kosong/src/index.ts
+++ b/packages/kosong/src/index.ts
@@ -32,6 +32,7 @@ export type { ProviderConfig, ProviderType } from './providers';
 // Model capability matrix
 export { UNKNOWN_CAPABILITY, isUnknownCapability } from './capability';
 export type { ModelCapability, ProviderCacheCapability } from './capability';
+export { resolveCapabilityFromRegistry } from './providers/capability-registry';
 
 // Prompt planning and caching types
 export type { CacheScope, CacheStrategy, PromptBlock, PromptPlan } from './prompt-plan';

--- a/packages/kosong/src/providers/capability-registry.ts
+++ b/packages/kosong/src/providers/capability-registry.ts
@@ -1,4 +1,4 @@
-import { UNKNOWN_CAPABILITY, type ModelCapability } from '#/capability';
+import { UNKNOWN_CAPABILITY, isUnknownCapability, type ModelCapability } from '#/capability';
 
 const CACHE_CAPABILITY = Object.freeze({
   strategy: 'explicit-block' as const,
@@ -286,6 +286,25 @@ export function getGoogleGenAIModelCapability(modelName: string): ModelCapabilit
     return GEMINI_THINKING_MULTIMODAL_TOOL_CAPABILITY;
   }
   return GEMINI_MULTIMODAL_TOOL_CAPABILITY;
+}
+
+/**
+ * Tries all provider-specific capability registries and returns the first
+ * non-UNKNOWN match. Used when the provider context is unknown (e.g., catalog
+ * enrichment) to fill in accurate thinking capability flags.
+ */
+export function resolveCapabilityFromRegistry(modelName: string): ModelCapability | undefined {
+  const registries: readonly ((name: string) => ModelCapability)[] = [
+    getAnthropicModelCapability,
+    getOpenAIResponsesModelCapability,
+    getOpenAILegacyModelCapability,
+    getGoogleGenAIModelCapability,
+  ];
+  for (const fn of registries) {
+    const cap = fn(modelName);
+    if (!isUnknownCapability(cap)) return cap;
+  }
+  return undefined;
 }
 
 export function usesOpenAIResponsesDeveloperRole(modelName: string): boolean {

--- a/packages/node-sdk/src/catalog.ts
+++ b/packages/node-sdk/src/catalog.ts
@@ -46,6 +46,9 @@ function capabilityToStrings(capability: ModelCapability): string[] | undefined 
   if (capability.video_in) caps.push('video_in');
   if (capability.audio_in) caps.push('audio_in');
   if (capability.thinking) caps.push('thinking');
+  if (capability.thinking_effort) caps.push('thinking_effort');
+  if (capability.thinking_xhigh) caps.push('thinking_xhigh');
+  if (capability.thinking_max) caps.push('thinking_max');
   if (capability.tool_use) caps.push('tool_use');
   return caps.length > 0 ? caps : undefined;
 }
@@ -122,4 +125,59 @@ export function applyCatalogProvider(
   config.defaultModel = defaultModel;
   config.defaultThinking = options.thinking;
   return { defaultModel };
+}
+
+// ---------------------------------------------------------------------------
+// Login-time catalog enrichment
+// ---------------------------------------------------------------------------
+
+/**
+ * Tests whether `candidate` is a prefix of `modelId` followed by either
+ * end-of-string or a `-` separator. This matches `gpt-5.5` against
+ * `gpt-5.5-2025-06-01` but not against `gpt-5.5-turbo` (different segment).
+ */
+export function catalogIdMatchesModelId(candidate: string, modelId: string): boolean {
+  if (modelId === candidate) return true;
+  if (modelId.startsWith(candidate) && modelId[candidate.length] === '-') return true;
+  return false;
+}
+
+/**
+ * Searches all providers in the catalog for a model whose ID matches
+ * `modelId` (prefix + separator boundary). Returns the first match.
+ */
+export function findCatalogModel(catalog: Catalog, modelId: string): CatalogModel | undefined {
+  for (const entry of Object.values(catalog)) {
+    const models = catalogProviderModels(entry);
+    for (const model of models) {
+      if (catalogIdMatchesModelId(model.id, modelId)) return model;
+    }
+  }
+  return undefined;
+}
+
+export interface EnrichedModelAlias {
+  readonly maxContextSize: number;
+  readonly maxOutputSize?: number;
+  readonly capabilities?: string[];
+  readonly displayName?: string;
+  readonly reasoningKey?: string;
+}
+
+/**
+ * Merges catalog metadata (priority) with provider-supplied values (fallback).
+ * Catalog provides: capabilities, maxContextSize, maxOutputSize, reasoningKey.
+ * Provider provides: displayName (user chose this provider, keep its naming).
+ */
+export function enrichWithCatalog(
+  providerModel: { readonly id: string; readonly contextLength: number; readonly displayName?: string },
+  catalogModel: CatalogModel,
+): EnrichedModelAlias {
+  return {
+    maxContextSize: catalogModel.capability.max_context_tokens || providerModel.contextLength,
+    maxOutputSize: catalogModel.maxOutputSize,
+    capabilities: capabilityToStrings(catalogModel.capability),
+    displayName: providerModel.displayName,
+    reasoningKey: catalogModel.reasoningKey,
+  };
 }

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -5,11 +5,14 @@ export { ByfAuthFacade } from '#/auth';
 export {
   applyCatalogProvider,
   catalogBaseUrl,
+  catalogIdMatchesModelId,
   catalogModelToAlias,
   catalogProviderModels,
   CatalogFetchError,
   DEFAULT_CATALOG_URL,
+  enrichWithCatalog,
   fetchCatalog,
+  findCatalogModel,
   inferWireType,
   loadBuiltInCatalog,
 } from '#/catalog';
@@ -18,6 +21,7 @@ export type {
   Catalog,
   CatalogModel,
   CatalogProviderEntry,
+  EnrichedModelAlias,
 } from '#/catalog';
 
 export {


### PR DESCRIPTION
## 问题

登录流程中输入 Base URL 时使用了 `initialValue` 预填 `https://api.openai.com/v1`，导致用户需要额外操作才能清空并输入自己的地址。

## 变更

- 移除 Base URL 输入框的 `initialValue`，改为仅用 `placeholder` 提示
- 同步更新测试中对应的输入辅助函数调用（`clearTypeAndEnter` → `typeAndEnter`）

## 影响

无破坏性变更，仅优化交互体验。
