### PR TITLE
chore: release 0.2.1

### DIFF
--- a/apps/cli/CHANGELOG.md
+++ b/apps/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @byfriends/cli
 
+## 0.2.1
+
+### Patch Changes
+
+- Release 0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byfriends/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "BYF (Be Your Friend), an AI coding agent that runs in your terminal",
   "license": "Proprietary",
   "author": "ByronFinn",

--- a/packages/agent-core/CHANGELOG.md
+++ b/packages/agent-core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @byfriends/agent-core
 
+## 0.2.1
+
+### Patch Changes
+
+- Release 0.2.1
+- Updated dependencies
+  - @byfriends/kaos@0.2.1
+  - @byfriends/kosong@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byfriends/agent-core",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Unified agent engine for BYF",
   "license": "Proprietary",
   "author": "ByronFinn",

--- a/packages/kaos/CHANGELOG.md
+++ b/packages/kaos/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @byfriends/kaos
 
+## 0.2.1
+
+### Patch Changes
+
+- Release 0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/kaos/package.json
+++ b/packages/kaos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byfriends/kaos",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Execution environment and filesystem/process abstractions for BYF",
   "license": "Proprietary",
   "author": "ByronFinn",

--- a/packages/kosong/CHANGELOG.md
+++ b/packages/kosong/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @byfriends/kosong
 
+## 0.2.1
+
+### Patch Changes
+
+- Release 0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/kosong/package.json
+++ b/packages/kosong/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byfriends/kosong",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "LLM and provider abstraction layer for BYF",
   "license": "Proprietary",
   "author": "ByronFinn",

--- a/packages/node-sdk/CHANGELOG.md
+++ b/packages/node-sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @byfriends/sdk
 
+## 0.2.1
+
+### Patch Changes
+
+- Release 0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/node-sdk/package.json
+++ b/packages/node-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byfriends/sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Public TypeScript SDK for BYF agents and sessions",
   "license": "Proprietary",
   "author": "ByronFinn",

--- a/packages/oauth/CHANGELOG.md
+++ b/packages/oauth/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @byfriends/oauth
 
+## 0.1.1
+
+### Patch Changes
+
+- Release 0.2.1
+
 ## 1.0.0
 
 ### Major Changes

--- a/packages/oauth/package.json
+++ b/packages/oauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byfriends/oauth",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Custom OAuth provider configuration for BYF",
   "license": "Proprietary",
   "author": "ByronFinn",


### PR DESCRIPTION
## Related Issue

N/A

## What Changed

Version bump to **0.2.1** for all packages:

- `@byfriends/cli`: 0.2.0 → 0.2.1
- `@byfriends/agent-core`: 0.2.0 → 0.2.1
- `@byfriends/sdk`: 0.2.0 → 0.2.1
- `@byfriends/kaos`: 0.2.0 → 0.2.1
- `@byfriends/kosong`: 0.2.0 → 0.2.1
- `@byfriends/oauth`: 0.1.0 → 0.1.1

## Changes Included

- Fix: Wrap long text in question-dialog and improve subagent handling
- Feat: Add extraBody to provider config for passing extra request body fields

## Post-Merge

After merging, run:

```bash
# Tag and push to trigger GitHub Release workflow
git tag @byfriends/cli@0.2.1
git push origin @byfriends/cli@0.2.1

# Publish to npm
pnpm run publish
```