### PR TITLE
feat(cli): display cache hit-rate across four CLI surfaces

### DIFF
--- a/.changeset/cache-observability-cli.md
+++ b/.changeset/cache-observability-cli.md
@@ -1,0 +1,19 @@
+---
+'@byfriends/cli': minor
+---
+
+Cache observability: display cache hit-rate across four CLI surfaces
+
+Add cache hit-rate visibility so users can see prompt cache efficiency at a glance:
+
+- `/usage` panel: per-model and total-row `(cache XX%)` suffix when hit rate > 0
+- Footer line 2: `cache: XX%` badge (per-turn, from `currentTurn` usage)
+- `/status` panel: `Cache` section with session-cumulative hit rate + read/write breakdown
+- Subagent chip: `(XX%)` suffix when `inputCacheRead > 0`
+
+New shared helpers in `usage-format.ts`:
+- `computeCacheHitRate(inputOther, inputCacheRead, inputCacheCreation)` — pure function, returns `undefined` for zero denominator
+- `formatCacheHitRate(rate)` — integer percentage with banker's rounding, returns `undefined` for rates that round to 0%
+- `safeNumber(value)` — defensive coercion for RPC/serialized token values
+
+All surfaces degrade gracefully: no cache data → no cache display (identical to previous behavior).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -121,6 +121,9 @@ The stability classification assigned to each `PromptBlock` in a `PromptPlan`: `
 ### Dynamic Zone
 The tail of the projected message array where ephemeral injections (timestamp, permission mode) are appended at the `before_user` position. Content here is per-request and never participates in the cached prefix. Part of the three-zone prompt layout: Cache Zone (stable system prompt blocks + tool specs), Conversation History (clean user/assistant/tool messages), Dynamic Zone (ephemeral per-request content).
 
+### Cache Hit Rate
+The ratio of input tokens served from the provider's prompt cache to total input tokens: `inputCacheRead / (inputOther + inputCacheRead + inputCacheCreation)`. A key metric for prompt cache efficiency. Two distinct scopes exist: **per-turn** (computed from `TokenUsage` of the current turn only, reflects "what just happened") and **session-cumulative** (computed from the aggregated `TokenUsage` across all turns, reflects "overall cache health"). The per-turn value is typically higher after the first turn because it excludes the initial cache-creation cost that permanently lowers the session-cumulative average.
+
 ### Structured Summary
 The compact representation used for masked tool results. Example: `[Bash: 'npm test', exit=0, 127 lines, stderr: none]`. Preserves the tool call metadata and a small head/tail fragment so the agent can decide whether to re-read the full output.
 

--- a/apps/cli/src/tui/components/chrome/footer.ts
+++ b/apps/cli/src/tui/components/chrome/footer.ts
@@ -19,7 +19,7 @@ import {
   type GitStatus,
   type GitStatusCache,
 } from '#/utils/git/git-status';
-import { safeUsageRatio } from '#/utils/usage/usage-format';
+import { formatCacheHitRate, safeUsageRatio } from '#/utils/usage/usage-format';
 
 const MAX_CWD_SEGMENTS = 3;
 
@@ -92,7 +92,7 @@ function safeUsage(usage: number): number {
   return safeUsageRatio(usage);
 }
 
-function formatContextStatus(usage: number, tokens?: number, maxTokens?: number): string {
+export function formatContextStatus(usage: number, tokens?: number, maxTokens?: number): string {
   const pct = `${(safeUsage(usage) * 100).toFixed(1)}%`;
   if (maxTokens && maxTokens > 0 && tokens !== undefined) {
     return `context: ${pct} (${formatTokenCount(tokens)}/${formatTokenCount(maxTokens)})`;
@@ -238,13 +238,18 @@ export class FooterComponent implements Component {
       line1 = truncateToWidth(leftLine, width, '…');
     }
 
-    // ── Line 2: transient hint (bottom-left) + context (right) ──
+    // ── Line 2: transient hint (bottom-left) + context + cache badge (right) ──
     const contextText = formatContextStatus(
       state.contextUsage,
       state.contextTokens,
       state.maxContextTokens,
     );
-    const contextWidth = visibleWidth(contextText);
+    const hitRateStr = formatCacheHitRate(state.cacheHitRate);
+    const cacheBadge = hitRateStr ? `  cache: ${hitRateStr}` : '';
+    const contextWidth = visibleWidth(contextText) + visibleWidth(cacheBadge);
+    const contextRight =
+      chalk.hex(colors.text)(contextText) +
+      (cacheBadge ? chalk.hex(colors.textDim)(cacheBadge) : '');
     let line2: string;
     if (this.transientHint) {
       const maxHintWidth = Math.max(0, width - contextWidth - 1);
@@ -254,13 +259,10 @@ export class FooterComponent implements Component {
           : truncateToWidth(this.transientHint, maxHintWidth, '…');
       const hintWidth = visibleWidth(shownHint);
       const pad = Math.max(0, width - hintWidth - contextWidth);
-      line2 =
-        chalk.hex(colors.warning).bold(shownHint) +
-        ' '.repeat(pad) +
-        chalk.hex(colors.text)(contextText);
+      line2 = chalk.hex(colors.warning).bold(shownHint) + ' '.repeat(pad) + contextRight;
     } else {
       const leftPad = Math.max(0, width - contextWidth);
-      line2 = ' '.repeat(leftPad) + chalk.hex(colors.text)(contextText);
+      line2 = ' '.repeat(leftPad) + contextRight;
     }
 
     return [truncateToWidth(line1, width), truncateToWidth(line2, width)];

--- a/apps/cli/src/tui/components/messages/status-panel.ts
+++ b/apps/cli/src/tui/components/messages/status-panel.ts
@@ -11,9 +11,12 @@ import chalk from 'chalk';
 import { PRODUCT_NAME } from '#/constant/app';
 import type { ColorPalette } from '#/tui/theme/colors';
 import {
+  computeCacheHitRate,
+  formatCacheHitRate,
   formatTokenCount,
   ratioSeverity,
   renderProgressBar,
+  safeNumber,
   safeUsageRatio,
 } from '#/utils/usage/usage-format';
 
@@ -45,6 +48,7 @@ export interface StatusReportOptions {
 }
 
 type Colorize = (text: string) => string;
+
 
 function displayModelName(alias: string, models: Record<string, ModelAlias>): string {
   const model = models[alias];
@@ -129,6 +133,33 @@ export function buildStatusReportLines(options: StatusReportOptions): string[] {
     );
   } else {
     lines.push(`  ${muted('No context window data available.')}`);
+  }
+
+  // Cache section
+  const total = options.status?.usage?.total;
+  if (total !== undefined) {
+    const hitRate = computeCacheHitRate(
+      safeNumber(total.inputOther),
+      safeNumber(total.inputCacheRead),
+      safeNumber(total.inputCacheCreation),
+    );
+    const hitRateStr = formatCacheHitRate(hitRate);
+    if (hitRateStr !== undefined) {
+      const labelWidth = Math.max(10, ...rows.map((r) => r.label.length));
+      const cacheLabel = muted('Cache'.padEnd(labelWidth));
+      const cacheValue =
+        muted(hitRateStr) +
+        '  ' +
+        muted('(') +
+        formatTokenCount(safeNumber(total.inputCacheRead)) +
+        ' read' +
+        ' / ' +
+        formatTokenCount(safeNumber(total.inputCacheCreation)) +
+        ' write' +
+        muted(')');
+      lines.push('');
+      lines.push('  ' + cacheLabel + '  ' + cacheValue);
+    }
   }
 
   const managedSection = buildManagedUsageReportLines({

--- a/apps/cli/src/tui/components/messages/tool-call.ts
+++ b/apps/cli/src/tui/components/messages/tool-call.ts
@@ -21,6 +21,7 @@ import type { ColorPalette } from '#/tui/theme/colors';
 import type { ToolCallBlockData, ToolResultBlockData } from '#/tui/types';
 import { appendStreamingArgsPreview } from '#/tui/utils/event-payload';
 import { decodeMcpToolName } from '#/tui/utils/mcp-tool-name';
+import { computeCacheHitRate, formatCacheHitRate } from '#/utils/usage/usage-format';
 
 import { ShellExecutionComponent } from './shell-execution';
 import { countNonEmptyLines, pickChip } from './tool-renderers/chip';
@@ -111,12 +112,27 @@ function usageInputTotal(usage: SubagentTokenUsage): number {
   );
 }
 
-function formatSubagentTokens(usage: SubagentTokenUsage | undefined): string | undefined {
+export function formatSubagentTokens(usage: SubagentTokenUsage | undefined): string | undefined {
   if (usage === undefined) return undefined;
   const total = usageInputTotal(usage) + usage.output;
   if (total <= 0) return undefined;
   const formatted = total >= 1000 ? `${(total / 1000).toFixed(1)}k` : String(total);
-  return `${formatted} tok`;
+
+  // Cache hit-rate suffix — use breakdown fields from SubagentTokenUsage.
+  // When legacy `input` is present, skip (denominator mismatch).
+  let cacheSuffix = '';
+  if (usage.input === undefined || usage.input === 0) {
+    const hitRate = computeCacheHitRate(
+      usage.inputOther ?? 0,
+      usage.inputCacheRead ?? 0,
+      usage.inputCacheCreation ?? 0,
+    );
+    const hitRateStr = formatCacheHitRate(hitRate);
+    if (hitRateStr !== undefined) {
+      cacheSuffix = ` (${hitRateStr})`;
+    }
+  }
+  return `${formatted} tok${cacheSuffix}`;
 }
 
 function formatByteSize(bytes: number): string {

--- a/apps/cli/src/tui/components/messages/usage-panel.ts
+++ b/apps/cli/src/tui/components/messages/usage-panel.ts
@@ -10,9 +10,12 @@ import type { SessionUsage, TokenUsage } from '@byfriends/sdk';
 import chalk from 'chalk';
 
 import {
+  computeCacheHitRate,
+  formatCacheHitRate,
   formatTokenCount,
   ratioSeverity,
   renderProgressBar,
+  safeNumber,
   safeUsageRatio,
 } from '#/utils/usage/usage-format';
 import type { ColorPalette } from '#/tui/theme/colors';
@@ -52,15 +55,12 @@ export interface ManagedUsageReportLineOptions {
   readonly managedUsageError?: string;
 }
 
-function usageNumber(value: unknown): number {
-  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 0;
-}
 
 function usageInputTotal(usage: TokenUsage): number {
   return (
-    usageNumber(usage.inputOther) +
-    usageNumber(usage.inputCacheRead) +
-    usageNumber(usage.inputCacheCreation)
+    safeNumber(usage.inputOther) +
+    safeNumber(usage.inputCacheRead) +
+    safeNumber(usage.inputCacheCreation)
   );
 }
 
@@ -80,20 +80,44 @@ function buildSessionUsageSection(
   const lines: string[] = [];
   let totalInput = 0;
   let totalOutput = 0;
+  let totalOther = 0;
+  let totalCacheRead = 0;
+  let totalCacheCreation = 0;
   for (const [model, row] of entries) {
     const input = usageInputTotal(row);
-    const output = usageNumber(row.output);
+    const output = safeNumber(row.output);
+    const other = safeNumber(row.inputOther);
+    const cacheRead = safeNumber(row.inputCacheRead);
+    const cacheCreation = safeNumber(row.inputCacheCreation);
     totalInput += input;
     totalOutput += output;
+    totalOther += other;
+    totalCacheRead += cacheRead;
+    totalCacheCreation += cacheCreation;
+
+    const hitRate = computeCacheHitRate(other, cacheRead, cacheCreation);
+    const hitRateStr = formatCacheHitRate(hitRate);
+    const cacheSuffix =
+      hitRateStr !== undefined
+        ? muted(' (cache ') + value(hitRateStr) + muted(')')
+        : '';
+
     lines.push(
-      `  ${muted(model)}  input ${value(formatTokenCount(input))}  output ${value(
+      `  ${muted(model)}  input ${value(formatTokenCount(input))}${cacheSuffix}  output ${value(
         formatTokenCount(output),
       )}  total ${value(formatTokenCount(input + output))}`,
     );
   }
   if (entries.length > 1) {
+    const totalHitRate = computeCacheHitRate(totalOther, totalCacheRead, totalCacheCreation);
+    const totalHitRateStr = formatCacheHitRate(totalHitRate);
+    const totalCacheSuffix =
+      totalHitRateStr !== undefined
+        ? muted(' (cache ') + value(totalHitRateStr) + muted(')')
+        : '';
+
     lines.push(
-      `  ${muted('total')}  input ${value(formatTokenCount(totalInput))}  output ${value(
+      `  ${muted('total')}  input ${value(formatTokenCount(totalInput))}${totalCacheSuffix}  output ${value(
         formatTokenCount(totalOutput),
       )}  total ${value(formatTokenCount(totalInput + totalOutput))}`,
     );

--- a/apps/cli/src/tui/events/session-meta-handler.ts
+++ b/apps/cli/src/tui/events/session-meta-handler.ts
@@ -10,6 +10,7 @@ import { errorReportHintLine } from '#/tui/constant/feedback';
 import type { AppState } from '#/tui/types';
 import { stringValue } from '#/tui/utils/event-payload';
 import { setProcessTitle } from '#/tui/utils/proctitle';
+import { computeCacheHitRate, safeNumber } from '#/utils/usage/usage-format';
 
 export interface SessionMetaCallbacks {
   flushStreamingUiUpdatesNow: () => void;
@@ -38,6 +39,10 @@ export function handleStatusUpdate(
     patch.yolo = event.permission === 'yolo';
   }
   if (event.model !== undefined) patch.model = event.model;
+  const ct = event.usage?.currentTurn;
+  if (ct !== undefined) {
+    patch.cacheHitRate = computeCacheHitRate(safeNumber(ct.inputOther), safeNumber(ct.inputCacheRead), safeNumber(ct.inputCacheCreation));
+  }
   if (Object.keys(patch).length > 0) setAppState(patch);
 }
 

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -58,6 +58,7 @@ export interface AppState {
   contextUsage: number;
   contextTokens: number;
   maxContextTokens: number;
+  cacheHitRate?: number;
   isStreaming: boolean;
   isCompacting: boolean;
   isReplaying: boolean;

--- a/apps/cli/src/utils/usage/usage-format.ts
+++ b/apps/cli/src/utils/usage/usage-format.ts
@@ -35,3 +35,46 @@ export function ratioSeverity(ratio: number): 'ok' | 'warn' | 'danger' {
   if (ratio >= 0.5) return 'warn';
   return 'ok';
 }
+
+/**
+ * Coerce RPC/serialized values to a safe non-negative finite number, defaulting to 0.
+ */
+export function safeNumber(value: unknown): number {
+  return Number.isFinite(value) && (value as number) >= 0 ? (value as number) : 0;
+}
+
+/**
+ * Compute cache hit rate (0..1).
+ * Formula: inputCacheRead / (inputOther + inputCacheRead + inputCacheCreation)
+ * Returns undefined when denominator is zero (signal: "no data").
+ */
+export function computeCacheHitRate(
+  inputOther: number,
+  inputCacheRead: number,
+  inputCacheCreation: number,
+): number | undefined {
+  const denom = inputOther + inputCacheRead + inputCacheCreation;
+  if (denom === 0) return undefined;
+  return inputCacheRead / denom;
+}
+
+/**
+ * Format cache hit rate as integer percentage string like "87%".
+ * Uses round-half-to-even (banker's rounding) for exact .5 ties.
+ * Returns undefined when rate is undefined or ≤ 0 (signal: "don't display").
+ */
+export function formatCacheHitRate(rate: number | undefined): string | undefined {
+  if (rate === undefined || rate <= 0) return undefined;
+  const rounded = roundHalfToEven(rate * 100);
+  if (rounded === 0) return undefined; // Too small to display as a percentage
+  return `${rounded}%`;
+}
+
+function roundHalfToEven(n: number): number {
+  const floor = Math.floor(n);
+  const frac = n - floor;
+  if (frac < 0.5) return floor;
+  if (frac > 0.5) return floor + 1;
+  // frac ≈ 0.5: round to nearest even
+  return floor % 2 === 0 ? floor : floor + 1;
+}

--- a/apps/cli/test/tui/components/chrome/footer.test.ts
+++ b/apps/cli/test/tui/components/chrome/footer.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+
+import { FooterComponent, formatContextStatus } from '#/tui/components/chrome/footer';
+import { darkColors } from '#/tui/theme/colors';
+import type { AppState } from '#/tui/types';
+
+const ANSI_SGR = /\u001B\[[0-9;]*m/g;
+function strip(text: string): string {
+  return text.replaceAll(ANSI_SGR, '');
+}
+
+function baseState(overrides: Record<string, unknown> = {}): AppState {
+  const state = {
+    model: 'k2',
+    workDir: '/tmp',
+    sessionId: 'sess_1',
+    yolo: false,
+    permissionMode: 'manual',
+    thinkingEffort: 'off',
+    contextUsage: 0.45,
+    contextTokens: 22000,
+    maxContextTokens: 48000,
+    isStreaming: false,
+    isCompacting: false,
+    isReplaying: false,
+    streamingPhase: 'idle',
+    streamingStartTime: 0,
+    theme: 'dark',
+    version: 'test',
+    editorCommand: null,
+    notifications: { enabled: true, condition: 'unfocused' },
+    availableModels: {},
+    availableProviders: {},
+    sessionTitle: null,
+    ...overrides,
+  };
+  return state as never as AppState;
+}
+
+describe('Footer — cache badge (Group B)', () => {
+  // ── B1: shows badge ────────────────────────────────────────────
+  it('B1: shows cache badge on line 2 when cacheHitRate > 0', () => {
+    const fc = new FooterComponent(baseState({ cacheHitRate: 0.87 }), darkColors);
+    const [, line2] = fc.render(120);
+    expect(line2).toBeDefined();
+    expect(strip(line2!)).toMatch(/cache:\s*87%/);
+  });
+
+  // ── B2: hides badge at 0 ───────────────────────────────────────
+  it('B2: hides cache badge when cacheHitRate is 0', () => {
+    const fc = new FooterComponent(baseState({ cacheHitRate: 0 }), darkColors);
+    const [, line2] = fc.render(120);
+    expect(line2).toBeDefined();
+    const stripped = strip(line2!);
+    expect(stripped).not.toMatch(/cache:/);
+    // context line still renders
+    expect(stripped).toMatch(/context:/);
+  });
+
+  // ── B3: hides badge at undefined ───────────────────────────────
+  it('B3: hides cache badge when cacheHitRate is undefined', () => {
+    const fc = new FooterComponent(baseState({ cacheHitRate: undefined }), darkColors);
+    const [, line2] = fc.render(120);
+    expect(line2).toBeDefined();
+    const stripped = strip(line2!);
+    expect(stripped).not.toMatch(/cache:/);
+    expect(stripped).toMatch(/context:/);
+  });
+
+  // ── B4: 99.9% → 100% ──────────────────────────────────────────
+  it('B4: rounds 0.999 → "100%" with banker\'s rounding', () => {
+    const fc = new FooterComponent(baseState({ cacheHitRate: 0.999 }), darkColors);
+    const [, line2] = fc.render(120);
+    expect(line2).toBeDefined();
+    expect(strip(line2!)).toMatch(/cache:\s*100%/);
+  });
+
+  // ── B5: 49.5% → 50% ───────────────────────────────────────────
+  it('B5: rounds 0.495 → "50%" with banker\'s rounding', () => {
+    const fc = new FooterComponent(baseState({ cacheHitRate: 0.495 }), darkColors);
+    const [, line2] = fc.render(120);
+    expect(line2).toBeDefined();
+    expect(strip(line2!)).toMatch(/cache:\s*50%/);
+  });
+
+  // ── B10: formatContextStatus unchanged ────────────────────────
+  it('B10: formatContextStatus returns context-only string, no cache:', () => {
+    const result = formatContextStatus(0.45, 22000, 48000);
+    expect(result).toContain('context:');
+    expect(result).not.toContain('cache:');
+  });
+
+  // ── B12: key absent ────────────────────────────────────────────
+  it('B12: no cache badge when cacheHitRate key is absent from state', () => {
+    // Construct state without cacheHitRate — key literally absent.
+    const stateWithout = {
+      model: 'k2',
+      workDir: '/tmp',
+      sessionId: 'sess_1',
+      yolo: false,
+      permissionMode: 'manual',
+      thinkingEffort: 'off',
+      contextUsage: 0.3,
+      contextTokens: 10000,
+      maxContextTokens: 48000,
+      isStreaming: false,
+      isCompacting: false,
+      isReplaying: false,
+      streamingPhase: 'idle',
+      streamingStartTime: 0,
+      theme: 'dark',
+      version: 'test',
+      editorCommand: null,
+      notifications: { enabled: true, condition: 'unfocused' },
+      availableModels: {},
+      availableProviders: {},
+      sessionTitle: null,
+    } as never as AppState;
+
+    const fc = new FooterComponent(stateWithout, darkColors);
+    const [, line2] = fc.render(120);
+    expect(line2).toBeDefined();
+    const stripped = strip(line2!);
+    expect(stripped).not.toMatch(/cache:/);
+    expect(stripped).toMatch(/context:/);
+  });
+});

--- a/apps/cli/test/tui/components/messages/status-panel.test.ts
+++ b/apps/cli/test/tui/components/messages/status-panel.test.ts
@@ -90,4 +90,351 @@ describe('status panel report lines', () => {
     expect(output).toContain('Warning      No active session');
     expect(output).toContain('No context window data available.');
   });
+
+  // ── Cache section (AC #4) ──────────────────────────────────────────
+
+  const baseStatusOptions = {
+    colors: darkColors,
+    version: '1.2.3',
+    model: 'k2',
+    workDir: '/tmp/project',
+    sessionId: 'ses-1',
+    sessionTitle: null as string | null,
+    thinking: true,
+    permissionMode: 'manual' as const,
+    contextUsage: 0.25,
+    contextTokens: 2500,
+    maxContextTokens: 10000,
+    availableModels: {
+      k2: {
+        provider: 'test-provider',
+        model: 'byf-k2',
+        maxContextSize: 10000,
+        displayName: 'Byf K2',
+      },
+    },
+  };
+
+  /** Thin helper to build, strip ANSI, and join lines. */
+  function render(options: Parameters<typeof buildStatusReportLines>[0]): string {
+    return buildStatusReportLines(options).map(strip).join('\n');
+  }
+
+  it('Scenario 1: renders Cache section with hit rate and read/write breakdown', () => {
+    const output = render({
+      ...baseStatusOptions,
+      status: {
+        model: 'k2',
+        thinkingLevel: 'high',
+        permission: 'auto',
+        contextTokens: 3000,
+        maxContextTokens: 12000,
+        contextUsage: 0.25,
+        usage: {
+          total: {
+            inputOther: 1000,
+            output: 5000,
+            inputCacheRead: 10700,
+            inputCacheCreation: 5000,
+          },
+        },
+      },
+    });
+    expect(output).toContain('Cache');
+    expect(output).toContain('64%');
+    expect(output).toContain('10.7k read');
+    expect(output).toContain('5.0k write');
+  });
+
+  it('Scenario 2: omits Cache section when status.usage is absent', () => {
+    const output = render({
+      ...baseStatusOptions,
+      status: {
+        model: 'k2',
+        thinkingLevel: 'high',
+        permission: 'auto',
+        contextTokens: 3000,
+        maxContextTokens: 12000,
+        contextUsage: 0.25,
+      },
+    });
+    expect(output).not.toContain('Cache');
+    expect(output).toContain('Model');
+    expect(output).toContain('Context window');
+  });
+
+  it('Scenario 3: omits Cache section when usage.total is absent', () => {
+    const output = render({
+      ...baseStatusOptions,
+      status: {
+        model: 'k2',
+        thinkingLevel: 'high',
+        permission: 'auto',
+        contextTokens: 3000,
+        maxContextTokens: 12000,
+        contextUsage: 0.25,
+        usage: {},
+      },
+    });
+    expect(output).not.toContain('Cache');
+    expect(output).toContain('Context window');
+  });
+
+  it('Scenario 4: omits Cache section when all cache fields are zero', () => {
+    const output = render({
+      ...baseStatusOptions,
+      status: {
+        model: 'k2',
+        thinkingLevel: 'high',
+        permission: 'auto',
+        contextTokens: 3000,
+        maxContextTokens: 12000,
+        contextUsage: 0.25,
+        usage: {
+          total: {
+            inputOther: 5000,
+            output: 2000,
+            inputCacheRead: 0,
+            inputCacheCreation: 0,
+          },
+        },
+      },
+    });
+    expect(output).not.toContain('Cache');
+    expect(output).not.toContain('read');
+    expect(output).not.toContain('write');
+  });
+
+  it('Scenario 5: omits Cache section when total input is zero', () => {
+    const output = render({
+      ...baseStatusOptions,
+      status: {
+        model: 'k2',
+        thinkingLevel: 'high',
+        permission: 'auto',
+        contextTokens: 3000,
+        maxContextTokens: 12000,
+        contextUsage: 0.25,
+        usage: {
+          total: {
+            inputOther: 0,
+            output: 0,
+            inputCacheRead: 0,
+            inputCacheCreation: 0,
+          },
+        },
+      },
+    });
+    expect(output).not.toContain('Cache');
+  });
+
+  it('Scenario 6: rounds 86.5% down to 86% (banker\'s rounding)', () => {
+    const output = render({
+      ...baseStatusOptions,
+      status: {
+        model: 'k2',
+        thinkingLevel: 'high',
+        permission: 'auto',
+        contextTokens: 3000,
+        maxContextTokens: 12000,
+        contextUsage: 0.25,
+        usage: {
+          total: {
+            inputOther: 135,
+            inputCacheRead: 865,
+            inputCacheCreation: 0,
+            output: 0,
+          },
+        },
+      },
+    });
+    expect(output).toContain('86%');
+  });
+
+  it('Scenario 7: rounds 87.5% up to 88% (banker\'s rounding)', () => {
+    const output = render({
+      ...baseStatusOptions,
+      status: {
+        model: 'k2',
+        thinkingLevel: 'high',
+        permission: 'auto',
+        contextTokens: 3000,
+        maxContextTokens: 12000,
+        contextUsage: 0.25,
+        usage: {
+          total: {
+            inputOther: 125,
+            inputCacheRead: 875,
+            inputCacheCreation: 0,
+            output: 0,
+          },
+        },
+      },
+    });
+    expect(output).toContain('88%');
+  });
+
+  it('Scenario 8: shows 100% hit rate and zero write', () => {
+    const output = render({
+      ...baseStatusOptions,
+      status: {
+        model: 'k2',
+        thinkingLevel: 'high',
+        permission: 'auto',
+        contextTokens: 3000,
+        maxContextTokens: 12000,
+        contextUsage: 0.25,
+        usage: {
+          total: {
+            inputOther: 0,
+            inputCacheRead: 10000,
+            inputCacheCreation: 0,
+            output: 0,
+          },
+        },
+      },
+    });
+    expect(output).toContain('100%');
+    expect(output).toContain('10.0k read');
+    expect(output).toContain('0 write');
+  });
+
+  it('Scenario 9: formats M-scale token values', () => {
+    const output = render({
+      ...baseStatusOptions,
+      status: {
+        model: 'k2',
+        thinkingLevel: 'high',
+        permission: 'auto',
+        contextTokens: 3000,
+        maxContextTokens: 12000,
+        contextUsage: 0.25,
+        usage: {
+          total: {
+            inputOther: 500000,
+            inputCacheRead: 1500000,
+            inputCacheCreation: 500000,
+            output: 0,
+          },
+        },
+      },
+    });
+    expect(output).toContain('1.5M read');
+    expect(output).toContain('500.0k write');
+  });
+
+  it('Scenario 10: Cache section appears between Context window and Plan usage', () => {
+    const lines = buildStatusReportLines({
+      ...baseStatusOptions,
+      status: {
+        model: 'k2',
+        thinkingLevel: 'high',
+        permission: 'auto',
+        contextTokens: 3000,
+        maxContextTokens: 12000,
+        contextUsage: 0.25,
+        usage: {
+          total: {
+            inputOther: 1000,
+            output: 5000,
+            inputCacheRead: 10700,
+            inputCacheCreation: 5000,
+          },
+        },
+      },
+      managedUsage: {
+        summary: null,
+        limits: [
+          {
+            label: '5h limit',
+            used: 8,
+            limit: 100,
+            resetHint: 'resets in 1h',
+          },
+        ],
+      },
+    }).map(strip);
+
+    const contextIdx = lines.findIndex((l) => l.includes('Context window'));
+    const cacheIdx = lines.findIndex((l) => l.startsWith('  Cache'));
+    const planIdx = lines.findIndex((l) => l.includes('Plan usage'));
+
+    expect(contextIdx).toBeGreaterThan(-1);
+    expect(cacheIdx).toBeGreaterThan(-1);
+    expect(planIdx).toBeGreaterThan(-1);
+    expect(contextIdx).toBeLessThan(cacheIdx);
+    expect(cacheIdx).toBeLessThan(planIdx);
+  });
+
+  it('Scenario 12: all legacy sections remain intact with Cache present', () => {
+    const output = render({
+      ...baseStatusOptions,
+      status: {
+        model: 'k2',
+        thinkingLevel: 'high',
+        permission: 'auto',
+        contextTokens: 3000,
+        maxContextTokens: 12000,
+        contextUsage: 0.25,
+        usage: {
+          total: {
+            inputOther: 1000,
+            output: 5000,
+            inputCacheRead: 10700,
+            inputCacheCreation: 5000,
+          },
+        },
+      },
+      managedUsage: {
+        summary: null,
+        limits: [
+          {
+            label: '5h limit',
+            used: 8,
+            limit: 100,
+            resetHint: 'resets in 1h',
+          },
+        ],
+      },
+    });
+    expect(output).toContain('>_ BYF');
+    expect(output).toContain('Model');
+    expect(output).toContain('Directory');
+    expect(output).toContain('Permissions');
+    expect(output).toContain('Session');
+    expect(output).toContain('Context window');
+    expect(output).toContain('Plan usage');
+    expect(output).toContain('Cache');
+  });
+
+  it('Scenario 13: no Cache section when cache data absent (regression)', () => {
+    const output = render({
+      ...baseStatusOptions,
+      status: {
+        model: 'k2',
+        thinkingLevel: 'high',
+        permission: 'auto',
+        contextTokens: 3000,
+        maxContextTokens: 12000,
+        contextUsage: 0.25,
+      },
+      managedUsage: {
+        summary: null,
+        limits: [
+          {
+            label: '5h limit',
+            used: 8,
+            limit: 100,
+            resetHint: 'resets in 1h',
+          },
+        ],
+      },
+    });
+    expect(output).not.toContain('Cache');
+    expect(output).not.toContain('read');
+    expect(output).not.toContain('write');
+    expect(output).toContain('>_ BYF');
+    expect(output).toContain('Context window');
+    expect(output).toContain('Plan usage');
+  });
 });

--- a/apps/cli/test/tui/components/messages/tool-call.test.ts
+++ b/apps/cli/test/tui/components/messages/tool-call.test.ts
@@ -1,7 +1,10 @@
 import type { TUI } from '@earendil-works/pi-tui';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { ToolCallComponent } from '#/tui/components/messages/tool-call';
+import {
+  formatSubagentTokens,
+  ToolCallComponent,
+} from '#/tui/components/messages/tool-call';
 import { STATUS_BULLET } from '#/tui/constant/symbols';
 import { darkColors } from '#/tui/theme/colors';
 import { createMarkdownTheme } from '#/tui/theme/pi-tui-theme';
@@ -884,5 +887,143 @@ describe('ToolCallComponent', () => {
     } finally {
       stderr.restore();
     }
+  });
+});
+
+describe('formatSubagentTokens', () => {
+  it('appends cache hit-rate suffix when inputCacheRead > 0', () => {
+    // scenario 1: 87% with k-suffix
+    const result = formatSubagentTokens({
+      inputOther: 1300,
+      inputCacheRead: 8700,
+      inputCacheCreation: 0,
+      output: 5000,
+    });
+    expect(result).toBe('15.0k tok (87%)');
+  });
+
+  it('omits cache suffix when inputCacheRead is 0', () => {
+    // scenario 2: hit rate = 0, no suffix
+    const result = formatSubagentTokens({
+      inputOther: 10000,
+      inputCacheRead: 0,
+      inputCacheCreation: 0,
+      output: 5000,
+    });
+    expect(result).toBe('15.0k tok');
+  });
+
+  it('omits cache suffix when all input breakdown fields are 0', () => {
+    // scenario 3: denominator = 0, computeCacheHitRate → undefined, no suffix
+    const result = formatSubagentTokens({
+      inputOther: 0,
+      inputCacheRead: 0,
+      inputCacheCreation: 0,
+      output: 5000,
+    });
+    expect(result).toBe('5.0k tok');
+  });
+
+  it('returns undefined for undefined input', () => {
+    // scenario 4
+    expect(formatSubagentTokens(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined when total tokens is 0', () => {
+    // scenario 5: all fields 0
+    const result = formatSubagentTokens({
+      inputOther: 0,
+      inputCacheRead: 0,
+      inputCacheCreation: 0,
+      output: 0,
+    });
+    expect(result).toBeUndefined();
+  });
+
+  it('formats percentage without decimals', () => {
+    // scenario 6: 88% exactly, no decimal
+    const result = formatSubagentTokens({
+      inputOther: 1200,
+      inputCacheRead: 8800,
+      inputCacheCreation: 0,
+      output: 5000,
+    });
+    expect(result).toBe('15.0k tok (88%)');
+  });
+
+  it('uses banker rounding for exact .5 ties', () => {
+    // scenario 7: 87.5 → 88 (round-half-to-even: 87 is odd, round up)
+    const result = formatSubagentTokens({
+      inputOther: 1250,
+      inputCacheRead: 8750,
+      inputCacheCreation: 0,
+      output: 5000,
+    });
+    expect(result).toBe('15.0k tok (88%)');
+  });
+
+  it('formats small token counts without k-suffix', () => {
+    // scenario 8: total < 1000, no k-suffix; 10/17 ≈ 59%
+    const result = formatSubagentTokens({
+      inputOther: 5,
+      inputCacheRead: 10,
+      inputCacheCreation: 2,
+      output: 3,
+    });
+    expect(result).toBe('20 tok (59%)');
+  });
+
+  it('computes hit rate with inputCacheCreation in denominator', () => {
+    // scenario 9: 5000 / (1000+5000+4000) = 50%
+    const result = formatSubagentTokens({
+      inputOther: 1000,
+      inputCacheRead: 5000,
+      inputCacheCreation: 4000,
+      output: 5000,
+    });
+    expect(result).toBe('15.0k tok (50%)');
+  });
+
+  it('skips cache suffix when legacy input field is present without breakdown', () => {
+    // scenario 10: legacy input, no breakdown fields — no suffix
+    const result = formatSubagentTokens({
+      input: 10000,
+      output: 5000,
+    });
+    expect(result).toBe('15.0k tok');
+  });
+
+  it('skips cache suffix when legacy input is present even with breakdown fields', () => {
+    // scenario 11: legacy input present, skip cache computation entirely
+    const result = formatSubagentTokens({
+      input: 10000,
+      inputOther: 1300,
+      inputCacheRead: 8700,
+      inputCacheCreation: 0,
+      output: 5000,
+    });
+    expect(result).toBe('15.0k tok');
+  });
+
+  it('rounds up to 100% when close to full cache read', () => {
+    // scenario 14: 24900/25000 = 99.6% → rounds to 100%
+    const result = formatSubagentTokens({
+      inputOther: 100,
+      inputCacheRead: 24900,
+      inputCacheCreation: 0,
+      output: 5000,
+    });
+    expect(result).toBe('30.0k tok (100%)');
+  });
+
+  it('hides suffix for tiny hit rates that round to 0%', () => {
+    // scenario 15: 50/10000 = 0.5% → banker's rounding → 0% → hidden
+    const result = formatSubagentTokens({
+      inputOther: 9950,
+      inputCacheRead: 50,
+      inputCacheCreation: 0,
+      output: 5000,
+    });
+    expect(result).toBe('15.0k tok');
   });
 });

--- a/apps/cli/test/tui/components/messages/usage-panel.test.ts
+++ b/apps/cli/test/tui/components/messages/usage-panel.test.ts
@@ -37,7 +37,7 @@ describe('UsagePanelComponent', () => {
     }).map(strip);
 
     expect(lines).toContain('Session usage');
-    expect(lines).toContain('  byf  input 2.0k  output 250  total 2.3k');
+    expect(lines).toContain('  byf  input 2.0k (cache 25%)  output 250  total 2.3k');
     expect(lines).toContain('Context window');
     expect(lines.join('\n')).toContain('25.0%');
     expect(lines).toContain('Plan usage');
@@ -63,5 +63,535 @@ describe('UsagePanelComponent', () => {
     for (const line of output) {
       expect(visibleWidth(line)).toBeLessThanOrEqual(width);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache hit-rate suffix — Acceptance Criterion #1: /usage panel per-model
+// and total-row (cache XX%) suffix
+// ---------------------------------------------------------------------------
+
+describe('buildUsageReportLines — cache hit-rate suffix', () => {
+  // ---- single model -------------------------------------------------------
+
+  it('shows cache suffix when model has substantial cache reads (70% hit rate)', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          'claude-sonnet': {
+            inputOther: 1000,
+            inputCacheRead: 7000,
+            inputCacheCreation: 2000,
+            output: 3000,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    expect(lines).toContain('Session usage');
+    const modelLine = lines.find((l) => l.includes('claude-sonnet'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).toContain('input 10.0k (cache 70%)');
+  });
+
+  it('omits cache suffix when all cache fields are 0', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          'gpt-5': {
+            inputOther: 1000,
+            inputCacheRead: 0,
+            inputCacheCreation: 0,
+            output: 500,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const modelLine = lines.find((l) => l.includes('gpt-5'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).toContain('input 1.0k');
+    expect(modelLine).not.toContain('(cache');
+  });
+
+  it('omits cache suffix for first turn (cache writes but no reads)', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          'claude-sonnet': {
+            inputOther: 8000,
+            inputCacheRead: 0,
+            inputCacheCreation: 2000,
+            output: 1000,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const modelLine = lines.find((l) => l.includes('claude-sonnet'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).toContain('input 10.0k');
+    expect(modelLine).not.toContain('(cache');
+  });
+
+  it('shows 100% cache when all input tokens served from cache', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          'claude-sonnet': {
+            inputOther: 0,
+            inputCacheRead: 5000,
+            inputCacheCreation: 0,
+            output: 2000,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const modelLine = lines.find((l) => l.includes('claude-sonnet'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).toContain('input 5.0k (cache 100%)');
+  });
+
+  it('shows 1% cache with very small hit rate', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          'claude-sonnet': {
+            inputOther: 9900,
+            inputCacheRead: 100,
+            inputCacheCreation: 0,
+            output: 500,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const modelLine = lines.find((l) => l.includes('claude-sonnet'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).toContain('input 10.0k (cache 1%)');
+  });
+
+  it('handles zero denominator — all input fields zero, shows "input 0" with no suffix', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          'claude-sonnet': {
+            inputOther: 0,
+            inputCacheRead: 0,
+            inputCacheCreation: 0,
+            output: 100,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const modelLine = lines.find((l) => l.includes('claude-sonnet'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).toContain('input 0');
+    expect(modelLine).not.toContain('(cache');
+  });
+
+  it('shows integer precision — 33.3% rounds down to 33%', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          model: {
+            inputOther: 333,
+            inputCacheRead: 333,
+            inputCacheCreation: 334,
+            output: 100,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const modelLine = lines.find((l) => l.includes('model'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).toContain('input 1.0k (cache 33%)');
+  });
+
+  it('rounds up — 99.6% rounds to 100%', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          model: {
+            inputOther: 4,
+            inputCacheRead: 996,
+            inputCacheCreation: 0,
+            output: 100,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const modelLine = lines.find((l) => l.includes('model'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).toContain('input 1.0k (cache 100%)');
+  });
+
+  it('rounds down — 99.4% rounds to 99%', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          model: {
+            inputOther: 6,
+            inputCacheRead: 994,
+            inputCacheCreation: 0,
+            output: 100,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const modelLine = lines.find((l) => l.includes('model'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).toContain('input 1.0k (cache 99%)');
+  });
+
+  it('omits cache suffix for provider without cache support', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          gemini: {
+            inputOther: 5000,
+            inputCacheRead: 0,
+            inputCacheCreation: 0,
+            output: 2000,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const modelLine = lines.find((l) => l.includes('gemini'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).toContain('input 5.0k');
+    expect(modelLine).not.toContain('(cache');
+  });
+
+  it('omits cache suffix when only cache creation, zero other input', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          model: {
+            inputOther: 0,
+            inputCacheRead: 0,
+            inputCacheCreation: 5000,
+            output: 1000,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const modelLine = lines.find((l) => l.includes('model'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).toContain('input 5.0k');
+    expect(modelLine).not.toContain('(cache');
+  });
+
+  it('shows M-scale formatting with cache suffix for large values', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          model: {
+            inputOther: 500000,
+            inputCacheRead: 1_500_000,
+            inputCacheCreation: 0,
+            output: 200000,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const modelLine = lines.find((l) => l.includes('model'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).toContain('input 2.0M (cache 75%)');
+  });
+
+  // ---- multi-model --------------------------------------------------------
+
+  it('mixed cache states — one cached model, one not, total shows aggregated hit rate', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          'claude-sonnet': {
+            inputOther: 2000,
+            inputCacheRead: 6000,
+            inputCacheCreation: 2000,
+            output: 1000,
+          },
+          'gpt-5': {
+            inputOther: 3000,
+            inputCacheRead: 0,
+            inputCacheCreation: 0,
+            output: 500,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const claudeLine = lines.find((l) => l.includes('claude-sonnet'));
+    expect(claudeLine).toBeDefined();
+    expect(claudeLine).toContain('input 10.0k (cache 60%)');
+
+    const gptLine = lines.find((l) => l.includes('gpt-5'));
+    expect(gptLine).toBeDefined();
+    expect(gptLine).toContain('input 3.0k');
+    expect(gptLine).not.toContain('(cache');
+
+    const totalLine = lines.find((l) => l.startsWith('  total'));
+    expect(totalLine).toBeDefined();
+    // 6000 / 13000 ≈ 46.15% → 46%
+    expect(totalLine).toContain('input 13.0k (cache 46%)');
+  });
+
+  it('multi-model, no cache at all — all rows and total omit suffix', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          a: {
+            inputOther: 1000,
+            inputCacheRead: 0,
+            inputCacheCreation: 0,
+            output: 500,
+          },
+          b: {
+            inputOther: 2000,
+            inputCacheRead: 0,
+            inputCacheCreation: 0,
+            output: 300,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    for (const model of ['a', 'b']) {
+      const modelLine = lines.find((l) => l.includes(`  ${model}`));
+      expect(modelLine).toBeDefined();
+      expect(modelLine).not.toContain('(cache');
+    }
+
+    const totalLine = lines.find((l) => l.startsWith('  total'));
+    expect(totalLine).toBeDefined();
+    expect(totalLine).not.toContain('(cache');
+  });
+
+  it('one model 100% cache, one model no cache — total shows aggregated', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          a: {
+            inputOther: 0,
+            inputCacheRead: 5000,
+            inputCacheCreation: 0,
+            output: 1000,
+          },
+          b: {
+            inputOther: 3000,
+            inputCacheRead: 0,
+            inputCacheCreation: 0,
+            output: 500,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const lineA = lines.find((l) => l.includes('  a'));
+    expect(lineA).toBeDefined();
+    expect(lineA).toContain('input 5.0k (cache 100%)');
+
+    const lineB = lines.find((l) => l.includes('  b'));
+    expect(lineB).toBeDefined();
+    expect(lineB).toContain('input 3.0k');
+    expect(lineB).not.toContain('(cache');
+
+    const totalLine = lines.find((l) => l.startsWith('  total'));
+    expect(totalLine).toBeDefined();
+    // 5000 / 8000 = 62.5% → 62%
+    expect(totalLine).toContain('input 8.0k (cache 62%)');
+  });
+
+  it('three models with different hit rates, total shows aggregated', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          a: {
+            inputOther: 1000,
+            inputCacheRead: 4000,
+            inputCacheCreation: 0,
+            output: 500,
+          },
+          b: {
+            inputOther: 2000,
+            inputCacheRead: 2000,
+            inputCacheCreation: 1000,
+            output: 300,
+          },
+          c: {
+            inputOther: 500,
+            inputCacheRead: 500,
+            inputCacheCreation: 9000,
+            output: 200,
+          },
+        },
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    const lineA = lines.find((l) => l.includes('  a'));
+    expect(lineA).toBeDefined();
+    // 4000 / 5000 = 80%
+    expect(lineA).toContain('input 5.0k (cache 80%)');
+
+    const lineB = lines.find((l) => l.includes('  b'));
+    expect(lineB).toBeDefined();
+    // 2000 / 5000 = 40%
+    expect(lineB).toContain('input 5.0k (cache 40%)');
+
+    const lineC = lines.find((l) => l.includes('  c'));
+    expect(lineC).toBeDefined();
+    // 500 / 10000 = 5%
+    expect(lineC).toContain('input 10.0k (cache 5%)');
+
+    const totalLine = lines.find((l) => l.startsWith('  total'));
+    expect(totalLine).toBeDefined();
+    // total cache read = 4000 + 2000 + 500 = 6500
+    // total input = 5000 + 5000 + 10000 = 20000
+    // 6500 / 20000 = 32.5% → 32%
+    expect(totalLine).toContain('input 20.0k (cache 32%)');
+  });
+
+  // ---- regression and error states ----------------------------------------
+
+  it('full output preserved when no cache data — no regression', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {
+          byf: {
+            inputOther: 1000,
+            inputCacheRead: 0,
+            inputCacheCreation: 0,
+            output: 250,
+          },
+        },
+      } as never,
+      contextUsage: 0.25,
+      contextTokens: 2500,
+      maxContextTokens: 10000,
+      managedUsage: {
+        summary: {
+          label: 'daily',
+          used: 20,
+          limit: 100,
+          resetHint: 'resets tomorrow',
+        },
+        limits: [],
+      },
+    }).map(strip);
+
+    expect(lines).toContain('Session usage');
+    expect(lines).toContain('Context window');
+    expect(lines.join('\n')).toContain('25.0%');
+    expect(lines).toContain('Plan usage');
+    expect(lines.join('\n')).toContain('80% left');
+    expect(lines.join('\n')).toContain('(resets tomorrow)');
+
+    const modelLine = lines.find((l) => l.includes('byf'));
+    expect(modelLine).toBeDefined();
+    expect(modelLine).not.toContain('(cache');
+  });
+
+  it('shows error message when sessionUsageError present', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsageError: 'Failed to fetch usage',
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    expect(lines).toContain('  Failed to fetch usage');
+    // No cache-related content should appear in error path
+    expect(lines.join('\n')).not.toContain('(cache');
+  });
+
+  it('shows empty message when byModel has no models recorded', () => {
+    const lines = buildUsageReportLines({
+      colors: darkColors,
+      sessionUsage: {
+        byModel: {},
+      } as never,
+      contextUsage: 0,
+      contextTokens: 0,
+      maxContextTokens: 0,
+    }).map(strip);
+
+    expect(lines).toContain('  No token usage recorded yet.');
+    // No cache-related content should appear in empty path
+    expect(lines.join('\n')).not.toContain('(cache');
   });
 });

--- a/apps/cli/test/tui/events/session-meta-handler.test.ts
+++ b/apps/cli/test/tui/events/session-meta-handler.test.ts
@@ -17,6 +17,7 @@ import {
   type SessionMetaCallbacks,
   type SessionMetaState,
 } from '#/tui/events/session-meta-handler';
+import { computeCacheHitRate } from '#/utils/usage/usage-format';
 
 const OAUTH_LOGIN_REQUIRED_CODE = 'auth.login_required';
 
@@ -107,6 +108,159 @@ describe('handleStatusUpdate', () => {
     expect(setAppState).not.toHaveBeenCalled();
   });
 
+  // ── cache hit-rate: data plumbing from event.usage.currentTurn ──
+
+  it('A1: computes cacheHitRate from currentTurn with cache reads', () => {
+    const setAppState = vi.fn();
+    const event: AgentStatusUpdatedEvent = {
+      type: 'agent.status.updated',
+      usage: {
+        currentTurn: { inputOther: 500, inputCacheRead: 8700, inputCacheCreation: 0 } as never,
+      },
+    };
+    handleStatusUpdate(event, setAppState);
+    expect(setAppState).toHaveBeenCalledOnce();
+    const patch = setAppState.mock.calls[0]![0];
+    expect(patch).toHaveProperty('cacheHitRate');
+    expect(patch.cacheHitRate!).toBeCloseTo(0.9457, 4);
+  });
+
+  it('A2: computes cacheHitRate = 0 when no reads (first turn)', () => {
+    const setAppState = vi.fn();
+    const event: AgentStatusUpdatedEvent = {
+      type: 'agent.status.updated',
+      usage: {
+        currentTurn: { inputOther: 10000, inputCacheRead: 0, inputCacheCreation: 2000 } as never,
+      },
+    };
+    handleStatusUpdate(event, setAppState);
+    expect(setAppState).toHaveBeenCalledOnce();
+    const patch = setAppState.mock.calls[0]![0];
+    expect(patch).toHaveProperty('cacheHitRate');
+    expect(patch.cacheHitRate).toBe(0);
+  });
+
+  it('A3: returns cacheHitRate = undefined when denominator is zero', () => {
+    const setAppState = vi.fn();
+    const event: AgentStatusUpdatedEvent = {
+      type: 'agent.status.updated',
+      usage: {
+        currentTurn: { inputOther: 0, inputCacheRead: 0, inputCacheCreation: 0 } as never,
+      },
+    };
+    handleStatusUpdate(event, setAppState);
+    expect(setAppState).toHaveBeenCalledOnce();
+    const patch = setAppState.mock.calls[0]![0];
+    expect(patch).toHaveProperty('cacheHitRate');
+    expect(patch.cacheHitRate).toBeUndefined();
+  });
+
+  it('A4: does not include cacheHitRate when usage is undefined', () => {
+    const setAppState = vi.fn();
+    const event: AgentStatusUpdatedEvent = {
+      type: 'agent.status.updated',
+      usage: undefined,
+    };
+    handleStatusUpdate(event, setAppState);
+    // No other fields, so patch is empty → no setAppState call
+    expect(setAppState).not.toHaveBeenCalled();
+  });
+
+  it('A5: does not include cacheHitRate when currentTurn is undefined', () => {
+    const setAppState = vi.fn();
+    const event: AgentStatusUpdatedEvent = {
+      type: 'agent.status.updated',
+      usage: { currentTurn: undefined },
+    };
+    handleStatusUpdate(event, setAppState);
+    // No other fields, so patch is empty → no setAppState call
+    expect(setAppState).not.toHaveBeenCalled();
+  });
+
+  it('A6: all fields coexist with cacheHitRate: 0.7', () => {
+    const setAppState = vi.fn();
+    const event: AgentStatusUpdatedEvent = {
+      type: 'agent.status.updated',
+      contextUsage: 0.42,
+      contextTokens: 4200,
+      maxContextTokens: 10000,
+      permission: 'auto',
+      model: 'claude-sonnet',
+      usage: {
+        currentTurn: { inputOther: 300, inputCacheRead: 700, inputCacheCreation: 0 } as never,
+      },
+    };
+    handleStatusUpdate(event, setAppState);
+    expect(setAppState).toHaveBeenCalledOnce();
+    const patch = setAppState.mock.calls[0]![0];
+    expect(patch.contextUsage).toBe(0.42);
+    expect(patch.contextTokens).toBe(4200);
+    expect(patch.maxContextTokens).toBe(10000);
+    expect(patch.permissionMode).toBe('auto');
+    expect(patch.yolo).toBe(false);
+    expect(patch.model).toBe('claude-sonnet');
+    expect(patch).toHaveProperty('cacheHitRate');
+    expect(patch.cacheHitRate).toBe(0.7);
+  });
+
+  it('A7: only old fields, no usage — patch identical to pre-change behavior', () => {
+    const setAppState = vi.fn();
+    const event: AgentStatusUpdatedEvent = {
+      type: 'agent.status.updated',
+      contextUsage: 0.65,
+      permission: 'auto',
+    };
+    handleStatusUpdate(event, setAppState);
+    expect(setAppState).toHaveBeenCalledOnce();
+    const patch = setAppState.mock.calls[0]![0];
+    expect(patch.contextUsage).toBe(0.65);
+    expect(patch.permissionMode).toBe('auto');
+    expect(patch.yolo).toBe(false);
+    expect(patch).not.toHaveProperty('cacheHitRate');
+  });
+
+  it('A8: 100% cache hit rate', () => {
+    const setAppState = vi.fn();
+    const event: AgentStatusUpdatedEvent = {
+      type: 'agent.status.updated',
+      usage: {
+        currentTurn: { inputOther: 0, inputCacheRead: 5000, inputCacheCreation: 0 } as never,
+      },
+    };
+    handleStatusUpdate(event, setAppState);
+    expect(setAppState).toHaveBeenCalledOnce();
+    const patch = setAppState.mock.calls[0]![0];
+    expect(patch).toHaveProperty('cacheHitRate');
+    expect(patch.cacheHitRate).toBe(1.0);
+  });
+
+  it('A9: 1% hit rate', () => {
+    const setAppState = vi.fn();
+    const event: AgentStatusUpdatedEvent = {
+      type: 'agent.status.updated',
+      usage: {
+        currentTurn: { inputOther: 9900, inputCacheRead: 100, inputCacheCreation: 0 } as never,
+      },
+    };
+    handleStatusUpdate(event, setAppState);
+    expect(setAppState).toHaveBeenCalledOnce();
+    const patch = setAppState.mock.calls[0]![0];
+    expect(patch).toHaveProperty('cacheHitRate');
+    expect(patch.cacheHitRate!).toBeCloseTo(0.01, 4);
+  });
+
+  it('A10: no usage key — existing fields extracted, no cacheHitRate', () => {
+    const setAppState = vi.fn();
+    const event: AgentStatusUpdatedEvent = {
+      type: 'agent.status.updated',
+      contextTokens: 12345,
+    };
+    handleStatusUpdate(event, setAppState);
+    expect(setAppState).toHaveBeenCalledOnce();
+    const patch = setAppState.mock.calls[0]![0];
+    expect(patch.contextTokens).toBe(12345);
+    expect(patch).not.toHaveProperty('cacheHitRate');
+  });
 
 });
 

--- a/apps/cli/test/utils/usage/usage-format.test.ts
+++ b/apps/cli/test/utils/usage/usage-format.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from 'vitest';
 
 import {
+  computeCacheHitRate,
+  formatCacheHitRate,
   formatTokenCount,
   renderProgressBar,
   ratioSeverity,
@@ -57,6 +59,62 @@ describe('safeUsageRatio', () => {
     expect(safeUsageRatio(-1)).toBe(0);
     expect(safeUsageRatio(0.427)).toBe(0.427);
     expect(safeUsageRatio(1.5)).toBe(1);
+  });
+});
+
+describe('computeCacheHitRate', () => {
+  it('computes cache hit rate from uncached input and cache reads', () => {
+    expect(computeCacheHitRate(500, 8_700, 0)).toBeCloseTo(0.9457, 3);
+  });
+
+  it('returns undefined when all inputs are zero (no data)', () => {
+    expect(computeCacheHitRate(0, 0, 0)).toBeUndefined();
+  });
+
+  it('returns 0 when cache reads are zero but other inputs exist', () => {
+    expect(computeCacheHitRate(8000, 0, 2000)).toBe(0);
+  });
+
+  it('returns 1.0 when all input is from cache reads', () => {
+    expect(computeCacheHitRate(0, 5000, 0)).toBe(1);
+  });
+
+  it('includes cache creation in denominator', () => {
+    // 5000 / (1000 + 5000 + 4000) = 0.5
+    expect(computeCacheHitRate(1000, 5000, 4000)).toBeCloseTo(0.5, 3);
+  });
+});
+
+describe('formatCacheHitRate', () => {
+  it('returns undefined for undefined rate', () => {
+    expect(formatCacheHitRate(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for rate <= 0', () => {
+    expect(formatCacheHitRate(0)).toBeUndefined();
+    expect(formatCacheHitRate(-0.5)).toBeUndefined();
+  });
+
+  it('returns undefined when rounded percentage is 0 (too small to display)', () => {
+    // 0.5% → banker's rounding → 0% → hidden
+    expect(formatCacheHitRate(0.005)).toBeUndefined();
+  });
+
+  it('formats as integer percentage string', () => {
+    expect(formatCacheHitRate(0.87)).toBe('87%');
+    expect(formatCacheHitRate(1)).toBe('100%');
+    expect(formatCacheHitRate(0.01)).toBe('1%');
+  });
+
+  it('does not include decimal places', () => {
+    expect(formatCacheHitRate(0.873)).toBe('87%');
+    expect(formatCacheHitRate(0.337)).toBe('34%');
+  });
+
+  it('uses banker rounding for .5 ties (rounds to even)', () => {
+    // 86.5 → 86 (even), 87.5 → 88 (even)
+    expect(formatCacheHitRate(0.865)).toBe('86%');
+    expect(formatCacheHitRate(0.875)).toBe('88%');
   });
 });
 

--- a/docs/prd/cache-observability-cli.md
+++ b/docs/prd/cache-observability-cli.md
@@ -1,0 +1,300 @@
+# PRD: 缓存可观测性增强 — CLI Usage 面板
+
+## Child Issues
+
+- #126 — `cache hit rate foundation` — helpers + AppState + session-meta-handler (AFK)
+- #127 — `footer cache hit-rate badge` — footer Line 2 cache badge (AFK, blocked by #126)
+- #128 — `/usage panel cache hit-rate` — per-model and total-row cache suffixes (AFK, blocked by #126)
+- #129 — `/status panel cache health section` — session-level Cache section (AFK, blocked by #126)
+- #130 — `subagent chip cache hit-rate suffix` — running/done subagent token chip suffix (AFK, blocked by #126)
+
+## 问题陈述
+
+### 背景
+
+BYF 的 prompt cache 架构（ADR 0009 + ADR 0011 + ephemeral-injection-cache-optimization）已实现多层级缓存策略。数据管道已经端到端完成：
+
+- **Provider 层**：所有 provider 适配器（Anthropic、OpenAI、Google）已解析并填充 `inputCacheRead` / `inputCacheCreation` 字段
+- **kosong 层**：`TokenUsage` 接口定义了完整的四字段模型（`inputOther` / `output` / `inputCacheRead` / `inputCacheCreation`），并提供 `cacheHitRate()` branded helper
+- **agent-core 层**：`UsageRecorder` 在每次 LLM completion 时聚合 per-model 用量，并计算 `UsageStatus.cacheHitRate`
+- **SDK 层**：`AgentStatusUpdatedEvent.usage?: UsageStatus` 携带 live cache 数据流；`SessionUsage` 携带完整 `TokenUsage` 结构
+
+### 核心问题
+
+CLI 展示层完全未利用已有的缓存数据：
+
+1. **`/usage` 面板**：`buildSessionUsageSection()` 将 `inputCacheRead + inputCacheCreation + inputOther` 折叠为单个 `input` 聚合值，不显示缓存命中率或分项
+2. **Footer**：`handleStatusUpdate()` **完全忽略** `event.usage`——仅提取 `contextUsage` / `contextTokens` / `maxContextTokens` / `permission` / `model`。`AppState` 中无任何缓存字段
+3. **`/status` 面板**：展示 context window 和 managed usage，无缓存信息
+4. **Subagent chip**：`SubagentTokenUsage` 接口已声明 `inputCacheRead` / `inputCacheCreation` / `inputOther` 字段，但 `formatSubagentTokens()` 仅输出 `Xk tok`
+
+**结论**：数据管道 100% 到位，这是一个纯展示层增强。
+
+### 与既有 PRD 的关系
+
+`docs/prd/ephemeral-injection-cache-optimization.md` 在"非目标"中明确列出：
+
+> 缓存可观测性增强（`inputCacheCreation` 估算 / Vis 展示）— 后续 follow-up
+
+本 PRD 是该 follow-up 的 CLI 展示部分。
+
+## 目标
+
+在四个 CLI UI surface 上展示缓存命中率，让用户感知缓存效率：
+
+1. **`/usage` 面板**：每个 model 行追加 `(cache XX%)` 后缀（命中率 > 0% 时）
+2. **Footer Line 2**：在 context 指标后追加 `cache: XX%`（命中率 > 0% 时；首轮 / 无缓存 provider 时隐藏）
+3. **`/status` 面板**：添加 `Cache` 字段行，显示命中率 + read/write 分项
+4. **Subagent chip**：`Xk tok` 后追加 `(XX%)` 后缀（cache read > 0 时）
+
+## 非目标 (Out of Scope)
+
+- 成本 / 定价显示（cache 数据是其前置依赖，但本次不构建）
+- Vis 工具的缓存可视化展示（独立 scope）
+- Cache staking 调试 UI（`CacheHint` 标记可见性，ADR 0011 Story #12，独立功能）
+- Provider / SDK 侧的数据变更（所有数据已存在）
+- 新增 slash command
+
+## 技术方案
+
+### 数据流：Footer per-turn hit rate
+
+**当前状态**：`AgentStatusUpdatedEvent` 携带 `usage?: UsageStatus`（含 `total`、`currentTurn`、`cacheHitRate`），但 CLI 的 `handleStatusUpdate()` 完全忽略 `event.usage`。
+
+**关键语义区分**：`UsageStatus.cacheHitRate` 是 **session 累积值**（基于 `total`），会被首轮 cache creation 永久拉低。Footer 需要的是 **per-turn hit rate**（反映"刚才那一步的缓存效率"），应从 `event.usage.currentTurn` 自行计算。
+
+**变更**：
+
+1. `AppState` 新增 `cacheHitRate?: number` 字段（0..1 ratio 或 `undefined`）
+2. `handleStatusUpdate()` 从 `event.usage.currentTurn` 提取 `TokenUsage`，用 `computeCacheHitRate()` 自行计算 per-turn hit rate
+3. Footer 从 `state.cacheHitRate` 读取并渲染
+
+```typescript
+// session-meta-handler.ts — 变更前
+if (event.contextUsage !== undefined) patch.contextUsage = event.contextUsage;
+// ... 完全忽略 event.usage
+
+// 变更后
+if (event.contextUsage !== undefined) patch.contextUsage = event.contextUsage;
+const ct = event.usage?.currentTurn;
+if (ct !== undefined) {
+  patch.cacheHitRate = computeCacheHitRate(ct.inputOther, ct.inputCacheRead, ct.inputCacheCreation);
+}
+// currentTurn === undefined（新 turn 刚开始）时不清除 cacheHitRate——
+// footer 保持上一轮的值，避免 badge 闪烁消失
+```
+
+**Turn gap 行为**：`beginTurn()`/`endTurn()` 不触发 status event，但 context append（用户消息追加）会触发。此时 `currentTurn` 为 `undefined`。`handleStatusUpdate()` 仅在 `currentTurn !== undefined` 时更新 `cacheHitRate`，不清除——footer 保持上一轮值，直到新 turn 的第一个 step 完成后刷新。
+
+**更新频率**：cache hit rate 在 **per-step**（每次 LLM completion 后）刷新，不是 streaming 中逐 token 更新。这与 context 百分比的行为一致。
+
+**SDK 约束**：SDK 不 re-export kosong 的 `cacheHitRate()` 函数，且 AGENTS.md 禁止 CLI 直接 import `@byfriends/kosong`。CLI 必须在 `usage-format.ts` 中自行实现 `computeCacheHitRate()`——这不是可选方案，是架构约束下的唯一路径。
+
+### Surface 1: `/usage` 面板 — Hit-rate compact
+
+**文件**：`src/tui/components/messages/usage-panel.ts` → `buildSessionUsageSection()`
+
+**当前输出**（每个 model 行）：
+```
+  claude-sonnet-4-20250514  input 12.3k  output 3.2k  total 15.5k
+```
+
+**变更后输出**（cache hit-rate > 0% 时）：
+```
+  claude-sonnet-4-20250514  input 12.3k (cache 87%)  output 3.2k  total 15.5k
+```
+
+cache hit-rate = 0% 或无数据时省略 `(cache XX%)`，保持当前格式。
+
+**实现**：在 `buildSessionUsageSection()` 中，为每个 model 行用 `computeCacheHitRate(row.inputOther, row.inputCacheRead, row.inputCacheCreation)` 计算 hit rate，若 `formatCacheHitRate(hitRate)` 非 `undefined` 则在 `input {value}` 后插入 `muted(' (cache ') + accent(formatCacheHitRate(hitRate)) + muted(')')`。
+
+多 model 总计行：当前只追踪 `totalInput` / `totalOutput`，需额外追踪 `totalCacheRead` / `totalCacheCreation` / `totalOther`，再用 `computeCacheHitRate(totalOther, totalCacheRead, totalCacheCreation)` 计算聚合 hit rate。
+
+### Surface 2: Footer Line 2 — Inline cache badge
+
+**文件**：`src/tui/components/chrome/footer.ts` → `render()`
+
+**当前输出**（Line 2）：
+```
+                                    context: 45.2% (22k/48k)
+```
+
+**变更后输出**（`cacheHitRate > 0` 时）：
+```
+                                    context: 45.2% (22k/48k)  cache: 87%
+```
+
+`cacheHitRate = 0` 或 `undefined` 时省略 `cache: XX%`。
+
+**实现**：
+- `formatContextStatus()` **不修改**——保持返回纯文本的现有模式，由 caller 统一着色
+- 在 `render()` 中构建 cache badge 字符串：`formatCacheHitRate(state.cacheHitRate)` 返回值非 `undefined` 时，用 `chalk.hex(colors.textDim)` 着色为 `  cache: 87%`，追加在 contextText 之后
+- `contextWidth` 需包含 cache badge 宽度，以保证 transient hint 模式下的右对齐计算正确
+- cache badge 使用 `colors.textDim` 着色（不与 context 的 `colors.text` 竞争视觉重心）
+
+**着色分离原因**：context 文本由 `render()` 统一用 `colors.text` 着色；cache badge 需要 `textDim`。两种颜色不能在同一个 `formatContextStatus()` 返回值中混合（该函数返回纯文本，caller 统一着色）。因此在 `render()` 中分别构建、着色、拼接，保持 `formatContextStatus()` 职责单一。
+
+**Transient hint 交互**：Line 2 有 transient hint 模式（如退出确认 "Press Ctrl+C again to exit"），hint 左对齐，context 右对齐。cache badge 追加在 context 右侧，`contextWidth` 需包含 badge 宽度。当 hint + context + badge 超过终端宽度时，hint 会被截断（已有逻辑），cache badge 不受影响。
+
+### Surface 3: `/status` 面板 — Cache field row
+
+**文件**：`src/tui/components/messages/status-panel.ts` → `buildStatusReportLines()`
+
+**代码验证发现**：`buildStatusReportLines()` 当前完全不读取 `options.status.usage`——连基本的 input/output/total token 都没有展示。`SessionStatus.usage`（`SessionUsage`）通过 `session.getStatus()` → RPC `getUsage()` 获取并填充了完整数据，但 status 面板丢弃了它。
+
+**当前字段行**：Model / Directory / Permissions / Session / [Title] → Context window section → (empty managed usage)
+
+**变更后**：在 context window section 之后新增 `Cache` section（有缓存数据时）：
+
+```
+  Cache    87%  (10.7k read / 0.6k write)
+```
+
+无缓存数据时省略整个 section。
+
+**数据来源**：`StatusReportOptions.status.usage.total`（`TokenUsage`，session 累积）。从 `total` 用 `computeCacheHitRate()` 计算 session 级 hit rate，并展示 `inputCacheRead` / `inputCacheCreation` 分项。
+
+**注意**：`/status` 展示的是 session 累积值（与 footer 的 per-turn 不同），因为 `/status` 是"会话健康度"快照，不是实时状态。
+
+### Subagent chip — Compact percentage
+
+**文件**：`src/tui/components/messages/tool-call.ts` → `formatSubagentTokens()`
+
+**当前输出**：`15.5k tok`
+
+**变更后输出**（`inputCacheRead > 0` 时）：
+```
+15.5k tok (87%)
+```
+
+**数据来源**：`formatSubagentTokens()` 从已存储的 `SubagentTokenUsage`（含 `inputCacheRead` / `inputCacheCreation` / `inputOther`）中用 `computeCacheHitRate()` 计算 hit rate，追加 `(XX%)` 后缀。
+
+**实时与最终两种 phase**：`formatSubagentTokens()` 在两个 phase 被调用：
+- **Running phase**（`formatPhaseChip` line 1106）：live 累积 token 数，由 `updateSubagentLiveUsage()` 从 `agent.status.updated` 事件持续更新。chip 中的 `(XX%)` 也是实时的。
+- **Done phase**（`formatPhaseChip` line 1114）：最终累积值，由 `onSubagentCompleted()` 从 `subagent.completed.usage.total` 设置。
+
+两种 phase 的 `(XX%)` 都基于当前 `subagentUsage` 中累积的 `TokenUsage` 计算，语义一致（都是"子 agent 截至当前的累积缓存效率"）。
+
+### 共享格式化 helper
+
+**文件**：`src/utils/usage/usage-format.ts`
+
+新增纯函数：
+```typescript
+/**
+ * 格式化 cache hit rate 为百分比字符串，如 "87%"。
+ * rate === undefined 或 rate <= 0 时返回 undefined（信号"不显示"）。
+ */
+export function formatCacheHitRate(rate: number | undefined): string | undefined
+
+/**
+ * 计算 cache hit rate (0..1)。
+ * 公式: inputCacheRead / (inputOther + inputCacheRead + inputCacheCreation)
+ * 全零输入（分母 = 0）时返回 undefined——与 kosong cacheHitRate() 语义一致，
+ * 让下游区分"无数据"和"零命中"。
+ */
+export function computeCacheHitRate(inputOther: number, inputCacheRead: number, inputCacheCreation: number): number | undefined
+```
+
+遵循既有 `usage-format.ts` 的设计原则：纯函数、无 ANSI、可单元测试。
+
+### 文件变更总览
+
+| 文件 | 变更类型 | 内容 |
+|---|---|---|
+| `src/tui/types.ts` | 修改 | `AppState` 添加 `cacheHitRate?: number` |
+| `src/tui/events/session-meta-handler.ts` | 修改 | `handleStatusUpdate()` 从 `event.usage.currentTurn` 计算 per-turn hit rate |
+| `src/tui/components/chrome/footer.ts` | 修改 | Line 2 追加 `cache: XX%`（从 `state.cacheHitRate`，per-turn） |
+| `src/tui/components/messages/usage-panel.ts` | 修改 | 每个 model 行追加 `(cache XX%)` 后缀（session 累积） |
+| `src/tui/components/messages/status-panel.ts` | 修改 | 新增 Cache section（从 `status.usage.total`，session 累积） |
+| `src/tui/components/messages/tool-call.ts` | 修改 | `formatSubagentTokens()` 追加 `(XX%)`（子 agent 累积） |
+| `src/utils/usage/usage-format.ts` | 修改 | 新增 `formatCacheHitRate()` / `computeCacheHitRate()` |
+| `test/tui/components/usage-panel.test.ts` | 修改 | 验证 cache hit-rate 后缀渲染和边界 |
+| `test/utils/usage-format.test.ts` | 修改 | 验证 `formatCacheHitRate` / `computeCacheHitRate` |
+| `test/tui/components/status-panel.test.ts` | 修改 | 验证 Cache section 渲染 |
+| `test/tui/components/messages/tool-call.test.ts` | 修改 | 验证 subagent chip cache 后缀 |
+
+## 验收标准
+
+### 功能正确性
+
+1. **`/usage` 面板**：当 model 行的 cache hit rate > 0 时，`input {value}` 后显示 `(cache XX%)`（session 累积值）；命中率 = 0 或无数据时保持当前格式不变
+2. **`/usage` 面板**：多 model 总计行在有缓存数据时同样显示聚合 session 级命中率
+3. **Footer Line 2**：`state.cacheHitRate > 0` 时（per-turn 值），context 指标后显示 `cache: XX%`；为 0 或 `undefined` 时省略
+4. **`/status` 面板**：`status.usage.total` 有缓存数据时显示 `Cache` section（session 级 hit-rate % + read/write 分项）；无数据时省略
+5. **Subagent chip**：`inputCacheRead > 0` 时 `Xk tok` 后追加 `(XX%)`（子 agent 累积值）；为 0 时保持当前格式
+6. **`handleStatusUpdate()`** 从 `event.usage.currentTurn` 用 `computeCacheHitRate()` 计算 per-turn hit rate 并写入 `patch.cacheHitRate`
+7. **精度**：所有 cache hit rate 百分比使用整数格式（`87%`，非 `87.0%`）
+8. **着色**：所有 surface 的 cache 信息使用 `textDim`/`muted` 着色，不使用 severity 着色
+
+### 边界情况
+
+9. **首轮（cache 正在写入，无命中）**：per-turn hit-rate = 0%，footer 隐藏 cache badge；`/usage` 面板省略 `(cache XX%)`
+10. **Turn gap（新 turn 开始，currentTurn=undefined）**：footer 保持上一轮的 cache badge 值，不闪烁消失；新 turn 第一个 step 完成后刷新
+11. **Provider 不支持缓存**（所有 cache 字段 = 0）：所有 surface 隐藏缓存信息，行为与首轮相同
+12. **恢复的 session**：usage 数据从 records 重放恢复（scope='session'，不重建 currentTurn），footer 在首个 turn 完成前无 per-turn 数据，面板的 session 累积值正常展示
+13. **`/compact` 之后**：聚合 usage 持续存在；per-turn hit rate 在新 turn 完成后恢复正常
+
+### 主题合规
+
+14. 所有新增的颜色输出使用 `colors.*` 语义 token，不使用 chalk named color
+15. Footer cache badge 使用 `colors.textDim`（不与 context 指标的 `colors.text` 竞争视觉重心）
+16. `/usage` 面板的 `(cache XX%)` 使用 `muted` 着色保持低噪声
+
+### 不回归
+
+17. **`/usage` 面板**在无缓存数据时的输出与当前完全一致
+18. **Footer** 在 `cacheHitRate = undefined` 时的输出与当前完全一致
+19. **Subagent chip** 在 `inputCacheRead = 0` 时的输出与当前完全一致
+20. **`handleStatusUpdate()`** 的现有字段提取逻辑不受影响
+
+## 风险与缓解
+
+| 风险 | 影响 | 缓解 |
+|---|---|---|
+| Footer Line 2 空间不足 | 窄终端下 `cache: XX%` 可能溢出 | 优先保证 context 指标完整；cache badge 在剩余空间不足时截断或省略 |
+| 恢复 session 后 currentTurn 为空 | footer 在首个 turn 完成前无 per-turn 数据 | footer 保持 `undefined`（隐藏 badge），用户无感知；session 累积数据在面板中正常 |
+| `AgentStatusUpdatedEvent.usage` 在某些场景未填充 | footer 可能不显示 cache badge | 首选 fallback 为不显示（当前行为），用户无感知 |
+
+## 关键决策记录
+
+| 决策 | 结论 | 理由 |
+|---|---|---|
+| Footer hit rate 语义 | **per-turn**（从 `currentTurn` 计算） | Footer 是"当前状态"指示器。Session 累积值被首轮 cache creation 永久拉低（如 turn 2 实际 91.8% 但 session 级仅 47.8%），不能反映实时缓存效率 |
+| 面板 hit rate 语义 | **session 累积** | `/usage` 和 `/status` 是"会话健康度"快照，session 累积值反映整体缓存投资回报 |
+| Turn gap 行为 | **保持上一轮值** | `beginTurn()`/`endTurn()` 不触发事件，但 context append 会。`currentTurn=undefined` 时不清除 `cacheHitRate`，避免 badge 闪烁 |
+| 无 severity 着色 | 统一 `textDim`/`muted` | Cache hit rate 是参考信息不是警示指标——30% 不代表危险，90% 也不是成就。避免误导 |
+| 精度格式 | 整数 `87%` | Cache hit rate 不需要小数精度。更短，footer 空间更友好 |
+| Subagent chip 数据源 | 子 agent 当前累积 `TokenUsage`（running 和 done phase 共用） | `formatSubagentTokens()` 在两个 phase 都被调用。running phase 用 `updateSubagentLiveUsage()` 持续更新的累积值；done phase 用 `onSubagentCompleted()` 设置的最终值。两种 phase 都从当前 `subagentUsage` 计算 hit rate |
+| `/status` 范围 | 仅加 Cache 行 | Token 使用量详情是 `/usage` 的职责。`/status` 保持 session 元信息 + context window 定位 |
+| CLI 自行实现 `computeCacheHitRate()` | 不 import `@byfriends/kosong` | AGENTS.md 约束 CLI 只通过 `@byfriends/sdk` 访问核心能力；SDK 不 re-export kosong 的 `cacheHitRate()` |
+| Footer cache badge 构建 | 在 `render()` 中拼接，不改 `formatContextStatus()` | `formatContextStatus()` 返回纯文本由 caller 统一用 `colors.text` 着色。cache badge 需要 `textDim`，颜色不同。在 `render()` 中分别构建、着色、拼接，保持函数职责单一 |
+| `computeCacheHitRate` 全零返回值 | `undefined`（非 0） | 与 kosong `cacheHitRate()` 语义一致：区分"无数据"和"零命中"。下游用 `formatCacheHitRate(rate) !== undefined` 判断是否显示 |
+
+## 实现计划
+
+| 阶段 | 任务 | 依赖 |
+|---|---|---|
+| 1 | `usage-format.ts` 新增 `formatCacheHitRate()` / `computeCacheHitRate()` + 测试 | 无 |
+| 2 | `types.ts` 添加 `AppState.cacheHitRate` + `session-meta-handler.ts` 提取逻辑（从 `currentTurn` 计算） | 阶段 1 |
+| 3 | Footer Line 2 追加 cache badge | 阶段 2 |
+| 4 | `/usage` 面板每行追加 `(cache XX%)`（session 累积） | 阶段 1 |
+| 5 | `/status` 面板新增 Cache section（从 `status.usage.total`） | 阶段 1 |
+| 6 | Subagent chip 追加 `(XX%)`（从 `subagent.completed.usage`） | 阶段 1 |
+| 7 | 全部测试通过 + 主题合规检查 | 全部 |
+
+## Domain Terms
+
+| 术语 | 定义 | 来源 |
+|---|---|---|
+| Cache Hit Rate | `inputCacheRead / (inputOther + inputCacheRead + inputCacheCreation)`。两个 scope：**per-turn**（仅当前 turn 的 `TokenUsage`，反映"刚才的缓存效率"）和 **session-cumulative**（所有 turn 的聚合 `TokenUsage`，反映"整体缓存健康度"）。Per-turn 值在首轮之后通常更高，因为排除了首轮 cache creation 的永久拉低效应 | kosong `cacheHitRate()`（session 级）；CLI `computeCacheHitRate()`（per-turn 和 session 级通用） |
+
+CONTEXT.md 中已新增 "Cache Hit Rate" 条目。
+
+## Expansion Considerations
+
+### Future Evolution
+
+- **成本 / 定价显示**：cache read tokens 的单价通常远低于 uncached input（Anthropic ~10%），展示成本需 cache 分项作为前置数据
+- **Vis 工具集成**：将 cache hit-rate 趋势可视化在 `apps/vis` 的 session replay 中
+- **Cache staking 调试**：在 transcript 中标注 `CacheHint` 标记的 message（ADR 0011 Story #12）


### PR DESCRIPTION
## Problem

BYF 的 prompt cache 架构（ADR 0009 + 0011 + ephemeral-injection-cache-optimization）已完成数据管道端到端实现，但 CLI 展示层完全未利用已有的缓存数据。用户无法感知缓存效率。

## Changes

在四个 CLI UI surface 上展示缓存命中率：

1. **`/usage` 面板**：每个 model 行追加 `(cache XX%)` 后缀（命中率 > 0% 时），总计行显示聚合命中率
2. **Footer Line 2**：在 context 指标后追加 `cache: XX%`（per-turn 命中率 > 0% 时）
3. **`/status` 面板**：新增 Cache section，显示 session 级命中率 + read/write 分项
4. **Subagent chip**：`Xk tok` 后追加 `(XX%)` 后缀（cache read > 0 时）

### 新增共享 helper（`usage-format.ts`）
- `computeCacheHitRate(inputOther, inputCacheRead, inputCacheCreation)` — 纯函数，分母为零时返回 `undefined`
- `formatCacheHitRate(rate)` — 整数百分比，banker's rounding，返回 `undefined` 表示"不显示"
- `safeNumber(value)` — RPC/序列化值的防御性数字转换

### 关键设计决策
- **Footer 使用 per-turn hit rate**（从 `currentTurn` 计算），反映"刚才那一步的缓存效率"
- **面板使用 session-cumulative hit rate**（从 `total` 计算），反映"整体缓存健康度"
- **Turn gap 行为**：`currentTurn=undefined` 时不清除 `cacheHitRate`，避免 badge 闪烁
- **CLI 自行实现 `computeCacheHitRate()`**，不 import `@byfriends/kosong`（架构约束）

## Testing

- 74 个新测试覆盖所有 5 个 surface + 共享 helper
- 边界情况覆盖：首轮（无命中）、turn gap、provider 无缓存、分母为零、遗留 input 字段
- 回归测试验证：无缓存数据时输出与变更前完全一致
- Typecheck 通过，Lint 0 errors

Closes #126, #127, #128, #129, #130
