### PR TITLE
fix: add subagent concurrency limit to prevent cascading proliferation

### DIFF
--- a/.changeset/fix-subagent-concurrency-limit.md
+++ b/.changeset/fix-subagent-concurrency-limit.md
@@ -1,0 +1,7 @@
+---
+'@byfriends/agent-core': minor
+---
+
+fix: add subagent concurrency limit to prevent cascading proliferation
+
+SessionSubagentHost now enforces `maxConcurrentSubagents` (default: 5) to cap parallel subagents per parent. Background tasks also get a default `maxRunningTasks` of 10. Configurable via `background.maxConcurrentSubagents` and `background.maxRunningTasks` in session config.

--- a/packages/agent-core/src/agent/index.ts
+++ b/packages/agent-core/src/agent/index.ts
@@ -153,7 +153,7 @@ export class Agent {
     this.usage = new UsageRecorder(this);
     this.tools = new ToolManager(this);
     this.background = new BackgroundManager(this, {
-      maxRunningTasks: config.backgroundMaxRunningTasks,
+      maxRunningTasks: config.backgroundMaxRunningTasks ?? 10,
       sessionDir: config.backgroundSessionDir,
     });
     this.replayBuilder = new ReplayBuilder(this);

--- a/packages/agent-core/src/config/schema.ts
+++ b/packages/agent-core/src/config/schema.ts
@@ -94,6 +94,7 @@ export type LoopControl = z.infer<typeof LoopControlSchema>;
 
 export const BackgroundConfigSchema = z.object({
   maxRunningTasks: z.number().int().min(1).optional(),
+  maxConcurrentSubagents: z.number().int().min(1).optional(),
   keepAliveOnExit: z.boolean().optional(),
   killGracePeriodMs: z.number().int().min(0).optional(),
   agentTaskTimeoutS: z.number().int().min(1).optional(),

--- a/packages/agent-core/src/session/index.ts
+++ b/packages/agent-core/src/session/index.ts
@@ -432,7 +432,12 @@ export class Session {
       sessionId: this.config.id,
       hookEngine: config.hookEngine ?? this.hookEngine,
       subagentHost:
-        config.subagentHost ?? new SessionSubagentHost(this, id, this.backgroundTaskTimeoutMs()),
+        config.subagentHost ?? new SessionSubagentHost(
+          this,
+          id,
+          this.backgroundTaskTimeoutMs(),
+          this.config.background?.maxConcurrentSubagents,
+        ),
       mcp: this.mcp,
       backgroundMaxRunningTasks: this.config.background?.maxRunningTasks,
       backgroundSessionDir: homedir,

--- a/packages/agent-core/src/session/subagent-host.ts
+++ b/packages/agent-core/src/session/subagent-host.ts
@@ -28,6 +28,11 @@ const SUMMARY_CONTINUATION_ATTEMPTS = 1;
 const HOOK_TEXT_PREVIEW_LENGTH = 500;
 const SUBAGENT_MAX_TOKENS_ERROR =
   'Subagent turn failed before completing its final summary: reason=max_tokens';
+/**
+ * Maximum number of concurrently running subagents per parent.
+ * Prevents cascading subagent proliferation that exhausts LLM bandwidth.
+ */
+const DEFAULT_MAX_CONCURRENT_SUBAGENTS = 5;
 
 type RunSubagentOptions = {
   readonly parentToolCallId: string;
@@ -58,15 +63,21 @@ export type SubagentHandle = {
 
 export class SessionSubagentHost {
   private readonly activeChildren = new Map<string, ActiveChild>();
+  /** Maximum concurrent subagents; exposed for testing and config diagnostics. */
+  readonly maxConcurrentSubagents: number;
 
   constructor(
     private readonly session: Session,
     private readonly ownerAgentId: string,
     readonly backgroundTaskTimeoutMs?: number | undefined,
-  ) {}
+    maxConcurrentSubagents: number | undefined = undefined,
+  ) {
+    this.maxConcurrentSubagents = maxConcurrentSubagents ?? DEFAULT_MAX_CONCURRENT_SUBAGENTS;
+  }
 
   async spawn(profileName: string, options: RunSubagentOptions): Promise<SubagentHandle> {
     options.signal.throwIfAborted();
+    this.assertCanSpawn();
 
     const parent = this.session.agents.get(this.ownerAgentId);
     if (parent === undefined) {
@@ -111,6 +122,7 @@ export class SessionSubagentHost {
 
   async resume(agentId: string, options: RunSubagentOptions): Promise<SubagentHandle> {
     options.signal.throwIfAborted();
+    this.assertCanSpawn();
 
     const parent = this.session.agents.get(this.ownerAgentId);
     if (parent === undefined) {
@@ -179,6 +191,14 @@ export class SessionSubagentHost {
     for (const [childId, child] of foregroundChildren) {
       this.session.agents.get(childId)?.subagentHost?.cancelAll();
       child.controller.abort();
+    }
+  }
+
+  private assertCanSpawn(): void {
+    if (this.activeChildren.size >= this.maxConcurrentSubagents) {
+      throw new Error(
+        `Too many concurrent subagents (${this.activeChildren.size} running, maximum ${this.maxConcurrentSubagents}).`,
+      );
     }
   }
 

--- a/packages/agent-core/src/tools/builtin/collaboration/agent.md
+++ b/packages/agent-core/src/tools/builtin/collaboration/agent.md
@@ -4,3 +4,4 @@ Launch a subagent to handle a task. The subagent starts with zero context — it
 - A subagent's result is only visible to you, not to the user. Summarize the relevant parts yourself when the user needs to see them.
 - Skip delegation for trivial work you can do directly — reading a known file, searching a small set of files, or any one-step task.
 - Once a subagent is running, do not redo its searches or reads in parallel, and do not abandon it midway and finish the job manually.
+- There is a concurrency limit on parallel subagents. If the limit is reached, wait for a running subagent to complete before launching another.

--- a/packages/agent-core/test/session/subagent-host.test.ts
+++ b/packages/agent-core/test/session/subagent-host.test.ts
@@ -741,6 +741,116 @@ describe('SessionSubagentHost', () => {
     expect(child.agent.config.modelAlias).toBe(parent.agent.config.modelAlias);
     expect(child.agent.config.modelAlias).not.toBe('stale-model-from-initial-spawn');
   });
+
+  it('rejects spawn when maxConcurrentSubagents is reached and reports the count', async () => {
+    const parent = testAgent();
+    parent.configure();
+    parent.newEvents();
+
+    let agentCounter = 0;
+    const summary = 'Summary with enough detail to skip re-prompting. '.repeat(10);
+    const child1 = testAgent();
+    const child2 = testAgent();
+    child1.mockNextResponse({ type: 'text', text: summary });
+    child2.mockNextResponse({ type: 'text', text: summary });
+    const session = fakeSession(parent.agent, child1.agent);
+    (session.createAgent as ReturnType<typeof vi.fn>).mockImplementation(
+      async (
+        config: Parameters<Session['createAgent']>[0],
+        profile?: ResolvedAgentProfile,
+        parentAgentId?: string,
+      ) => {
+        const id = `agent-${agentCounter}`;
+        const child = agentCounter === 0 ? child1 : child2;
+        session.agents.set(id, child.agent);
+        agentCounter++;
+        return { id, agent: child.agent };
+      },
+    );
+    const host = new SessionSubagentHost(session, 'main', undefined, 2);
+
+    const h1 = await host.spawn('coder', {
+      parentToolCallId: 'call_1',
+      prompt: 'Task 1',
+      description: 'First',
+      runInBackground: true,
+      signal,
+    });
+    const h2 = await host.spawn('coder', {
+      parentToolCallId: 'call_2',
+      prompt: 'Task 2',
+      description: 'Second',
+      runInBackground: true,
+      signal,
+    });
+
+    expect(h1.agentId).toBe('agent-0');
+    expect(h2.agentId).toBe('agent-1');
+
+    // Third spawn should fail with a message that includes the actual count.
+    await expect(
+      host.spawn('coder', {
+        parentToolCallId: 'call_3',
+        prompt: 'Task 3',
+        description: 'Third',
+        runInBackground: true,
+        signal,
+      }),
+    ).rejects.toThrow('Too many concurrent subagents (2 running, maximum 2)');
+
+    await Promise.all([h1.completion, h2.completion]);
+  });
+
+  it('rejects spawn when maxConcurrentSubagents is 1', async () => {
+    const parent = testAgent();
+    parent.configure();
+    parent.newEvents();
+
+    const child1 = testAgent();
+    const summary = 'Summary with enough detail to skip re-prompting. '.repeat(10);
+    child1.mockNextResponse({ type: 'text', text: summary });
+    const session = fakeSession(parent.agent, child1.agent);
+    (session.createAgent as ReturnType<typeof vi.fn>).mockImplementation(
+      async () => ({ id: 'agent-0', agent: child1.agent }),
+    );
+    const host = new SessionSubagentHost(session, 'main', undefined, 1);
+
+    const h1 = await host.spawn('coder', {
+      parentToolCallId: 'call_1',
+      prompt: 'Task 1',
+      description: 'First',
+      runInBackground: true,
+      signal,
+    });
+
+    await expect(
+      host.spawn('coder', {
+        parentToolCallId: 'call_2',
+        prompt: 'Task 2',
+        description: 'Second',
+        runInBackground: true,
+        signal,
+      }),
+    ).rejects.toThrow('Too many concurrent subagents (1 running, maximum 1)');
+
+    await h1.completion;
+  });
+
+  it('uses default maxConcurrentSubagents when not configured', () => {
+    const parent = testAgent();
+    parent.configure();
+    const session = fakeSession(parent.agent, testAgent().agent);
+    const host = new SessionSubagentHost(session, 'main');
+    expect(host.maxConcurrentSubagents).toBe(5);
+  });
+
+  it('accepts custom maxConcurrentSubagents config', () => {
+    const parent = testAgent();
+    parent.configure();
+    const session = fakeSession(parent.agent, testAgent().agent);
+    const host = new SessionSubagentHost(session, 'main', undefined, 10);
+    expect(host.maxConcurrentSubagents).toBe(10);
+  });
 });
 
 describe('Session resume permission parent chain', () => {


### PR DESCRIPTION
## 问题

dev-skills 会话中的 subagent 持续嵌套膨胀，没有并发上限或生命周期管理。主 agent 在一个 turn 内连续派生 subagent，subagent 可能又派生新的 subagent，导致同一 session 内堆积了 8 个并行的子任务，资源竞争严重。

## 修复

- **SessionSubagentHost** 添加 `maxConcurrentSubagents` 限制（默认 5），在 `spawn()` 和 `resume()` 入口处通过 `assertCanSpawn()` 拦截超限派生
- **BackgroundManager** 添加 `maxRunningTasks` 默认值 10，防止后台任务（bash + agent）无限制膨胀
- 两个参数均可通过 `background.maxConcurrentSubagents` 和 `background.maxRunningTasks` 自定义

## 变更

- `packages/agent-core/src/session/subagent-host.ts` — DEFAULT_MAX_CONCURRENT_SUBAGENTS = 5，assertCanSpawn() 守卫
- `packages/agent-core/src/agent/index.ts` — maxRunningTasks 默认 10
- `packages/agent-core/src/config/schema.ts` — maxConcurrentSubagents 配置项
- `packages/agent-core/src/session/index.ts` — 将配置传入 subagent host
- `packages/agent-core/src/tools/builtin/collaboration/agent.md` — 文档中说明并发限制
- `packages/agent-core/test/session/subagent-host.test.ts` — 4 个回归测试

## 验证

- 26 个 subagent-host 测试通过
- 1967 个 agent-core 测试通过
- TypeScript 编译通过
