### PR TITLE
fix(cli, agent-core): wrap long text in question-dialog and improve subagent handling

### DIFF
--- a/apps/cli/src/tui/components/dialogs/question-dialog.ts
+++ b/apps/cli/src/tui/components/dialogs/question-dialog.ts
@@ -14,6 +14,7 @@ import {
   type Focusable,
   truncateToWidth,
   visibleWidth,
+  wrapTextWithAnsi,
 } from '@earendil-works/pi-tui';
 import chalk from 'chalk';
 
@@ -32,6 +33,36 @@ const REVIEW_TITLE = 'Review your answer before submit';
 const SUBMIT_PROMPT = 'Ready to submit your answers?';
 const UNANSWERED_WARNING = 'Some questions are still unanswered.';
 const SUBMIT_ACTIONS = ['Submit', 'Cancel'] as const;
+
+/**
+ * Wrap a line of text so that each output line is <= width visible columns.
+ * The first line is prefixed with `firstLinePrefix`, subsequent lines with
+ * `continuationPrefix`. A style function is applied to each full line
+ * (prefix + wrapped text) so ANSI codes cover the entire line.
+ */
+function wrapWithPrefix(
+  text: string,
+  width: number,
+  firstLinePrefix: string,
+  continuationPrefix: string,
+  styleFn: (s: string) => string,
+): string[] {
+  const firstWidth = visibleWidth(firstLinePrefix);
+  const contWidth = visibleWidth(continuationPrefix);
+  const maxPrefix = Math.max(firstWidth, contWidth);
+  const wrapW = Math.max(1, width - maxPrefix);
+  const wrapped = wrapTextWithAnsi(text, wrapW);
+  const lines: string[] = [];
+  for (let i = 0; i < wrapped.length; i++) {
+    const line = wrapped[i] ?? '';
+    if (i === 0) {
+      lines.push(styleFn(firstLinePrefix + line));
+    } else {
+      lines.push(styleFn(continuationPrefix + line));
+    }
+  }
+  return lines.length > 0 ? lines : [styleFn(firstLinePrefix + text)];
+}
 
 interface DisplayOption {
   readonly label: string;
@@ -432,7 +463,7 @@ export class QuestionDialogComponent extends Container implements Focusable {
     this.pushTabs(lines);
     lines.push('');
 
-    lines.push(accent(` ? ${question.question}`));
+    lines.push(...wrapWithPrefix(question.question, width, ` ? `, `    `, accent));
     if (this.isEditingOther()) {
       lines.push(dim('   Type your answer, then press Enter to save.'));
     }
@@ -442,7 +473,8 @@ export class QuestionDialogComponent extends Container implements Focusable {
       const bodyLines = question.body.trim().split('\n');
       const visibleBodyLines = bodyLines.slice(0, MAX_BODY_LINES);
       for (const bodyLine of visibleBodyLines) {
-        lines.push(dim(`   ${bodyLine}`));
+        const wrapped = wrapWithPrefix(bodyLine, width, '   ', '   ', dim);
+        lines.push(...wrapped);
       }
       if (bodyLines.length > visibleBodyLines.length) {
         lines.push(dim(`   ... ${String(bodyLines.length - visibleBodyLines.length)} more lines`));
@@ -473,31 +505,46 @@ export class QuestionDialogComponent extends Container implements Focusable {
 
       const label = this.renderOptionLabel(questionIdx, option, isCursor);
 
-      let line: string;
       if (question.multi_select) {
         const checked = isSelected ? '✓' : ' ';
-        const body = `[${checked}] ${label}`;
-        if (isSelected && isCursor) line = success.bold(`  ${body}`);
-        else if (isSelected) line = success(`  ${body}`);
-        else if (isCursor) line = accent(`  ${body}`);
-        else line = dim(`  ${body}`);
-      } else if (isSelected && this.isAnswered(questionIdx)) {
-        line = isCursor
-          ? success.bold(`  → [${String(num)}] ${label}`)
-          : success(`    [${String(num)}] ${label}`);
-      } else if (isCursor) {
-        line = accent(`  → [${String(num)}] ${label}`);
+        const firstPrefix = `  [${checked}] `;
+        const contPrefix = '      ';
+        if (isSelected && isCursor) {
+          lines.push(...wrapWithPrefix(label, width, firstPrefix, contPrefix, success.bold));
+        } else if (isSelected) {
+          lines.push(...wrapWithPrefix(label, width, firstPrefix, contPrefix, success));
+        } else if (isCursor) {
+          lines.push(...wrapWithPrefix(label, width, firstPrefix, contPrefix, accent));
+        } else {
+          lines.push(...wrapWithPrefix(label, width, firstPrefix, contPrefix, dim));
+        }
       } else {
-        line = dim(`    [${String(num)}] ${label}`);
+        const firstPrefix = `  → [${String(num)}] `;
+        const contPrefix = '        ';
+        if (isSelected && this.isAnswered(questionIdx)) {
+          const np = isCursor ? firstPrefix : `    [${String(num)}] `;
+          if (isCursor) {
+            lines.push(...wrapWithPrefix(label, width, np, contPrefix, success.bold));
+          } else {
+            lines.push(...wrapWithPrefix(label, width, np, contPrefix, success));
+          }
+        } else if (isCursor) {
+          lines.push(...wrapWithPrefix(label, width, firstPrefix, contPrefix, accent));
+        } else {
+          lines.push(
+            ...wrapWithPrefix(label, width, `    [${String(num)}] `, contPrefix, dim),
+          );
+        }
       }
-      lines.push(line);
 
       if (
         option.description !== undefined &&
         option.description.length > 0 &&
         !(this.isEditingOther() && isCursor && isOther)
       ) {
-        lines.push(dim(`        ${option.description}`));
+        lines.push(
+          ...wrapWithPrefix(option.description, width, '        ', '        ', dim),
+        );
       }
     }
 
@@ -539,9 +586,9 @@ export class QuestionDialogComponent extends Container implements Focusable {
       const question = this.request.data.questions[i];
       if (question === undefined) continue;
       const answer = this.answers[i];
-      lines.push(`  ${dim('Q')}  ${question.question}`);
+      lines.push(...wrapWithPrefix(question.question, width, `  Q  `, `     `, dim));
       if (answer !== undefined && answer.length > 0) {
-        lines.push(`  ${accent('→')}  ${text(answer)}`);
+        lines.push(...wrapWithPrefix(answer, width, `  →  `, `     `, text));
       } else {
         lines.push(`  ${dim('→')}  ${dim(NOT_ANSWERED_LABEL)}`);
       }

--- a/apps/cli/test/tui/components/dialogs/question-dialog.test.ts
+++ b/apps/cli/test/tui/components/dialogs/question-dialog.test.ts
@@ -436,4 +436,132 @@ describe('QuestionDialogComponent', () => {
     expect(collected).toEqual([]);
   });
 
+  // ── Text wrapping ──────────────────────────────────────────────
+
+  it('wraps long question text instead of truncating with ellipsis', () => {
+    const longQuestion =
+      'What is the best approach to handle this very long question that should wrap to multiple lines instead of being truncated';
+    const pending = makePending([
+      {
+        question: longQuestion,
+        multi_select: false,
+        options: [{ label: 'A' }, { label: 'B' }],
+      },
+    ]);
+    const { dialog } = makeDialog(pending);
+    const lines = dialog.render(40);
+    const out = strip(lines.join('\n'));
+
+    // Should contain the full question text split across lines
+    expect(out).toContain('What is the best');
+    expect(out).toContain('truncated');
+    // Verify wrapping: question appears on multiple lines, not one long line
+    const questionLines = lines.filter((l) => strip(l).includes('What is the best'));
+    expect(questionLines).toHaveLength(1);
+    // The question should span multiple visual lines
+    const strippedLines = lines.map(strip);
+    const qStart = strippedLines.findIndex((l) => l.startsWith(' ? What'));
+    expect(qStart).toBeGreaterThanOrEqual(0);
+    expect(strippedLines[qStart + 1] ?? '').toContain('this very long');
+  });
+
+  it('wraps long option labels instead of truncating', () => {
+    const pending = makePending([
+      {
+        question: 'Pick?',
+        multi_select: false,
+        options: [
+          { label: 'This is a very long option label that wraps to multiple lines easily' },
+          { label: 'B' },
+        ],
+      },
+    ]);
+    const { dialog } = makeDialog(pending);
+    const lines = dialog.render(40);
+    const out = strip(lines.join('\n'));
+
+    expect(out).toContain('This is a very long');
+    expect(out).toContain('multiple');
+    expect(out).toContain('easily');
+  });
+
+  it('wraps long option descriptions instead of truncating', () => {
+    const pending = makePending([
+      {
+        question: 'Pick?',
+        multi_select: false,
+        options: [
+          {
+            label: 'A',
+            description:
+              'This is a very long option description that should wrap to multiple lines instead of being truncated with ellipsis',
+          },
+          { label: 'B' },
+        ],
+      },
+    ]);
+    const { dialog } = makeDialog(pending);
+    const out = strip(dialog.render(40).join('\n'));
+
+    expect(out).toContain('This is a very long');
+    expect(out).toContain('ellipsis');
+  });
+
+  it('wraps long body text lines instead of truncating', () => {
+    const longLine =
+      'This is a very long body line that should wrap properly to multiple lines within the available width of the terminal instead of being cut off';
+    const pending = makePending([
+      {
+        question: 'Read?',
+        body: longLine,
+        multi_select: false,
+        options: [{ label: 'A' }, { label: 'B' }],
+      },
+    ]);
+    const { dialog } = makeDialog(pending);
+    const out = strip(dialog.render(40).join('\n'));
+
+    expect(out).toContain('This is a very long');
+    expect(out).toContain('cut off');
+  });
+
+  it('wraps long question text in the submit review tab', () => {
+    const longQuestion =
+      'What is the very long question text in the review tab that should wrap to multiple lines';
+    const pending = makePending([
+      {
+        question: longQuestion,
+        multi_select: false,
+        options: [{ label: 'Selected Answer' }, { label: 'B' }],
+      },
+    ]);
+    const { dialog } = makeDialog(pending);
+    // Navigate to submit tab
+    dialog.handleInput('\t');
+    const out = strip(dialog.render(40).join('\n'));
+
+    expect(out).toContain('What is the very');
+    expect(out).toContain('multiple lines');
+  });
+
+  it('wraps long answer text in the submit review tab', () => {
+    const pending = makePending([
+      {
+        question: 'Q?',
+        multi_select: false,
+        options: [
+          { label: 'This is a very long answer that wraps in the review tab instead of being truncated' },
+          { label: 'B' },
+        ],
+      },
+    ]);
+    const { dialog } = makeDialog(pending);
+    dialog.handleInput('\r');
+    dialog.handleInput('\t');
+    const out = strip(dialog.render(40).join('\n'));
+
+    expect(out).toContain('This is a very long');
+    expect(out).toContain('truncated');
+  });
+
 });

--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -302,11 +302,14 @@ export class ContextMemory implements RecordRestoreHandler {
       case 'tool.result': {
         let result = event.result;
 
-        // Attempt output offloading for large string outputs
+        // Attempt output offloading for large string outputs.
+        // Agent tool results are subagent summaries — distilled by another LLM
+        // — and should never be offloaded (see ADR in commit message).
         if (
           !this.agent.records.restoring &&
           this.scratchManager !== undefined &&
-          typeof result.output === 'string'
+          typeof result.output === 'string' &&
+          (this.toolCallInfo.get(event.toolCallId)?.name ?? 'unknown') !== 'Agent'
         ) {
           const offloadResult = await offloadOutput(
             event.toolCallId,

--- a/packages/agent-core/src/agent/context/observation-masking.ts
+++ b/packages/agent-core/src/agent/context/observation-masking.ts
@@ -28,6 +28,7 @@ export function getToolPriority(toolName: string): ToolPriority {
   switch (toolName) {
     case 'Write':
     case 'Edit':
+    case 'Agent':
       return 'high';
     case 'Bash':
       return 'medium';

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -22,6 +22,8 @@ export type OAuthRef = z.infer<typeof OAuthRefSchema>;
 
 const StringRecordSchema = z.record(z.string(), z.string());
 
+const ExtraBodySchema = z.record(z.string(), z.unknown());
+
 export const ProviderConfigSchema = z.object({
   type: ProviderTypeSchema,
   apiKey: z.string().optional(),
@@ -31,6 +33,7 @@ export const ProviderConfigSchema = z.object({
   oauth: OAuthRefSchema.optional(),
   env: StringRecordSchema.optional(),
   customHeaders: StringRecordSchema.optional(),
+  extraBody: ExtraBodySchema.optional(),
 });
 
 export type ProviderConfig = z.infer<typeof ProviderConfigSchema>;

--- a/packages/agent-core/src/providers/runtime-provider.ts
+++ b/packages/agent-core/src/providers/runtime-provider.ts
@@ -251,6 +251,10 @@ function toKosongProviderConfig(
         ...byfRequestHeaders,
         ...provider.customHeaders,
       };
+      const generationKwargs = {
+        prompt_cache_key: promptCacheKey,
+        extra_body: provider.extraBody,
+      };
       if (Object.keys(defaultHeaders).length === 0) {
         return {
           type: 'openai-completions',
@@ -258,9 +262,7 @@ function toKosongProviderConfig(
           baseUrl: providerValue(provider.baseUrl, provider.env, 'BYF_BASE_URL'),
           reasoningKey,
           thinkingEffortKey: provider.thinkingEffortKey,
-          generationKwargs: {
-            prompt_cache_key: promptCacheKey,
-          },
+          generationKwargs,
           apiKey: providerApiKey(provider),
         };
       }
@@ -270,9 +272,7 @@ function toKosongProviderConfig(
         baseUrl: providerValue(provider.baseUrl, provider.env, 'BYF_BASE_URL'),
         reasoningKey,
         thinkingEffortKey: provider.thinkingEffortKey,
-        generationKwargs: {
-          prompt_cache_key: promptCacheKey,
-        },
+        generationKwargs,
         defaultHeaders,
         apiKey: providerApiKey(provider),
       };

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -19,6 +19,11 @@ import SUMMARY_CONTINUATION_PROMPT from './summary-continuation.md';
  * agent receives a technically complete handoff.
  */
 const SUMMARY_MIN_LENGTH = 200;
+/**
+ * Soft upper bound (characters) communicated to the subagent via prompt so
+ * it self-regulates summary length. Not enforced at runtime.
+ */
+const SUMMARY_MAX_LENGTH = 8_000;
 const SUMMARY_CONTINUATION_ATTEMPTS = 1;
 const HOOK_TEXT_PREVIEW_LENGTH = 500;
 const SUBAGENT_MAX_TOKENS_ERROR =
@@ -224,9 +229,13 @@ export class SessionSubagentHost {
       await this.triggerSubagentStart(parent, profileName, options.prompt, options.signal);
       options.signal.throwIfAborted();
 
+      // Inject length budget constraint so the subagent self-regulates its
+      // summary length (prevents oversized handoffs that would blow the
+      // parent agent's context window).
+      const budgetLine = `Summary length constraint: minimum ${SUMMARY_MIN_LENGTH} characters, maximum ${SUMMARY_MAX_LENGTH} characters.`;
+      let childPrompt = `${budgetLine}\n\n${options.prompt}`;
       // Explore subagents start cold; a git-context block helps them orient
       // in the repository before searching.
-      let childPrompt = options.prompt;
       if (profileName === 'explore') {
         const gitContext = await collectGitContext(child.runtime.kaos, child.config.cwd);
         if (gitContext) childPrompt = `${gitContext}\n\n${childPrompt}`;

--- a/packages/agent-core/test/agent/context.test.ts
+++ b/packages/agent-core/test/agent/context.test.ts
@@ -742,6 +742,94 @@ function assistantToolCallMessage(ids: readonly string[]): Message {
   };
 }
 
+  it('does not offload Agent tool results regardless of size', async () => {
+    const homedir = `/tmp/byf-test-offload-${Date.now()}`;
+    const ctx = testAgent({ homedir, sessionId: 'test-session' });
+    ctx.configure();
+
+    const stepUuid = 'step-agent';
+    const toolCallId = 'call_agent_large';
+
+    await ctx.agent.context.appendLoopEvent({ type: 'step.begin', uuid: stepUuid, turnId: '', step: 1 });
+
+    // Register the tool call as an Agent tool
+    await ctx.agent.context.appendLoopEvent({
+      type: 'tool.call',
+      uuid: toolCallId,
+      turnId: '',
+      step: 1,
+      stepUuid,
+      toolCallId,
+      name: 'Agent',
+      args: { prompt: 'explore the codebase' },
+    });
+
+    // Produce a large output that would normally trigger offloading (> 8000 tokens ≈ 32K chars)
+    const largeOutput = 'x'.repeat(40_000);
+    await ctx.agent.context.appendLoopEvent({
+      type: 'tool.result',
+      parentUuid: stepUuid,
+      toolCallId,
+      result: { output: largeOutput },
+    });
+
+    // The Agent tool result must remain intact — not replaced by a scratch-file preview
+    const lastMessage = ctx.agent.context.history[ctx.agent.context.history.length - 1];
+    expect(lastMessage.role).toBe('tool');
+    expect(textOf(lastMessage)).toBe(largeOutput);
+
+    // Cleanup
+    try {
+      const { rmSync } = await import('node:fs');
+      rmSync(homedir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  });
+
+  it('offloads non-Agent tool results when they exceed the threshold', async () => {
+    const homedir = `/tmp/byf-test-offload-other-${Date.now()}`;
+    const ctx = testAgent({ homedir, sessionId: 'test-session' });
+    ctx.configure();
+
+    const stepUuid = 'step-bash';
+    const toolCallId = 'call_bash_large';
+
+    await ctx.agent.context.appendLoopEvent({ type: 'step.begin', uuid: stepUuid, turnId: '', step: 1 });
+
+    await ctx.agent.context.appendLoopEvent({
+      type: 'tool.call',
+      uuid: toolCallId,
+      turnId: '',
+      step: 1,
+      stepUuid,
+      toolCallId,
+      name: 'Bash',
+      args: { command: 'cat large-file.txt' },
+    });
+
+    const largeOutput = 'x'.repeat(40_000);
+    await ctx.agent.context.appendLoopEvent({
+      type: 'tool.result',
+      parentUuid: stepUuid,
+      toolCallId,
+      result: { output: largeOutput },
+    });
+
+    // Bash tool results should be offloaded to scratch
+    const lastMessage = ctx.agent.context.history[ctx.agent.context.history.length - 1];
+    expect(lastMessage.role).toBe('tool');
+    expect(textOf(lastMessage)).toContain('[Tool output offloaded to scratch file');
+
+    // Cleanup
+    try {
+      const { rmSync } = await import('node:fs');
+      rmSync(homedir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  });
+
 function toolMessage(toolCallId: string, text: string): Message {
   return {
     role: 'tool',

--- a/packages/agent-core/test/agent/observation-masking.test.ts
+++ b/packages/agent-core/test/agent/observation-masking.test.ts
@@ -69,9 +69,10 @@ function buildHistoryWithToolResults(
 }
 
 describe('getToolPriority', () => {
-  it('returns high for Write and Edit', () => {
+  it('returns high for Write, Edit, and Agent', () => {
     expect(getToolPriority('Write')).toBe('high');
     expect(getToolPriority('Edit')).toBe('high');
+    expect(getToolPriority('Agent')).toBe('high');
   });
 
   it('returns medium for Bash', () => {

--- a/packages/agent-core/test/harness/runtime-provider.test.ts
+++ b/packages/agent-core/test/harness/runtime-provider.test.ts
@@ -356,6 +356,39 @@ describe('resolveRuntimeProvider Byf request headers', () => {
     });
   });
 
+  it('forwards provider extraBody to generation kwargs extra_body', () => {
+    const resolved = resolveRuntimeProvider({
+      config: {
+        ...BASE_CONFIG,
+        providers: {
+          'test-provider': {
+            type: 'openai-completions',
+            apiKey: 'test-key',
+            baseUrl: 'https://api.example/v1',
+            extraBody: { thinking: { keep: 'all' } },
+          },
+        },
+      },
+    });
+
+    expect(resolved.provider).toMatchObject({
+      type: 'openai-completions',
+      generationKwargs: {
+        extra_body: { thinking: { keep: 'all' } },
+      },
+    });
+  });
+
+  it('omits extra_body when provider extraBody is not configured', () => {
+    const resolved = resolveRuntimeProvider({
+      config: BASE_CONFIG,
+    });
+
+    const extraBody = (resolved.provider as Record<string, unknown>)?.generationKwargs
+      ?.extra_body;
+    expect(extraBody).toBeUndefined();
+  });
+
   it('forwards provider thinkingEffortKey to openai-completions runtime config', () => {
     const resolved = resolveRuntimeProvider({
       config: {

--- a/packages/agent-core/test/session/subagent-host.test.ts
+++ b/packages/agent-core/test/session/subagent-host.test.ts
@@ -224,7 +224,7 @@ describe('SessionSubagentHost', () => {
     expect(child.llmCalls[0]?.history).toMatchObject([
       {
         role: 'user',
-        content: [{ type: 'text', text: 'Find the cause' }],
+        content: [{ type: 'text', text: 'Summary length constraint: minimum 200 characters, maximum 8000 characters.\n\nFind the cause' }],
       },
     ]);
   });
@@ -264,7 +264,7 @@ describe('SessionSubagentHost', () => {
     expect(child.llmCalls[0]?.history).toMatchObject([
       {
         role: 'user',
-        content: [{ type: 'text', text: 'Implement the fix' }],
+        content: [{ type: 'text', text: 'Summary length constraint: minimum 200 characters, maximum 8000 characters.\n\nImplement the fix' }],
       },
     ]);
   });
@@ -540,7 +540,7 @@ describe('SessionSubagentHost', () => {
       content: [
         {
           type: 'text',
-          text: '<git-context>\nWorking directory: /repo\nBranch: main\n</git-context>\n\nFind the cause',
+          text: '<git-context>\nWorking directory: /repo\nBranch: main\n</git-context>\n\nSummary length constraint: minimum 200 characters, maximum 8000 characters.\n\nFind the cause',
         },
       ],
     });
@@ -569,8 +569,68 @@ describe('SessionSubagentHost', () => {
 
     expect(child.llmCalls[0]?.history[0]).toMatchObject({
       role: 'user',
-      content: [{ type: 'text', text: 'Implement the fix' }],
+      content: [
+        { type: 'text', text: 'Summary length constraint: minimum 200 characters, maximum 8000 characters.\n\nImplement the fix' },
+      ],
     });
+  });
+
+  it('prepends budget constraint with correct min/max character values', async () => {
+    const parent = testAgent();
+    parent.configure();
+    parent.newEvents();
+
+    const summary = 'A'.repeat(300); // above SUMMARY_MIN_LENGTH
+    const child = testAgent();
+    child.mockNextResponse({ type: 'text', text: summary });
+    const session = fakeSession(parent.agent, child.agent);
+    const host = new SessionSubagentHost(session, 'main');
+
+    const handle = await host.spawn('coder', {
+      parentToolCallId: 'call_budget',
+      prompt: 'Check budget format',
+      description: 'Budget test',
+      runInBackground: false,
+      signal,
+    });
+    await handle.completion;
+
+    // The first user message must start with the budget constraint line
+    const firstUserText = child.llmCalls[0]?.history[0]?.content?.[0];
+    expect(firstUserText).toMatchObject({ type: 'text' });
+    expect((firstUserText as { type: 'text'; text: string }).text).toMatch(
+      /^Summary length constraint: minimum \d+ characters, maximum \d+ characters\./,
+    );
+  });
+
+  it('orders prompt as gitContext → budgetLine → userPrompt for explore subagents', async () => {
+    const parent = testAgent({ cwd: '/repo' });
+    parent.configure();
+    parent.newEvents();
+
+    const summary = 'B'.repeat(300);
+    const child = testAgent();
+    child.mockNextResponse({ type: 'text', text: summary });
+    const session = fakeSession(parent.agent, child.agent);
+    const host = new SessionSubagentHost(session, 'main');
+
+    const handle = await host.spawn('explore', {
+      parentToolCallId: 'call_order',
+      prompt: 'Analyze the project',
+      description: 'Order test',
+      runInBackground: false,
+      signal,
+    });
+    await handle.completion;
+
+    const text = (child.llmCalls[0]?.history[0]?.content?.[0] as { type: 'text'; text: string }).text;
+    // git context comes first
+    const gitIdx = text.indexOf('<git-context>');
+    const budgetIdx = text.indexOf('Summary length constraint:');
+    const promptIdx = text.indexOf('Analyze the project');
+
+    expect(gitIdx).toBeLessThan(budgetIdx);
+    expect(budgetIdx).toBeLessThan(promptIdx);
   });
 
   it('resumes an idle child agent by id', async () => {
@@ -624,7 +684,7 @@ describe('SessionSubagentHost', () => {
       system: "explore prompt"
       tools: Read
       messages:
-        user: text "Earlier context\\n\\nContinue from context"
+        user: text "Earlier context\\n\\nSummary length constraint: minimum 200 characters, maximum 8000 characters.\\n\\nContinue from context"
     `);
     expect(parent.allEvents).toContainEqual(
       expect.objectContaining({


### PR DESCRIPTION
## Related Issue

N/A

## What Changed

This PR merges two commits from `dev` into `main`:

### 1. `fix(cli, agent-core): wrap long text in question-dialog and improve subagent handling`

- **CLI**: Added `wrapWithPrefix` helper in `QuestionDialog` to wrap long question text, body text, and option labels so they fit within terminal width, instead of overflowing.
- **agent-core**: Skip output offloading for `Agent` tool results — subagent summaries are already LLM-distilled and should not be truncated/offloaded.
- **agent-core**: Mark `Agent` tool as `high` priority in observation-masking.
- **agent-core**: Inject summary length budget (min 200 chars, max 8000 chars) into subagent prompt so subagents self-regulate summary length and prevent oversized handoffs that blow the parent agent's context window.

### 2. `feat: add extraBody to provider config for passing extra request body fields`

- Added `extraBody` option to provider configuration, allowing users to pass additional fields in API request bodies (e.g., custom headers, model-specific parameters).