### PR TITLE
refactor: migrate providers to BaseChatProvider, extract DialogManager, clean up legacy code

### DIFF
--- a/.changeset/agent-core-task-entry.md
+++ b/.changeset/agent-core-task-entry.md
@@ -1,0 +1,5 @@
+---
+'@byfriends/agent-core': patch
+---
+
+Refactor `BackgroundProcessManager` to use a `TaskEntry` discriminated union (`ProcessTaskEntry | PromiseTaskEntry`), eliminating the `as unknown as KaosProcess` cast for agent tasks. `BackgroundTaskInfo.pid` is now typed as `number | null` to accurately reflect that promise-based agent tasks have no OS process id.

--- a/.changeset/cli-dialog-manager.md
+++ b/.changeset/cli-dialog-manager.md
@@ -1,0 +1,5 @@
+---
+'@byfriends/cli': patch
+---
+
+Extract `DialogManager` from `ByfTui` to own the editor-replacement picker/dialog methods (help, session, model, theme, permission, settings, editor selectors). No user-facing behavior change.

--- a/.changeset/kosong-base-provider.md
+++ b/.changeset/kosong-base-provider.md
@@ -2,4 +2,4 @@
 '@byfriends/kosong': patch
 ---
 
-Migrate `openai-responses` and `google-genai` adapters to extend `BaseChatProvider`, removing duplicated `_clone`, accessors, and `_createClient` boilerplate. Google error classification now reuses `convertProviderError` while preserving its fetch-specific `TypeError` handling.
+Migrate all four provider adapters (`openai-completions`, `anthropic`, `openai-responses`, `google-genai`) to extend `BaseChatProvider`, and their `StreamedMessage` implementations to extend `BaseStreamedMessage`. This removes duplicated `_clone`, accessors, `_createClient` boilerplate, and the `StreamedMessage` field/getter skeleton. Finish-reason normalization is now config-driven via `makeFinishReasonNormalizer` for OpenAI and Anthropic adapters. Google error classification reuses `convertProviderError` while preserving its fetch-specific `TypeError` handling.

--- a/.changeset/kosong-base-provider.md
+++ b/.changeset/kosong-base-provider.md
@@ -1,0 +1,5 @@
+---
+'@byfriends/kosong': patch
+---
+
+Migrate `openai-responses` and `google-genai` adapters to extend `BaseChatProvider`, removing duplicated `_clone`, accessors, and `_createClient` boilerplate. Google error classification now reuses `convertProviderError` while preserving its fetch-specific `TypeError` handling.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -41,7 +41,7 @@ CLI command to configure a catalog provider from models.dev. Complements `/login
 CLI command to open an interactive selector to remove a configured provider. The provider for `defaultModel` is highlighted by default. The `/disconnect` alias behaves identically.
 
 ### Agent
-The central class in `agent-core`. Holds subsystem references (ContextMemory, ConfigState, ToolManager, PermissionManager, PlanMode, BackgroundManager, AgentRecords, TurnFlow, InjectionManager, UsageRecorder, SkillManager, HookEngine, ReplayBuilder). Must be usable on its own — the constructor must not force the caller to create a Session instance, nor require an `agentId` or `session`.
+The central class in `agent-core`. Holds subsystem references (ContextMemory, ConfigState, ToolManager, PermissionManager, FullCompaction, BackgroundManager, AgentRecords, TurnFlow, InjectionManager, UsageRecorder, SkillManager, HookEngine, ReplayBuilder). Must be usable on its own — the constructor must not force the caller to create a Session instance, nor require an `agentId` or `session`.
 
 ### Session
 The outer lifecycle container in `agent-core`. Owns a `SkillRegistry`, `McpConnectionManager`, and a map of `Agent` instances (main + sub-agents). Creates agents, loads skills & MCP servers, manages metadata, triggers hooks.

--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -20,16 +20,13 @@ import {
 import { homedir } from 'node:os';
 import { resolve as resolvePath } from 'node:path';
 import {
-  log,
-} from '@byfriends/sdk';
-import {
   applyProviderConfig,
   fetchModels,
+  log,
 } from '@byfriends/sdk';
 import { BUILT_IN_CATALOG_JSON } from '../built-in-catalog';
 import type {
   AgentStatusUpdatedEvent,
-  AssistantDeltaEvent,
   BackgroundTaskInfo,
   BackgroundTaskStartedEvent,
   BackgroundTaskTerminatedEvent,
@@ -40,7 +37,6 @@ import type {
   CreateSessionOptions,
   ErrorEvent,
   Event,
-  HookResultEvent,
   ByfHarness,
   McpServerInfo,
   PermissionMode,
@@ -54,16 +50,7 @@ import type {
   SubagentCompletedEvent,
   SubagentFailedEvent,
   SubagentSpawnedEvent,
-  ThinkingDeltaEvent,
-  ToolCallDeltaEvent,
-  ToolCallStartedEvent,
-  ToolProgressEvent,
-  ToolResultEvent,
   TurnEndedEvent,
-  TurnStartedEvent,
-  TurnStepCompletedEvent,
-  TurnStepInterruptedEvent,
-  TurnStepStartedEvent,
   WarningEvent,
 } from '@byfriends/sdk';
 import chalk from 'chalk';
@@ -2245,7 +2232,9 @@ export class ByfTui implements DialogHost {
       applyThemeChoice: (theme) => this.applyThemeChoice(theme),
       showUsage: () => this.showUsage(),
       getSlashCommands: () => this.getSlashCommands(),
-      showNotice: (title, detail) => this.showNotice(title, detail),
+      showNotice: (title, detail) => {
+        this.showNotice(title, detail);
+      },
       stop: () => this.stop(),
     };
   }

--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -106,20 +106,11 @@ import {
   resolveSection,
 } from './components/dialogs/approval-panel';
 import { CompactionComponent } from './components/dialogs/compaction';
-import { EditorSelectorComponent } from './components/dialogs/editor-selector';
 import { FileViewerComponent } from './components/dialogs/file-viewer';
-import { HelpPanelComponent } from './components/dialogs/help-panel';
-import { ModelSelectorComponent } from './components/dialogs/model-selector';
-import { PermissionSelectorComponent } from './components/dialogs/permission-selector';
 import { QuestionDialogComponent } from './components/dialogs/question-dialog';
-import { SessionPickerComponent } from './components/dialogs/session-picker';
 import { TasksBrowserController, type TasksBrowserEnv } from './components/dialogs/tasks-browser/';
-import {
-  SettingsSelectorComponent,
-  type SettingsSelection,
-} from './components/dialogs/settings-selector';
-import { ThemeSelectorComponent } from './components/dialogs/theme-selector';
 import { CustomEditor } from './components/editor/custom-editor';
+import { DialogManager, type DialogManagerCallbacks } from './dialog-manager';
 import { FileMentionProvider } from './components/editor/file-mention-provider';
 import { AgentGroupComponent } from './components/messages/agent-group';
 import { AssistantMessageComponent } from './components/messages/assistant-message';
@@ -473,6 +464,7 @@ export class ByfTui implements DialogHost {
   private isShuttingDown = false;
   private readonly turnEventHandler: TurnEventHandler;
   private readonly tasksBrowserController: TasksBrowserController;
+  private readonly dialogManager: DialogManager;
 
   public onExit?: (exitCode?: number) => Promise<void>;
 
@@ -501,6 +493,7 @@ export class ByfTui implements DialogHost {
     this.state = createTUIState(tuiOptions);
     this.gitLsFilesCache = createGitLsFilesCache(tuiOptions.initialAppState.workDir);
     this.turnEventHandler = new TurnEventHandler(this.turnEventState(), this.turnEventCallbacks());
+    this.dialogManager = new DialogManager(this.state, this, this.dialogManagerCallbacks());
 
     // Register approval / question UI controllers before SDK handlers.
     this.reverseRpcDisposers.push(
@@ -648,7 +641,7 @@ export class ByfTui implements DialogHost {
     }
     void this.showTmuxKeyboardWarningIfNeeded();
     if (this.state.startupState === 'picker') {
-      void this.bootstrapFromPicker();
+      void this.dialogManager.bootstrapFromPicker();
       // resumeSession (fired on picker select) owns post-pick init; nothing
       // else to do here until the user makes a choice.
       return;
@@ -1070,7 +1063,7 @@ export class ByfTui implements DialogHost {
     editor.onEscape = () => {
       if (this.pendingExit) this.clearPendingExit();
       if (this.state.showingSessionPicker) {
-        this.hideSessionPicker();
+        this.dialogManager.hideSessionPicker();
         return;
       }
       if (this.state.appState.isStreaming) {
@@ -1364,7 +1357,7 @@ export class ByfTui implements DialogHost {
         void this.stop();
         return;
       case 'help':
-        this.showHelpPanel();
+        this.dialogManager.showHelpPanel();
         return;
       case 'version':
         this.showStatus(`Byf Code v${this.state.appState.version}`);
@@ -1374,7 +1367,7 @@ export class ByfTui implements DialogHost {
         this.state.ui.requestRender();
         return;
       case 'sessions':
-        void this.showSessionPicker();
+        void this.dialogManager.showSessionPicker();
         return;
       case 'tasks':
         if (this.session === undefined) {
@@ -1396,10 +1389,10 @@ export class ByfTui implements DialogHost {
         this.handleModelCommand(args);
         return;
       case 'permission':
-        this.showPermissionPicker();
+        this.dialogManager.showPermissionPicker();
         return;
       case 'settings':
-        this.showSettingsSelector();
+        this.dialogManager.showSettingsSelector();
         return;
       case 'usage':
         void this.showUsage();
@@ -2239,6 +2232,21 @@ export class ByfTui implements DialogHost {
       showError: (msg) =>{  this.showError(msg); },
       showStatus: (msg, color) =>{  this.showStatus(msg, color); },
       setAppState: (patch) =>{  this.setAppState(patch); },
+    };
+  }
+
+  private dialogManagerCallbacks(): DialogManagerCallbacks {
+    return {
+      fetchSessions: () => this.fetchSessions(),
+      resumeSession: (sessionId) => this.resumeSession(sessionId),
+      applyEditorChoice: (value) => this.applyEditorChoice(value),
+      performModelSwitch: (alias, thinkingEffort) => this.performModelSwitch(alias, thinkingEffort),
+      applyPermissionChoice: (mode) => this.applyPermissionChoice(mode),
+      applyThemeChoice: (theme) => this.applyThemeChoice(theme),
+      showUsage: () => this.showUsage(),
+      getSlashCommands: () => this.getSlashCommands(),
+      showNotice: (title, detail) => this.showNotice(title, detail),
+      stop: () => this.stop(),
     };
   }
 
@@ -3259,70 +3267,7 @@ export class ByfTui implements DialogHost {
     this.restoreEditor();
   }
 
-  // Shows the help panel with the current slash command list.
-  private showHelpPanel(): void {
-    this.state.showingHelpPanel = true;
-    this.mountEditorReplacement(
-      new HelpPanelComponent({
-        commands: this.getSlashCommands(),
-        colors: this.state.theme.colors,
-        onClose: () => {
-          this.hideHelpPanel();
-        },
-      }),
-    );
-  }
-
-  // Hides the help panel and returns focus to the editor.
-  private hideHelpPanel(): void {
-    this.state.showingHelpPanel = false;
-    this.restoreEditor();
-  }
-
   // Loads sessions and shows the session picker.
-  private async showSessionPicker(): Promise<void> {
-    await this.fetchSessions();
-    this.mountSessionPicker(() => {
-      this.hideSessionPicker();
-    });
-  }
-
-  // Shows the startup session picker and exits when it is cancelled.
-  private async bootstrapFromPicker(): Promise<void> {
-    await this.fetchSessions();
-    this.mountSessionPicker(() => {
-      this.hideSessionPicker();
-      void this.stop();
-    });
-  }
-
-  // Hides the session picker and restores the editor.
-  private hideSessionPicker(): void {
-    this.state.showingSessionPicker = false;
-    this.restoreEditor();
-  }
-
-  // Mounts a session picker with shared selection behavior.
-  private mountSessionPicker(onCancel: () => void): void {
-    this.state.showingSessionPicker = true;
-    this.mountEditorReplacement(
-      new SessionPickerComponent({
-        sessions: this.state.sessions,
-        loading: this.state.loadingSessions,
-        currentSessionId: this.state.appState.sessionId,
-        colors: this.state.theme.colors,
-        onSelect: (sessionId: string) => {
-          void this.resumeSession(sessionId).then((switched) => {
-            if (switched) {
-              this.hideSessionPicker();
-            }
-          });
-        },
-        onCancel,
-      }),
-    );
-  }
-
   private createTasksBrowserEnv(): TasksBrowserEnv {
     return {
       host: {
@@ -3374,24 +3319,6 @@ export class ByfTui implements DialogHost {
     };
   }
 
-  // Shows the editor command selector.
-  private showEditorPicker(): void {
-    const currentValue = this.state.appState.editorCommand ?? '';
-    this.mountEditorReplacement(
-      new EditorSelectorComponent({
-        currentValue,
-        colors: this.state.theme.colors,
-        onSelect: (value) => {
-          this.restoreEditor();
-          void this.applyEditorChoice(value);
-        },
-        onCancel: () => {
-          this.restoreEditor();
-        },
-      }),
-    );
-  }
-
   // Persists and applies the selected external editor command.
   private async applyEditorChoice(value: string): Promise<void> {
     const previous = this.state.appState.editorCommand ?? '';
@@ -3420,35 +3347,6 @@ export class ByfTui implements DialogHost {
       value.length > 0
         ? `Editor set to "${value}".`
         : 'Editor set to auto-detect ($VISUAL / $EDITOR).',
-    );
-  }
-
-  // Shows the model selector when models are available.
-  private showModelPicker(selectedValue: string = this.state.appState.model): void {
-    const entries = Object.entries(this.state.appState.availableModels);
-    if (entries.length === 0) {
-      this.showNotice(
-        'No models configured',
-        'Run /login or /connect to add a provider.',
-      );
-      return;
-    }
-    this.mountEditorReplacement(
-      new ModelSelectorComponent({
-        models: this.state.appState.availableModels,
-        currentValue: this.state.appState.model,
-        selectedValue,
-        currentThinkingEffort: this.state.appState.thinkingEffort,
-        colors: this.state.theme.colors,
-        searchable: true,
-        onSelect: ({ alias, thinkingEffort }) => {
-          this.restoreEditor();
-          void this.performModelSwitch(alias, thinkingEffort);
-        },
-        onCancel: () => {
-          this.restoreEditor();
-        },
-      }),
     );
   }
 
@@ -3530,77 +3428,6 @@ export class ByfTui implements DialogHost {
       thinking: thinkingConfig,
     });
     return true;
-  }
-
-  // Shows the theme selector.
-  private showThemePicker(): void {
-    this.mountEditorReplacement(
-      new ThemeSelectorComponent({
-        currentValue: this.state.appState.theme,
-        colors: this.state.theme.colors,
-        onSelect: (value) => {
-          this.restoreEditor();
-          void this.applyThemeChoice(value);
-        },
-        onCancel: () => {
-          this.restoreEditor();
-        },
-      }),
-    );
-  }
-
-  // Shows the permission mode selector.
-  private showPermissionPicker(): void {
-    this.mountEditorReplacement(
-      new PermissionSelectorComponent({
-        currentValue: this.state.appState.permissionMode,
-        colors: this.state.theme.colors,
-        onSelect: (value) => {
-          this.restoreEditor();
-          void this.applyPermissionChoice(value);
-        },
-        onCancel: () => {
-          this.restoreEditor();
-        },
-      }),
-    );
-  }
-
-  // Shows the settings selector entry point.
-  private showSettingsSelector(): void {
-    this.mountEditorReplacement(
-      new SettingsSelectorComponent({
-        colors: this.state.theme.colors,
-        onSelect: (value) => {
-          this.handleSettingsSelection(value);
-        },
-        onCancel: () => {
-          this.restoreEditor();
-        },
-      }),
-    );
-  }
-
-  // Routes a settings selection to the matching selector or panel.
-  private handleSettingsSelection(value: SettingsSelection): void {
-    this.restoreEditor();
-    switch (value) {
-      case 'model':
-        this.showModelPicker();
-        return;
-      case 'permission':
-        this.showPermissionPicker();
-        return;
-      case 'theme':
-        this.showThemePicker();
-        return;
-      case 'editor':
-        this.showEditorPicker();
-        return;
-      case 'usage':
-        void this.showUsage();
-        return;
-    }
   }
 
   // Applies a permission mode choice to the active session and app state.
@@ -3823,7 +3650,7 @@ export class ByfTui implements DialogHost {
   private async handleEditorCommand(args: string, _eCtx: {}): Promise<void> {
     const command = args.trim();
     if (command.length === 0) {
-      this.showEditorPicker();
+      this.dialogManager.showEditorPicker();
       return;
     }
     await this.applyEditorChoice(command);
@@ -3833,7 +3660,7 @@ export class ByfTui implements DialogHost {
   private async handleThemeCommand(args: string): Promise<void> {
     const theme = args.trim();
     if (theme.length === 0) {
-      this.showThemePicker();
+      this.dialogManager.showThemePicker();
       return;
     }
     if (!isTheme(theme)) {
@@ -3847,14 +3674,14 @@ export class ByfTui implements DialogHost {
   private handleModelCommand(args: string): void {
     const alias = args.trim();
     if (alias.length === 0) {
-      this.showModelPicker();
+      this.dialogManager.showModelPicker();
       return;
     }
     if (this.state.appState.availableModels[alias] === undefined) {
       this.showError(`Unknown model alias: ${alias}`);
       return;
     }
-    this.showModelPicker(alias);
+    this.dialogManager.showModelPicker(alias);
   }
 
   // Handles the /title command.

--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -2056,42 +2056,42 @@ export class ByfTui implements DialogHost {
 
     switch (event.type) {
       case 'turn.started':
-        this.handleTurnBegin(event);
+        this.turnEventHandler.handleTurnBegin(event);
         break;
       case 'turn.ended':
         this.handleTurnEnd(event, sendQueued);
         break;
       case 'turn.step.started':
-        this.handleStepBegin(event);
+        this.turnEventHandler.handleStepBegin(event);
         break;
       case 'turn.step.interrupted':
-        this.handleStepInterrupted(event);
+        this.turnEventHandler.handleStepInterrupted(event);
         break;
       case 'turn.step.completed':
-        this.handleStepCompleted(event);
+        this.turnEventHandler.handleStepCompleted(event);
         break;
       case 'turn.step.retrying':
         break;
       case 'tool.progress':
-        this.handleToolProgress(event);
+        this.turnEventHandler.handleToolProgress(event);
         break;
       case 'assistant.delta':
-        this.handleAssistantDelta(event);
+        this.turnEventHandler.handleAssistantDelta(event);
         break;
       case 'hook.result':
-        this.handleHookResult(event);
+        this.turnEventHandler.handleHookResult(event);
         break;
       case 'thinking.delta':
-        this.handleThinkingDelta(event);
+        this.turnEventHandler.handleThinkingDelta(event);
         break;
       case 'tool.call.started':
-        this.handleToolCall(event);
+        this.turnEventHandler.handleToolCall(event);
         break;
       case 'tool.call.delta':
-        this.handleToolCallDelta(event);
+        this.turnEventHandler.handleToolCallDelta(event);
         break;
       case 'tool.result':
-        this.handleToolResult(event);
+        this.turnEventHandler.handleToolResult(event);
         break;
       case 'agent.status.updated':
         this.handleStatusUpdate(event);
@@ -2148,10 +2148,6 @@ export class ByfTui implements DialogHost {
     return routeSubagentEventImpl(event, this.subagentEventState());
   }
 
-  // Initializes turn-scoped buffers when the SDK starts a turn.
-  private handleTurnBegin(event: TurnStartedEvent): void {
-    this.turnEventHandler.handleTurnBegin(event);
-  }
 
   // Finalizes turn-scoped state when the SDK completes a turn.
   private handleTurnEnd(event: TurnEndedEvent, sendQueued: (item: QueuedMessage) => void): void {
@@ -2164,22 +2160,7 @@ export class ByfTui implements DialogHost {
     this.turnEventHandler.handleTurnEnd(event, sendQueued);
   }
 
-  // Resets live render state for a new turn step.
-  private handleStepBegin(event: TurnStepStartedEvent): void {
-    this.turnEventHandler.handleStepBegin(event);
-  }
 
-  // Surfaces step-level outcomes the user needs to act on. The common
-  // case (finishReason === 'tool_use' or 'end_turn') is silent — those
-  // already render via tool.call.started/tool.result and assistant.delta.
-  // The interesting case is max_tokens: the model started a tool_use but
-  // ran out of budget before finalizing it, so the partial tool call is
-  // still pinned in 'Preparing' state with no signal that anything went
-  // wrong. Flip those into a visible 'Truncated' state and append a
-  // notice pointing at the config knob.
-  private handleStepCompleted(event: TurnStepCompletedEvent): void {
-    this.turnEventHandler.handleStepCompleted(event);
-  }
 
   private isAnthropicSessionActive(): boolean {
     const providerKey = this.state.appState.availableModels[this.state.appState.model]?.provider;
@@ -2187,48 +2168,13 @@ export class ByfTui implements DialogHost {
     return this.state.appState.availableProviders[providerKey]?.type === 'anthropic';
   }
 
-  // Renders user-facing status for an interrupted turn step.
-  private handleStepInterrupted(event: TurnStepInterruptedEvent): void {
-    this.turnEventHandler.handleStepInterrupted(event);
-  }
 
-  // Appends a thinking delta to the live thinking block.
-  private handleThinkingDelta(event: ThinkingDeltaEvent): void {
-    this.turnEventHandler.handleThinkingDelta(event);
-  }
 
-  // Appends an assistant text delta to the live assistant block.
-  private handleAssistantDelta(event: AssistantDeltaEvent): void {
-    this.turnEventHandler.handleAssistantDelta(event);
-  }
 
-  private handleHookResult(event: HookResultEvent): void {
-    this.turnEventHandler.handleHookResult(event);
-  }
 
-  // Starts or updates a rendered tool call from a tool-call start event.
-  private handleToolCall(event: ToolCallStartedEvent): void {
-    this.turnEventHandler.handleToolCall(event);
-  }
 
-  // Accumulates streaming tool-call arguments and updates the rendered call.
-  private handleToolCallDelta(event: ToolCallDeltaEvent): void {
-    this.turnEventHandler.handleToolCallDelta(event);
-  }
 
-  // Streams a `{kind:'status'}` progress text into the live tool box so
-  // long-blocking tools (e.g. the MCP synthetic `authenticate` tool whose
-  // 15-minute browser wait would otherwise show only a spinner) can surface
-  // their authorization URL. Non-status update kinds stay out of the terminal
-  // transcript because only status text needs persistent display.
-  private handleToolProgress(event: ToolProgressEvent): void {
-    this.turnEventHandler.handleToolProgress(event);
-  }
 
-  // Completes a tool call and applies any tool-specific UI side effects.
-  private handleToolResult(event: ToolResultEvent): void {
-    this.turnEventHandler.handleToolResult(event);
-  }
 
   private turnEventState(): TurnEventState {
     const state = this.state;

--- a/apps/cli/src/tui/components/chrome/footer.ts
+++ b/apps/cli/src/tui/components/chrome/footer.ts
@@ -19,7 +19,7 @@ import {
   type GitStatus,
   type GitStatusCache,
 } from '#/utils/git/git-status';
-import { formatCacheHitRate, safeUsageRatio } from '#/utils/usage/usage-format';
+import { formatCacheHitRate, formatTokenCount, safeUsageRatio } from '#/utils/usage/usage-format';
 
 const MAX_CWD_SEGMENTS = 3;
 
@@ -80,12 +80,6 @@ function shortenCwd(path: string): string {
   if (segments.length <= MAX_CWD_SEGMENTS) return work;
   const tail = segments.slice(-MAX_CWD_SEGMENTS).join('/');
   return `…/${tail}`;
-}
-
-function formatTokenCount(n: number): string {
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
-  return String(n);
 }
 
 function safeUsage(usage: number): number {

--- a/apps/cli/src/tui/components/dialogs/tasks-browser.ts
+++ b/apps/cli/src/tui/components/dialogs/tasks-browser.ts
@@ -546,7 +546,8 @@ export class TasksBrowserApp extends Container implements Focusable {
           ? `finished ${formatRelativeTime(task.endedAt)}`
           : '';
     if (timing.length > 0) lines.push(`${label('Time:')}${chalk.hex(colors.textMuted)(timing)}`);
-    if (task.pid > 0) lines.push(`${label('Pid:')}${chalk.hex(colors.textMuted)(String(task.pid))}`);
+    if (task.pid !== null && task.pid > 0)
+      lines.push(`${label('Pid:')}${chalk.hex(colors.textMuted)(String(task.pid))}`);
     if (task.exitCode !== null && task.exitCode !== undefined) {
       lines.push(`${label('Exit code:')}${chalk.hex(colors.textMuted)(String(task.exitCode))}`);
     }

--- a/apps/cli/src/tui/dialog-manager.ts
+++ b/apps/cli/src/tui/dialog-manager.ts
@@ -2,16 +2,16 @@ import type { PermissionMode } from '@byfriends/sdk';
 
 import { EditorSelectorComponent } from '#/tui/components/dialogs/editor-selector';
 import { HelpPanelComponent, type HelpPanelCommand } from '#/tui/components/dialogs/help-panel';
-import { ModelSelectorComponent, type ModelSelection } from '#/tui/components/dialogs/model-selector';
+import { ModelSelectorComponent } from '#/tui/components/dialogs/model-selector';
 import { PermissionSelectorComponent } from '#/tui/components/dialogs/permission-selector';
-import { SessionPickerComponent, type SessionRow } from '#/tui/components/dialogs/session-picker';
+import { SessionPickerComponent } from '#/tui/components/dialogs/session-picker';
 import {
   SettingsSelectorComponent,
   type SettingsSelection,
 } from '#/tui/components/dialogs/settings-selector';
 import { ThemeSelectorComponent } from '#/tui/components/dialogs/theme-selector';
 import type { Theme } from '#/tui/theme';
-import type { AppState, DialogHost, ThinkingEffortLevel, TUIState } from '#/tui/types';
+import type { DialogHost, ThinkingEffortLevel, TUIState } from '#/tui/types';
 
 /**
  * TUI methods the DialogManager delegates to. Keeping these explicit avoids

--- a/apps/cli/src/tui/dialog-manager.ts
+++ b/apps/cli/src/tui/dialog-manager.ts
@@ -1,0 +1,227 @@
+import type { PermissionMode } from '@byfriends/sdk';
+
+import { EditorSelectorComponent } from '#/tui/components/dialogs/editor-selector';
+import { HelpPanelComponent, type HelpPanelCommand } from '#/tui/components/dialogs/help-panel';
+import { ModelSelectorComponent, type ModelSelection } from '#/tui/components/dialogs/model-selector';
+import { PermissionSelectorComponent } from '#/tui/components/dialogs/permission-selector';
+import { SessionPickerComponent, type SessionRow } from '#/tui/components/dialogs/session-picker';
+import {
+  SettingsSelectorComponent,
+  type SettingsSelection,
+} from '#/tui/components/dialogs/settings-selector';
+import { ThemeSelectorComponent } from '#/tui/components/dialogs/theme-selector';
+import type { Theme } from '#/tui/theme';
+import type { AppState, DialogHost, ThinkingEffortLevel, TUIState } from '#/tui/types';
+
+/**
+ * TUI methods the DialogManager delegates to. Keeping these explicit avoids
+ * giving the manager a reference back to the full ByfTui instance and keeps
+ * the dialog layer a pure function of state + host + callbacks.
+ */
+export interface DialogManagerCallbacks {
+  fetchSessions(): Promise<void>;
+  resumeSession(sessionId: string): Promise<boolean>;
+  applyEditorChoice(value: string): Promise<void>;
+  performModelSwitch(alias: string, thinkingEffort: ThinkingEffortLevel): Promise<void>;
+  applyPermissionChoice(mode: PermissionMode): Promise<void>;
+  applyThemeChoice(theme: Theme): Promise<void>;
+  showUsage(): Promise<void>;
+  getSlashCommands(): readonly HelpPanelCommand[];
+  showNotice(title: string, detail?: string): void;
+  stop(): Promise<void>;
+}
+
+/**
+ * Owns the editor-replacement dialogs and selectors that were previously
+ * private methods on ByfTui. This shrinks the TUI god object while leaving
+ * stateful editor/streaming/approval logic where it belongs.
+ */
+export class DialogManager {
+  constructor(
+    private readonly state: TUIState,
+    private readonly host: DialogHost,
+    private readonly callbacks: DialogManagerCallbacks,
+  ) {}
+
+  // Shows the help panel with the current slash command list.
+  showHelpPanel(): void {
+    this.state.showingHelpPanel = true;
+    this.host.show(
+      new HelpPanelComponent({
+        commands: this.callbacks.getSlashCommands(),
+        colors: this.state.theme.colors,
+        onClose: () => {
+          this.hideHelpPanel();
+        },
+      }),
+    );
+  }
+
+  // Hides the help panel and returns focus to the editor.
+  hideHelpPanel(): void {
+    this.state.showingHelpPanel = false;
+    this.host.close();
+  }
+
+  // Loads sessions and shows the session picker.
+  async showSessionPicker(): Promise<void> {
+    await this.callbacks.fetchSessions();
+    this.mountSessionPicker(() => {
+      this.hideSessionPicker();
+    });
+  }
+
+  // Shows the startup session picker and exits when it is cancelled.
+  async bootstrapFromPicker(): Promise<void> {
+    await this.callbacks.fetchSessions();
+    this.mountSessionPicker(() => {
+      this.hideSessionPicker();
+      void this.callbacks.stop();
+    });
+  }
+
+  // Hides the session picker and restores the editor.
+  hideSessionPicker(): void {
+    this.state.showingSessionPicker = false;
+    this.host.close();
+  }
+
+  // Mounts a session picker with shared selection behavior.
+  private mountSessionPicker(onCancel: () => void): void {
+    this.state.showingSessionPicker = true;
+    this.host.show(
+      new SessionPickerComponent({
+        sessions: this.state.sessions,
+        loading: this.state.loadingSessions,
+        currentSessionId: this.state.appState.sessionId,
+        colors: this.state.theme.colors,
+        onSelect: (sessionId: string) => {
+          void this.callbacks.resumeSession(sessionId).then((switched) => {
+            if (switched) {
+              this.hideSessionPicker();
+            }
+          });
+        },
+        onCancel,
+      }),
+    );
+  }
+
+  // Shows the editor command selector.
+  showEditorPicker(): void {
+    const currentValue = this.state.appState.editorCommand ?? '';
+    this.host.show(
+      new EditorSelectorComponent({
+        currentValue,
+        colors: this.state.theme.colors,
+        onSelect: (value) => {
+          this.host.close();
+          void this.callbacks.applyEditorChoice(value);
+        },
+        onCancel: () => {
+          this.host.close();
+        },
+      }),
+    );
+  }
+
+  // Shows the model selector when models are available.
+  showModelPicker(selectedValue: string = this.state.appState.model): void {
+    const entries = Object.entries(this.state.appState.availableModels);
+    if (entries.length === 0) {
+      this.callbacks.showNotice(
+        'No models configured',
+        'Run /login or /connect to add a provider.',
+      );
+      return;
+    }
+    this.host.show(
+      new ModelSelectorComponent({
+        models: this.state.appState.availableModels,
+        currentValue: this.state.appState.model,
+        selectedValue,
+        currentThinkingEffort: this.state.appState.thinkingEffort,
+        colors: this.state.theme.colors,
+        searchable: true,
+        onSelect: ({ alias, thinkingEffort }) => {
+          this.host.close();
+          void this.callbacks.performModelSwitch(alias, thinkingEffort);
+        },
+        onCancel: () => {
+          this.host.close();
+        },
+      }),
+    );
+  }
+
+  // Shows the theme selector.
+  showThemePicker(): void {
+    this.host.show(
+      new ThemeSelectorComponent({
+        currentValue: this.state.appState.theme,
+        colors: this.state.theme.colors,
+        onSelect: (value) => {
+          this.host.close();
+          void this.callbacks.applyThemeChoice(value);
+        },
+        onCancel: () => {
+          this.host.close();
+        },
+      }),
+    );
+  }
+
+  // Shows the permission mode selector.
+  showPermissionPicker(): void {
+    this.host.show(
+      new PermissionSelectorComponent({
+        currentValue: this.state.appState.permissionMode,
+        colors: this.state.theme.colors,
+        onSelect: (value) => {
+          this.host.close();
+          void this.callbacks.applyPermissionChoice(value);
+        },
+        onCancel: () => {
+          this.host.close();
+        },
+      }),
+    );
+  }
+
+  // Shows the settings selector entry point.
+  showSettingsSelector(): void {
+    this.host.show(
+      new SettingsSelectorComponent({
+        colors: this.state.theme.colors,
+        onSelect: (value) => {
+          this.handleSettingsSelection(value);
+        },
+        onCancel: () => {
+          this.host.close();
+        },
+      }),
+    );
+  }
+
+  // Routes a settings selection to the matching selector or panel.
+  private handleSettingsSelection(value: SettingsSelection): void {
+    this.host.close();
+    switch (value) {
+      case 'model':
+        this.showModelPicker();
+        return;
+      case 'permission':
+        this.showPermissionPicker();
+        return;
+      case 'theme':
+        this.showThemePicker();
+        return;
+      case 'editor':
+        this.showEditorPicker();
+        return;
+      case 'usage':
+        void this.callbacks.showUsage();
+        return;
+    }
+  }
+}

--- a/apps/cli/test/tui/components/chrome/footer.test.ts
+++ b/apps/cli/test/tui/components/chrome/footer.test.ts
@@ -90,6 +90,19 @@ describe('Footer — cache badge (Group B)', () => {
     expect(result).not.toContain('cache:');
   });
 
+  // ── #135: footer must use the canonical formatTokenCount (finite/negative guard) ──
+  it('#135: renders NaN tokens as 0 (not "NaN") via canonical formatTokenCount guard', () => {
+    const result = formatContextStatus(0.45, Number.NaN, 48000);
+    expect(result).not.toContain('NaN');
+    expect(result).toContain('0/48.0k');
+  });
+
+  it('#135: renders negative tokens as 0 via canonical formatTokenCount guard', () => {
+    const result = formatContextStatus(0.45, -5, 48000);
+    expect(result).not.toContain('-5');
+    expect(result).toContain('0/48.0k');
+  });
+
   // ── B12: key absent ────────────────────────────────────────────
   it('B12: no cache badge when cacheHitRate key is absent from state', () => {
     // Construct state without cacheHitRate — key literally absent.

--- a/apps/cli/test/tui/components/messages/thinking.test.ts
+++ b/apps/cli/test/tui/components/messages/thinking.test.ts
@@ -2,6 +2,7 @@ import type { TUI } from '@earendil-works/pi-tui';
 import { describe, expect, it, vi } from 'vitest';
 
 import { ThinkingComponent } from '#/tui/components/messages/thinking';
+import { SPINNER_FRAMES } from '#/tui/constant/rendering';
 import { STATUS_BULLET } from '#/tui/constant/symbols';
 import { darkColors } from '#/tui/theme/colors';
 
@@ -16,9 +17,9 @@ describe('ThinkingComponent', () => {
     const component = new ThinkingComponent('working it out', darkColors, true, 'live');
     const out = strip(component.render(80).join('\n'));
 
-    expect(out).toContain('◐ thinking...');
-    expect(out).not.toContain('  ◐ thinking...');
-    expect(out).not.toContain(`${STATUS_BULLET}◐`);
+    expect(out).toContain(`${SPINNER_FRAMES[0]} thinking...`);
+    expect(out).not.toContain(`  ${SPINNER_FRAMES[0]} thinking...`);
+    expect(out).not.toContain(`${STATUS_BULLET}${SPINNER_FRAMES[0]}`);
     expect(out).toContain('  working it out');
   });
 
@@ -40,11 +41,11 @@ describe('ThinkingComponent', () => {
       requestRender,
     } as unknown as TUI);
 
-    expect(strip(component.render(80).join('\n'))).toContain('◐ thinking...');
+    expect(strip(component.render(80).join('\n'))).toContain(`${SPINNER_FRAMES[0]} thinking...`);
 
     vi.advanceTimersByTime(80);
     expect(requestRender).toHaveBeenCalled();
-    expect(strip(component.render(80).join('\n'))).toContain('◓ thinking...');
+    expect(strip(component.render(80).join('\n'))).toContain(`${SPINNER_FRAMES[1]} thinking...`);
 
     component.finalize();
     requestRender.mockClear();

--- a/docs/adr/0014-task-entry-discriminated-union.md
+++ b/docs/adr/0014-task-entry-discriminated-union.md
@@ -1,0 +1,112 @@
+# ADR 0014: TaskEntry Discriminated Union
+
+## Status
+
+Accepted
+
+## Context
+
+`BackgroundProcessManager` (`packages/agent-core/src/tools/background/manager.ts`) manages two fundamentally different kinds of background tasks through a single data structure:
+
+1. **Real process tasks** — user-launched long-running shell commands (`npm run dev`, `pytest`). These are real OS processes with a pid, stdin/stdout/stderr streams, and signal-based termination.
+2. **Agent (Promise-based) tasks** — sub-agents launched in the background by the main agent. These are pure JS Promoutines: no pid, no streams, cancelled via an abort callback.
+
+The `ManagedProcess` structure was designed around the real-process shape — its `proc: KaosProcess` field requires the full process interface (stdin/stdout/stderr/pid/wait/kill). To make agent tasks fit, `registerAgentTask` (`manager.ts:808-818`) fabricates a fake process object and casts it past the type system:
+
+```typescript
+proc: {
+  stdin: { write: () => false, end: () => {} } as never,
+  stdout: { setEncoding: () => {}, on: () => {} } as never,
+  pid: 0,
+  wait: () => completion.then(() => 0),
+  kill: async () => { opts.abort?.(); },
+} as unknown as KaosProcess,  // type-system escape hatch
+```
+
+This is the only `as unknown` cast in `packages/agent-core/src`. Its consequences:
+
+- **Silent failure risk**: `proc.stdout.on(...)` and `proc.pid` are dead/zero for agent tasks. Any code that assumes `entry.proc` is real will misbehave on agent tasks, and TypeScript cannot catch it.
+- **False unity**: `ManagedProcess` pretends to be one thing, but agent tasks have no process. The name itself ("ManagedProcess") is misleading for a structure that also holds Promises.
+- **Confused responsibilities**: the manager fuses two execution models (OS process vs JS Promise) into one map, one status machine, and one set of fields.
+
+The `improve-architecture` scan (2026-06-17) flagged this as a High-priority design debt (H3).
+
+## Decision
+
+Replace `ManagedProcess` with a **discriminated union** (`TaskEntry`) that shares common fields but separates the two task shapes.
+
+```typescript
+interface TaskCommon {
+  taskId: string;
+  command: string;
+  description: string;
+  status: 'running' | 'completed' | 'failed' | 'killed' | 'lost';
+  startedAt: number;
+  endedAt: number | null;
+  exitCode: number | null;
+  outputChunks: string[];        // moved up: both kinds produce text output
+  outputSizeBytes: number;       // moved up: both need persistence/display
+  waiters: Array<...>;
+  terminalFired: boolean;
+  stopRequested: boolean;
+  outputSessionDir: string | undefined;
+  lifecyclePromise: Promise<void>;
+  persistWriteQueue: Promise<void>;
+  outputWriteQueue: Promise<void>;
+  agentId?: string;              // agent-task identifier
+  subagentType?: string;
+}
+
+interface ProcessTaskEntry extends TaskCommon {
+  kind: 'process';
+  proc: KaosProcess;             // only present for real processes
+  timeoutMs?: number;
+}
+
+interface PromiseTaskEntry extends TaskCommon {
+  kind: 'promise';
+  completion: Promise<{ result: string }>;
+  abort: () => void;             // cancellation for agent tasks
+  timeoutMs?: number;
+}
+
+type TaskEntry = ProcessTaskEntry | PromiseTaskEntry;
+```
+
+The type name `ManagedProcess` is renamed to `TaskEntry` throughout (~20 reference sites).
+
+### Why `outputChunks`/`outputSizeBytes` moved to `TaskCommon`
+
+Verified during grill: `outputChunks` is already `string[]` (`manager.ts:112`), not `Buffer[]`. Both real-process stdout chunks and agent result strings are already stored as strings. Both kinds need output persistence, `/tasks` panel display, and ring-buffer trimming. Moving these fields up is friction-free and unifies the "task output text" semantics.
+
+### Why the reconcile path is untouched
+
+Verified during grill: `reconcile`/`loadFromDisk` (`manager.ts:993-1029`) loads persisted tasks into a `ghosts` map of `BackgroundTaskInfo` (read-only snapshots), and marks any non-terminal ghost as `'lost'`. It does **not** reconstruct an active `TaskEntry` — because neither a dead process nor a lost Promise can be resumed. The discriminated union therefore only affects active-entry construction and handling; the reconcile/ghost path is completely unaware of the change.
+
+## Alternatives Considered
+
+### A. Two independent managers + a coordinator facade
+
+Split into `RealProcessManager` + `PromiseTaskManager`, unified by a `BackgroundCoordinator` facade.
+
+**Rejected**: the external interface (`register`/`stop`/`list`/`onTerminal`/slot reservation) is genuinely common — unifying it is correct. Splitting forces the persistence layer (`persist.ts`), restore (`reconcile`), callback subscriptions, task-id allocation, and concurrency-slot accounting to be either duplicated or re-aggregated at the facade. The blast radius (callers, persistence, restore) far exceeds the benefit, since the aggregation is the right design.
+
+### B. Narrow the `proc` type to a `TaskHandle` union
+
+Keep a single `ManagedProcess` structure, but change `proc: KaosProcess` to `proc: KaosProcess | PromiseTaskHandle` where `PromiseTaskHandle` only has `wait`/`kill`.
+
+**Rejected**: this treats the symptom (the cast) without separating the concerns. `ManagedProcess` would still be one structure holding two task kinds; the "outputChunks is meaningless for promise tasks" structural pollution (now resolved by moving `outputChunks` to common) would have persisted. Every `entry.proc.X` access site would still need runtime branching. It is half a solution.
+
+## Consequences
+
+- **Positive**: Eliminates the only `as unknown` cast in `packages/agent-core/src`. TypeScript now forces a `kind` guard before any access to `entry.proc`, guaranteeing process-specific fields are only read on real processes.
+- **Positive**: The `ManagedProcess` → `TaskEntry` rename honestly reflects that the structure may hold either a process or a Promise.
+- **Positive**: Adding a future third task kind (e.g. a webhook-driven task) is a natural union variant extension.
+- **Positive**: Reconcile path is provably unaffected — reduces risk and eliminated a planned verification slice.
+- **Negative**: ~20 reference sites must be updated to the new type name. Mechanical but touches several files within `tools/background/`.
+- **Negative**: The 6 methods that touch `proc` (`stop`, `toInfo`, `settleProcessExit` at `manager.ts:673,700,702,1067,1125,1138`) now carry `kind` branches — slightly more internal control flow.
+
+## Related
+
+- PRD: `docs/prd/design-debt-cleanup-high-priority.md` (H3)
+- Source scan: `improve-architecture` report (2026-06-17), finding H3

--- a/docs/adr/0015-base-chat-provider.md
+++ b/docs/adr/0015-base-chat-provider.md
@@ -1,0 +1,97 @@
+# ADR 0015: BaseChatProvider Abstract Base Class
+
+## Status
+
+Accepted
+
+## Context
+
+`packages/kosong` has four LLM provider adapters — `anthropic.ts` (1042 lines), `openai-responses.ts` (1006), `google-genai.ts` (899), `openai-completions.ts` (669). Each `implements ChatProvider` (an interface, no base class).
+
+The `improve-architecture` scan (2026-06-17, finding H4) identified **14 duplicated patterns** across these adapters. The four most pervasive are 4-way near-identical copies:
+
+1. **`StreamedMessage` class skeleton** — fields, getters, `[Symbol.asyncIterator]`, constructor branching (`anthropic.ts:525-584`, `openai-responses.ts:496-529`, `google-genai.ts:453-493`, `openai-completions.ts:282-325`).
+2. **`_clone()` + `withGenerationKwargs`** — `Object.assign(Object.create(proto), this)` + deep-copy `_generationKwargs` (4 copies).
+3. **`_createClient(auth)` wrapper** + accessor quartet (`modelName`/`modelParameters`/`getCapability`) — 4 copies each.
+4. **`normalizeXxxFinishReason`** — structurally identical null-guard → switch → return, differing only in case labels (4 copies).
+
+The existing shared module `openai-common.ts` serves only 2 of 4 adapters (the OpenAI family). Anthropic and Google are fully independent — they don't use it at all.
+
+### Origin (why the design started this way)
+
+Git history (`git log --diff-filter=A`) confirms all four providers arrived in the initial commit `f4a0872` — a fork of Kimi Code (Moonshot AI). The upstream design was inherited, not chosen by BYF. Three real reasons explain the upstream structure:
+
+1. Each adapter wraps a **different official SDK** (`@anthropic-ai/sdk`, `openai`, `@google/genai`) with incompatible client types and constructors.
+2. Upstream Kimi was itself OpenAI-compatible, so `openai-common.ts` was an OpenAI-family-internal toolkit, never a cross-provider abstraction.
+3. BYF is a hard fork (CONTEXT.md: no upstream merges). Subsequent work (caching, observability) added fields by copy-pasting across 4 files because per-change cost was lower than refactor cost — debt accumulated silently.
+
+### Why act now
+
+The duplication is not static — it grows. The `cache-observability-cli.md` PRD added `inputCacheRead`/`inputCacheCreation` parsing by editing each adapter's `_extractUsage` independently. ADR 0011's stated goal ("adding a new provider requires only a new adapter") is undermined: a new provider today must copy-paste all 14 patterns.
+
+A key grill insight: the duplication splits cleanly into two categories — **SDK-agnostic boilerplate** (`_clone`, accessors, `StreamedMessage` skeleton — nothing to do with which SDK is wrapped) and **protocol-specific logic** (`generate()`, message mapping, streaming parsing, cache-control injection — genuinely different per provider). Only the former should be shared.
+
+## Decision
+
+Introduce `abstract class BaseChatProvider implements ChatProvider` and `abstract class BaseStreamedMessage implements StreamedMessage`. Move SDK-agnostic boilerplate up; leave protocol-specific logic in subclasses.
+
+### What moves up to the base class
+
+- `_clone()` / `withGenerationKwargs()` — pure boilerplate, SDK-independent.
+- Accessors: `modelName`, `modelParameters`, `getCapability` — return stored fields.
+- `StreamedMessage` skeleton: fields, `[Symbol.asyncIterator]` forwarding, getter quartet.
+- `_createClient(auth)` shell — delegates the actual SDK construction to a new abstract `createRawClient(auth, defaultHeaders)`.
+
+### What stays in subclasses
+
+- `generate()` — the streaming/dispatch loop, protocol-specific.
+- Message mapping (`convertMessage`, content-part flattening) — protocol-specific.
+- `createRawClient()` — `new OpenAI(...)` vs `new Anthropic(...)` vs `new GoogleGenAI(...)`.
+- `thinkingEffort` getter — mapping logic differs per provider.
+
+### Normalization: config-driven, in a new `provider-common.ts`
+
+Structurally-identical-but-field-name-different logic becomes config-driven, placed in a new `provider-common.ts` (separate from `openai-common.ts`, which keeps OpenAI-family wire-format conversion):
+
+- `makeFinishReasonNormalizer(mapping)` — shared switch skeleton, per-provider case-label table.
+- `extractCacheUsage(total, cached, output)` — the `inputOther = input - cached` formula (the cache-observability parsing).
+- `convertProviderError(error, opts?)` — the error-classification ladder (`NETWORK_RE`/`TIMEOUT_RE` + status normalization).
+
+**Google's fetch handling is not pure duplication** (grill correction): `google-genai.ts:637` adds `| fetch failed` and `:655` checks `error instanceof TypeError && msg.includes('fetch')` because the Google SDK throws `TypeError` on network failures. `convertProviderError` accepts an optional `extraNetworkMatchers` hook so Google supplies its fetch-specific matcher rather than diverging the whole function.
+
+### Migration order (grill decision 6)
+
+1. Migrate `openai-completions` (establishes the base-class skeleton) **and** `anthropic` (validates the base class works across protocols, not just the OpenAI family) together as a tracer bullet.
+2. Then batch-migrate `openai-responses` and `google-genai`.
+
+This ensures the base-class design is proven on the most dissimilar consumer before being propagated, rather than discovering a design flaw on the third provider.
+
+## Alternatives Considered
+
+### A. Pure-function shared module (extend `openai-common.ts`)
+
+No base class; extract duplicated code into pure functions in a shared module. Providers keep `implements ChatProvider` and call the functions.
+
+**Rejected**: the boilerplate (`_clone`, accessors, `StreamedMessage` skeleton) is stateful and tied to instance fields (`_model`, `_generationKwargs`, `_client`). Pure-function sharing would still leave each provider declaring the same instance fields and wiring them to the shared functions — most of the copy-paste remains, just redirected. New providers still copy the field/boilerplate surface. The base class makes "extend and get the boilerplate for free" real.
+
+### B. Extract only the core three (StreamedMessage + finish-reason + usage + error)
+
+Don't touch `_clone`/`_createClient` (they're coupled to per-SDK client types).
+
+**Rejected**: `_clone` is pure `Object.assign(Object.create(proto), this)` + deep-copy `_generationKwargs` — the SDK client type is irrelevant to the clone mechanics. `_createClient`'s shell (`resolveAuthBackedClient` + `mergeRequestHeaders`) is identical; only the inner `new XxxSDK(...)` differs, which is exactly what `createRawClient()` abstracts. Stopping at "core three" leaves the highest-copy-count patterns (4× each) in place.
+
+## Consequences
+
+- **Positive**: Adding a provider (Mistral, Cohere, etc.) now means `extends BaseChatProvider` + implementing `generate()`/`createRawClient()`/`thinkingEffort` — boilerplate is inherited. This finally realizes ADR 0011's "new provider = new adapter only" goal.
+- **Positive**: `_clone`, accessors, `StreamedMessage` skeleton, and the three normalization functions each have a single implementation. Drift across providers becomes impossible for these.
+- **Positive**: `createProvider` factory and `ProviderConfig` union are unchanged — no external API impact.
+- **Positive**: `google-genai`'s fetch-specific error handling is preserved via the `extraNetworkMatchers` hook rather than silently dropped.
+- **Negative**: Introduces an inheritance layer. Each provider now extends a base class rather than directly implementing an interface. Reverting would require changing all four providers back — moderately hard to reverse (one of the three ADR conditions).
+- **Negative**: Subclass-specific clone cleanup (e.g. `openai-completions`'s `clone._files = undefined`) needs an override or a `_resetCloneState` hook — minor per-subclass boilerplate.
+- **Negative**: Anthropic's `StreamedMessage._usage` initializes to a non-null default while the other three use `undefined`; the base unifies to `undefined` and Anthropic overrides in its constructor — a small behavioral alignment.
+
+## Related
+
+- PRD: `docs/prd/design-debt-cleanup-high-priority.md` (H4)
+- Source scan: `improve-architecture` report (2026-06-17), finding H4
+- Supersedes-none, complements: ADR 0011 (turn-boundary cache staking — benefits from consistent cross-provider normalization)

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -4,11 +4,18 @@ How the engineering skills should consume this repo's domain documentation when 
 
 ## Before exploring, read these
 
-- **`CONTEXT.md`** at the repo root, or
-- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
-- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+- **`CONTEXT.md`** at the repo root — domain glossary (core concepts, terminology, relationships)
+- **`CONTEXT-MAP.md`** at the root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/prd/`** — product requirements documents. Skills like `improve-architecture` and `review` read these for planned features and acceptance criteria.
+- **`docs/adr/`** — architecture decision records. Read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
 
-If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skills (`/grill` for CONTEXT.md and ADRs, `/think` or `/story` for PRDs) create them lazily.
+
+## What to do if files are missing
+
+If `CONTEXT.md` doesn't exist yet, consumer skills should proceed without it. The first run of `/grill` will create it lazily. Do not create an empty `CONTEXT.md` during setup — an empty file is noise.
+
+Same for `docs/prd/` and `docs/adr/` — create them only when there's actual content to write.
 
 ## File structure
 
@@ -17,9 +24,12 @@ Single-context repo (most repos):
 ```
 /
 ├── CONTEXT.md
-├── docs/adr/
-│   ├── 0001-event-sourced-orders.md
-│   └── 0002-postgres-for-write-model.md
+├── docs/
+│   ├── prd/
+│   │   └── <feature>.md
+│   └── adr/
+│       ├── 0001-event-sourced-orders.md
+│       └── 0002-postgres-for-write-model.md
 └── src/
 ```
 
@@ -28,7 +38,9 @@ Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
 ```
 /
 ├── CONTEXT-MAP.md
-├── docs/adr/                          ← system-wide decisions
+├── docs/
+│   ├── prd/                           ← shared PRDs
+│   └── adr/                           ← system-wide decisions
 └── src/
     ├── ordering/
     │   ├── CONTEXT.md

--- a/docs/prd/design-debt-cleanup-high-priority.md
+++ b/docs/prd/design-debt-cleanup-high-priority.md
@@ -442,3 +442,12 @@ function extractCacheUsage(
 - **`cache-observability-cli.md`**：H4 的 usage 归一化集中后，该 PRD 依赖的 `inputCacheRead`/`inputCacheCreation` 四字段模型有更可靠的单一来源。
 - **`ephemeral-injection-cache-optimization.md`** / **ADR 0011**：H4 让 cache hint 的 provider 适配更一致（归一化逻辑集中）。
 - **`approval-fullscreen-viewer.md`**：已 Done，H1 的 DialogManager 抽取不影响它（FileViewerComponent 已独立）。
+
+## 实现后验收记录
+
+### H1-6 行数缺口
+
+- **PRD 目标**：`byf-tui.ts` 第二阶段后 < 3000 行。
+- **实际结果**：`wc -l apps/cli/src/tui/byf-tui.ts` = **3916 行**（`main` 基准约 4154 行，净减少约 238 行）。
+- **缺口原因**：第二阶段仅抽取了 `DialogManager`（约 150 行纯 picker 转发），而 PRD 已明确保留 `setupEditorHandlers`（Ctrl-C 状态机，131 行）、流式渲染 hook、MCP/background badge 等带状态逻辑在 `ByfTui` 内。这些保留项使文件无法降到 3000 行以下。
+- **结论**：H1 的功能正确性（AC 1–5、7）与不回归要求均已满足；**H1-6 的硬数字目标未达成**，但符合 PRD 自身描述的“诚实版”瘦身范围。若合并此 PR，建议在 PR 描述中明确记录实际行数与偏差原因。

--- a/docs/prd/design-debt-cleanup-high-priority.md
+++ b/docs/prd/design-debt-cleanup-high-priority.md
@@ -1,0 +1,444 @@
+# PRD: 设计债清理 — 三个 High 项
+
+**Status**: Approved
+**Created**: 2026-06-17
+**Source**: `improve-architecture` 扫描报告（11 个发现中的 H1/H3/H4）
+
+## Child Issues
+
+* #132 — `refactor(kosong): add BaseChatProvider + BaseStreamedMessage + provider-common normalization` (AFK)
+* #133 — `refactor(agent-core): TaskEntry discriminated union, eliminate as-unknown-as-KaosProcess` (AFK)
+* #134 — `refactor(cli): remove byf-tui event forwarding shims, route directly to handlers` (AFK)
+* #135 — `fix(cli): use canonical formatTokenCount in footer` (AFK)
+* #136 — `docs: fix CONTEXT.md stale PlanMode reference` (AFK)
+* #137 — `refactor(kosong): migrate openai-completions + anthropic to BaseChatProvider` (AFK, blocked by #132)
+* #138 — `refactor(kosong): migrate openai-responses + google-genai to BaseChatProvider` (AFK, blocked by #137)
+* #139 — `refactor(cli): extract DialogManager for picker/show* methods` (AFK, blocked by #134)
+
+## 问题陈述
+
+### 背景
+
+`improve-architecture` 周期扫描发现了 11 个设计债信号（0 阻塞 / 4 高 / 7 中）。本 PRD 覆盖其中三个 High 项，它们分属三个不同的层，各自独立可交付：
+
+| ID | 层 | 位置 | 核心问题 |
+|---|---|---|---|
+| H1 | `apps/cli`（TUI） | `tui/byf-tui.ts` | 4154 行上帝对象，14 职责，38 次/4 周改动热点 |
+| H3 | `packages/agent-core` | `tools/background/manager.ts` | 1210 行上帝对象，两套执行模型用 `as unknown as KaosProcess` 硬接 |
+| H4 | `packages/kosong` | `providers/*.ts` | 4 个 provider 适配器，14 处重复，共享层只服务 2/4 |
+
+H2/M3/M6/M7 等低工作量项**不走本 PRD**，直接在实现阶段顺手修掉。
+
+### 为什么是这三项
+
+- **H1** 是全仓最高频改动文件，每次 UI 功能都碰撞在这里，合并冲突和 blame 噪声最严重。
+- **H3** 含 `as unknown as KaosProcess` 类型逃逸 —— 代码里唯一的"骗过类型系统"的点，任何依赖进程字段的代码在 agent 任务上静默失败且 TS 查不出。
+- **H4** 是 ADR 0011"新增 provider 只需新 adapter"目标的实际阻碍：每加一个 provider 就复制粘贴 14 处样板。
+
+## 目标
+
+三个项各自独立，不构成单一交付。每个项的"完成"定义见各自的验收标准。
+
+### H1：`byf-tui.ts` 瘦身（诚实版，分两阶段）
+
+- **第一阶段（零风险）**：删除 ~26 个私有转发壳（`handleTurnBegin` → `turnEventHandler.handleTurnBegin` 等），`handleEvent` switch 直接调用已抽取的 handler 类。两个长 switch（`handleEvent` + `handleBuiltInSlashCommand` 合计 54 case）改为注册表查找。
+- **第二阶段（渐进抽取）**：抽取 `DialogManager`（10+ 个纯转发 picker），评估其他可外移的 handler。
+- **诚实目标**：从 4154 行降到 ~2800 行。**不追求 1500 行** —— `setupEditorHandlers`（Ctrl-C 状态机）、流式渲染 hook 等带状态的逻辑会留在 `ByfTui` 内，强行抽出会制造寄生类。
+
+### H3：`BackgroundProcessManager` 判别联合
+
+- 把 `ManagedProcess` 拆成两个变体：`ProcessTaskEntry`（真进程，持有 `proc: KaosProcess`）和 `PromiseTaskEntry`（agent/promise 任务，持有 `completion` + `abort`），共享 `TaskCommon` 公共字段，用 `kind` 字段区分。
+- **消除 `as unknown as KaosProcess`**：agent 任务根本不出现 `proc` 字段，类型系统强制 `entry.proc` 只在 `kind === 'process'` 时可访问。
+- **对外接口不变**：`register`、`registerAgentTask`、`stop`、`list`、`onTerminal`、持久化/恢复签名保持不变（调用方 `agent.ts:242` 无感）。
+
+### H4：kosong provider 抽象基类
+
+- 引入 `abstract class BaseChatProvider implements ChatProvider`，把与 SDK 无关的样板上移：`_clone()`、`withGenerationKwargs`、accessor（`modelName`/`modelParameters`/`getCapability`）、`StreamedMessage` 骨架、`_createClient` 样板（`createRawClient()` 留给子类）。
+- 把结构相同、字段名不同的归一化逻辑做成**模板方法或配置表**：`normalizeFinishReason`、`_extractUsage`（`input - cached` 公式）、`convertError`（含 `NETWORK_RE`/`TIMEOUT_RE`）。
+- **保留在子类**：`generate()`、消息映射（`convertMessage`）、流式解析 —— 这些是协议特化，不该共享。
+- **不碰** `createProvider` factory 和 `ProviderConfig` 联合类型。
+
+## 非目标 (Out of Scope)
+
+- H2（footer `formatTokenCount` 重复）、M3（`formatBytes` 等）、M6（`tryAttach` 孪生）、M7（CONTEXT.md PlanMode）—— 低工作量，实现阶段顺手修，不立项。
+- M1（`Agent.rpcMethods` 内联分发表）、M2（`TurnFlow` 混 telemetry）、M5（`ByfCore` 门面长肉）—— Medium 项，本 PRD 不覆盖，后续扫描再评估。
+- H1 第二阶段不抽 `setupEditorHandlers`（Ctrl-C 状态机带状态，抽出会变寄生类）。
+- H3 不拆成两个独立管理器（方案 B，改动面过大，持久化/恢复/调用方都要适配两套）。
+- H4 不统一消息映射/流式解析（协议特化，强行共享会泄漏）。
+- 不改任何对外公开 API（SDK、CLI 命令、provider 配置格式）。
+- 不改 wire records 磁盘格式（H3 的 `PersistedTask` 是独立类型，改 entry 内部结构不碰它）。
+
+## 技术方案
+
+### H1：`byf-tui.ts` 瘦身
+
+#### 第一阶段：删转发壳 + 注册表化（零风险）
+
+**现状**（`byf-tui.ts:2152`）：
+```typescript
+private handleTurnBegin(event: TurnStartedEvent): void {
+  this.turnEventHandler.handleTurnBegin(event);  // 纯转发
+}
+// ... 还有 25 个同构的转发壳
+```
+
+`handleEvent` switch 内联调用这些壳（`byf-tui.ts:2059`）：
+```typescript
+switch (event.type) {
+  case 'turn.started': this.handleTurnBegin(event); break;  // 经由转发壳
+  // ... 54 个 case（两 switch 合计）
+}
+```
+
+**变更**：
+1. 删除 ~26 个私有转发壳，`handleEvent` switch 直接调用 `this.turnEventHandler.handleTurnBegin(event)` / `this.sessionMetaHandler.handleStatusUpdate(event)` / `this.subagentEventHandler.routeSubagentEvent(event)`。
+2. `handleEvent` 改为事件类型 → handler 方法的注册表查找（或保留 switch 但 case 体直接转发，二者择优，实现时定）。**关键约束**：`routeSubagentEvent`（`:2049`）在 switch 之前短路返回，这个时序要保留。
+3. `handleBuiltInSlashCommand`（84 行 switch）已有 `commands/registry.ts`，让 switch 体直接调对应方法（已经是这样），但移除其中重复的转发层。
+
+**已核实的约束**：
+- 转发壳只被 `handleEvent` switch 内联调用，**无外部引用**（`rg` 确认），删除零风险。
+- 三个 handler 类已存在：`events/turn-event-handler.ts`、`events/session-meta-handler.ts`、`events/subagent-event-handler.ts`。
+
+#### 第二阶段：抽 DialogManager + 评估外移
+
+**抽取 `DialogManager`**（纯转发 picker，~150 行）：
+- `showSessionPicker`、`showModelPicker`、`showThemePicker`、`showPermissionPicker`、`showSettingsSelector`、`showHelpPanel` 等 10+ 方法，每个都是 `mountEditorReplacement(new XxxSelector(...))` 的变体。
+- `DialogManager` 持有 `TUIState` 引用和 `FullscreenHost` 实现，构造时注入。
+- `ByfTui` 保留 `private dialogManager` 字段，picker 调用转发给它。
+
+**不抽取的**（诚实清单，double review 结论）：
+- `setupEditorHandlers`（131 行）—— Ctrl-C 退出确认状态机，读写 `pendingExit`、调 `cancelCurrentStream`/`cancelCurrentCompaction`。抽出会变寄生类。
+- 流式渲染 hook（`onStreamingTextStart/Update/End`、`onToolCallStart/End` 等）—— 紧耦合 `state.appState` 和 live pane 状态。
+- MCP 状态 UI、background-task badge —— 紧耦合事件流和 footer 状态。
+
+### H3：`BackgroundProcessManager` 判别联合
+
+**现状**（`manager.ts:808-818`，agent 任务伪造进程）：
+```typescript
+proc: {
+  stdin: { write: () => false, end: () => {} } as never,
+  stdout: { setEncoding: () => {}, on: () => {} } as never,
+  pid: 0,
+  wait: () => completion.then(() => 0),
+  kill: async () => { opts.abort?.(); },
+} as unknown as KaosProcess,  // ← 类型逃逸
+```
+
+**变更后**：
+```typescript
+// 公共字段（两类任务共享）
+interface TaskCommon {
+  taskId: string;
+  command: string;
+  description: string;
+  status: 'running' | 'completed' | 'failed' | 'killed';
+  startedAt: number;
+  endedAt: number | null;
+  exitCode: number | null;
+  waiters: Array<...>;
+  terminalFired: boolean;
+  stopRequested: boolean;
+  outputSessionDir: string | undefined;
+  lifecyclePromise: Promise<void>;
+  persistWriteQueue: Promise<void>;
+  outputWriteQueue: Promise<void>;
+  // agent 任务标识（沿用现状）
+  agentId?: string;
+  subagentType?: string;
+}
+
+// 真进程任务
+interface ProcessTaskEntry extends TaskCommon {
+  kind: 'process';
+  proc: KaosProcess;
+  timeoutMs?: number;
+}
+
+// agent / promise 任务
+interface PromiseTaskEntry extends TaskCommon {
+  kind: 'promise';
+  completion: Promise<{ result: string }>;
+  abort: () => void;
+  timeoutMs?: number;
+}
+
+type TaskEntry = ProcessTaskEntry | PromiseTaskEntry;
+```
+
+**关于 `outputChunks`**：现状 `outputChunks: string[]`（`manager.ts:112`，已核实），两类任务都已用 string 存储（进程 stdout chunk 和 agent 结果字符串都是 string），**无类型摩擦**。因此 `outputChunks`/`outputSizeBytes` 直接上移到 `TaskCommon` —— 两类任务的输出展示需求一致（持久化、`/tasks` 面板、ring buffer 裁剪）。
+
+**关键改动点**（只在这几处触碰 `proc`，已 `rg` 核实共 6 处）：
+1. `register()` —— 构造 `ProcessTaskEntry`（`kind: 'process'`），保持现有 proc 接线。
+2. `registerAgentTask()` —— 构造 `PromiseTaskEntry`（`kind: 'promise'`），**不再创建假 `proc`**。deadline race 逻辑（`manager.ts:840-899`）保持不变，只是从 `entry.proc` 换成 `entry.completion`/`entry.abort`。
+3. `stop()`（`:673,700,702`）—— 按 `kind` 分支：process 走 SIGTERM→SIGKILL（`entry.proc.kill`），promise 走 `entry.abort()`。
+4. `toInfo`/`settleProcessExit`（`:1067,1125,1138`）—— 按 `kind` 组装 `TaskInfo`，`entry.proc.pid` 只在 `kind === 'process'` 时读取；promise 任务的 pid 返回 `null`。
+5. `appendOutput`/`flushOutput`/`getOutput`/`readOutput` —— 操作 `TaskCommon.outputChunks`，两类任务共用，无需分支。
+
+**类型重命名**：`ManagedProcess` 类型重命名为 `TaskEntry`（决策 1）。约 20 处引用批量更新（`appendOutput(entry: ManagedProcess, ...)` 等）。诚实反映"它可能是进程也可能是 promise"。
+
+**持久化 + reconcile 路径完全不动**：`persist.ts` 用独立的 `PersistedTask` 类型。**关键事实（grill 核实）**：`reconcile`/`loadFromDisk` 把磁盘任务加载进 `ghosts` map（`BackgroundTaskInfo` 只读快照），running 的标记为 `lost`（`manager.ts:1010-1029`）—— **它根本不重建活动 `TaskEntry`**，因为进程和 promise 都无法从磁盘恢复。因此判别联合**不影响 reconcile 路径**，无需"从前缀判 kind 重建 entry"的逻辑。
+
+### H4：kosong provider 抽象基类
+
+**现状**：4 个 provider 都 `implements ChatProvider`（接口，无基类），`_clone`/`_createClient`/accessor/`StreamedMessage` 骨架各拷贝 4 份。`openai-common.ts` 只服务 2/4 adapter（OpenAI 家族）。
+
+**变更后**：
+
+```typescript
+// providers/base-chat-provider.ts (新增)
+export abstract class BaseChatProvider implements ChatProvider {
+  protected constructor(
+    protected readonly _model: string,
+    protected _generationKwargs: GenerationKwargs = {},
+    protected readonly _apiKey?: string,
+    protected readonly _baseUrl?: string,
+    protected readonly _defaultHeaders?: Record<string, string>,
+    protected _client?: unknown,           // 各 SDK 的 client 类型由子类约束
+    protected readonly _clientFactory?: () => unknown,
+  ) {}
+
+  // —— 上移的样板 ——
+  get modelName(): string { return this._model; }
+  get modelParameters(): Record<string, unknown> {
+    return { model: this._model, ...this._generationKwargs };
+  }
+  getCapability(model?: string): ProviderCapability {
+    return lookupCapability(this.capabilityKey, model ?? this._model);
+  }
+  abstract get capabilityKey(): ProviderCapabilityKey;
+
+  withGenerationKwargs(kwargs: GenerationKwargs): this {
+    const clone = this._clone();
+    clone._generationKwargs = { ...clone._generationKwargs, ...kwargs };
+    return clone;
+  }
+
+  protected _clone(): this {
+    const clone = Object.assign(
+      Object.create(Object.getPrototypeOf(this) as object) as this, this,
+    );
+    clone._generationKwargs = { ...this._generationKwargs };
+    return clone;
+  }
+
+  protected _createClient(auth: ProviderRequestAuth | undefined): unknown {
+    return resolveAuthBackedClient(
+      { cachedClient: this._client, clientFactory: this._clientFactory },
+      auth,
+      (a) => {
+        const defaultHeaders = mergeRequestHeaders(this._defaultHeaders, a?.headers);
+        return this.createRawClient(a, defaultHeaders);  // 子类实现
+      },
+    );
+  }
+
+  protected abstract createRawClient(
+    auth: ResolvedAuth,
+    defaultHeaders: Record<string, string> | undefined,
+  ): unknown;
+
+  // —— 子类必须实现 ——
+  abstract generate(...): StreamedMessage;
+  abstract get thinkingEffort(): ThinkingEffort | undefined;
+}
+```
+
+**`StreamedMessage` 骨架上移**（`providers/streamed-message.ts` 新增）：
+```typescript
+export abstract class BaseStreamedMessage implements StreamedMessage {
+  protected _id: string | undefined;
+  protected _usage: TokenUsage | undefined;
+  protected _finishReason: FinishReason | undefined;
+  protected _rawFinishReason: string | undefined;
+  protected _iter: AsyncIterable<StreamedMessagePart>;
+
+  constructor(iter: AsyncIterable<StreamedMessagePart>) {
+    this._iter = iter;
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<StreamedMessagePart> {
+    yield* this._iter;
+  }
+  get id() { return this._id; }
+  get usage() { return this._usage; }
+  get finishReason() { return this._finishReason; }
+  get rawFinishReason() { return this._rawFinishReason; }
+}
+```
+
+**归一化逻辑做成配置驱动**（新建 `provider-common.ts`，决策 2）：
+```typescript
+// finish reason：结构相同，case 标签不同
+function makeFinishReasonNormalizer(
+  mapping: Record<string, FinishReason>,
+): (raw: string | null) => { finishReason: FinishReason; rawFinishReason: string | undefined } {
+  return (raw) => {
+    if (!raw) return { finishReason: 'unknown', rawFinishReason: undefined };
+    return { finishReason: mapping[raw] ?? 'unknown', rawFinishReason: raw };
+  };
+}
+
+// usage：input - cached 公式，字段名不同
+function extractCacheUsage(
+  total: number,
+  cached: number,
+  output: number,
+): TokenUsage {
+  return { inputOther: Math.max(0, total - cached), output, inputCacheRead: cached, inputCacheCreation: 0 };
+}
+
+// error：共享 NETWORK_RE/TIMEOUT_RE + 分类梯子
+// convertOpenAIError 已在 openai-common.ts，提炼成通用 convertProviderError
+```
+
+**关于 google-genai 的 regex（grill 修正）**：google 版（`google-genai.ts:637`）不是纯重复——它比 openai-common 版多了 `| fetch failed` 分支，并在 `:655` 额外处理 `error instanceof TypeError && msg.includes('fetch')`（google SDK 用 fetch，TypeError 是它的网络错误形态）。归一化时**必须保留 google 的额外 fetch 处理**，不能简单删除。做法：`convertProviderError` 接受一个可选的 provider 特化钩子（如 `extraNetworkMatchers?: RegExp[]`），google 传入 `[/^fetch failed$/i]` + TypeError 检查。
+
+**各 provider 改造**：
+- `anthropic.ts`：`extends BaseChatProvider`，`createRawClient` 返回 `new Anthropic({...})`，保留自己的 `generate`/`convertMessage`/流式解析/cache_control 注入。`StreamedMessage` 继承 `BaseStreamedMessage`。
+- `openai-completions.ts` / `openai-responses.ts`：`extends BaseChatProvider`，`createRawClient` 返回 `new OpenAI({...})`。`deriveCacheKeyFromPromptPlan` 可上移到基类或保留在 `provider-common.ts`（两者择一）。
+- `google-genai.ts`：`extends BaseChatProvider`，改用共享的 `convertProviderError`（传入 fetch 特化钩子），保留 vertex 分支（`_createClient` 里 `if (this._vertexai)` 那段逻辑进 `createRawClient`）。
+
+**不改动**：
+- `provider.ts` 的 `ChatProvider` 接口（`BaseChatProvider implements` 它，接口不变）。
+- `providers/index.ts` 的 `createProvider` factory（`new XxxChatProvider(config)` 无感）。
+- `ProviderConfig` 联合类型。
+- 各 provider 的 `generate()`、消息映射、流式解析逻辑。
+
+## 验收标准
+
+### H1
+
+#### 功能正确性
+1. **转发壳删除**：`byf-tui.ts` 中不再有形如 `private handleXxx(event) { this.xxxHandler.handleXxx(event); }` 的单行转发方法（`handleEvent` switch 直接调 handler 类）
+2. **事件路由时序**：`routeSubagentEvent` 仍在 switch 之前短路返回（`byf-tui.ts:2049` 的时序保留）
+3. **slash command 分发**：`handleBuiltInSlashCommand` 行为不变，所有内置命令（exit/help/version/new/sessions/tasks 等）仍正常工作
+4. **DialogManager 抽取**（第二阶段）：10+ 个 picker 方法通过 `dialogManager` 调用，`ByfTui` 不再直接 `new XxxSelector`
+
+#### 不回归
+5. **所有现有 TUI 行为不变**：输入、streaming、approval、compaction、subagent chip、footer、所有 picker
+6. **`byf-tui.ts` 行数下降**：第一阶段后 < 4050 行（删 ~100 行转发壳）；第二阶段后 < 3000 行（抽 DialogManager 等）
+7. **`byf-tui-message-flow.test.ts` 等现有测试全部通过**（这是 byf-tui 的端到端覆盖）
+
+### H3
+
+#### 功能正确性
+8. **类型安全**：`manager.ts` 中不再出现 `as unknown as KaosProcess`（`rg` 确认零匹配）
+9. **判别联合**：`TaskEntry` 是 `ProcessTaskEntry | PromiseTaskEntry`，访问 `entry.proc` 前必须有 `entry.kind === 'process'` 守卫（TS 编译强制）
+10. **对外接口不变**：`register`、`registerAgentTask`、`stop`、`list`、`onTerminal`、`getTask`、`waitForTerminal` 等方法签名不变；调用方 `agent.ts:242` 无需修改
+11. **持久化兼容**：`PersistedTask` 磁盘格式不变；旧 session 恢复正常（reconcile 不重建活动 entry，已 grill 核实）
+
+#### 不回归
+12. **进程任务行为不变**：SIGTERM→5s→SIGKILL、stdout/stderr 采集、ring buffer、disk offload 全部正常
+13. **agent 任务行为不变**：deadline race、abort 回调、`RunCancelled` → killed 映射、结果 appendOutput 全部正常
+14. **现有 background 测试全部通过**
+
+### H4
+
+#### 功能正确性
+15. **基类引入**：`BaseChatProvider` 和 `BaseStreamedMessage` 存在，4 个 provider 均 `extends BaseChatProvider`
+16. **样板消除**：`_clone`、`withGenerationKwargs`、accessor（`modelName`/`modelParameters`/`getCapability`）、`StreamedMessage` 骨架在基类中只有一份实现
+17. **归一化集中**：`normalizeFinishReason`、`extractCacheUsage`、`convertProviderError`（含 `NETWORK_RE`/`TIMEOUT_RE`）在共享模块中只有一份；`google-genai.ts:637-638` 的重复 regex 删除
+18. **子类只保留特化**：`generate()`、消息映射、流式解析、cache_control/prompt_cache_key 注入留在各 provider
+
+#### 不回归
+19. **`createProvider` factory 不变**：`new XxxChatProvider(config)` 调用方式无感
+20. **四个 provider 的请求/响应行为完全不变**：消息格式、流式事件、usage 解析、error 归类、cache 行为
+21. **kosong 现有测试全部通过**（含各 provider 的单元测试）
+22. **cache 可观测性数据不受影响**：`inputCacheRead`/`inputCacheCreation` 解析结果与改造前一致（`cache-observability-cli.md` PRD 依赖的 4 字段模型不变）
+
+### 通用
+23. **每个项独立可交付**：H1/H3/H4 互不依赖，可分别 PR
+24. **伴随低工作量修复**（非阻塞，实现时顺手）：H2（footer `formatTokenCount` 用 canonical 版）、M7（CONTEXT.md PlanMode → FullCompaction）
+
+## 边界情况
+
+### H3
+- **agent 任务也要展示输出**：agent 的结果字符串（`completion.then(r => r.result)`）目前通过 `appendOutput` 写入。**决策（已核实类型）**：`outputChunks: string[]`（`manager.ts:112`），两类任务都已用 string，`outputChunks`/`outputSizeBytes` 上移到 `TaskCommon`，无类型摩擦。
+- **恢复路径不受影响（grill 核实）**：`reconcile`/`loadFromDisk` 把磁盘任务加载进 `ghosts` map（`BackgroundTaskInfo` 只读快照），running 的标记为 `lost`——**它不重建活动 `TaskEntry`**，因为进程和 promise 都无法从磁盘恢复。判别联合只影响活动 entry 的构造和处理，reconcile/ghost 路径完全无感。
+- **`stop()` 对 promise 任务的语义**：调 `entry.abort()`，状态机走 `stopRequested` → `killed`（沿用现状 `manager.ts:879-881`）。
+
+### H4
+- **`_clone` 的 `_files` 清理**：`openai-completions.ts:666` 的 `clone._files = undefined` 是该 provider 特有，基类 `_clone` 不含；子类 override `_clone` 后追加，或在基类提供 `protected _resetCloneState(clone: this): void` 钩子。
+- **Anthropic 的 `_usage` 初始化差异**：现状 anthropic 的 `StreamedMessage._usage` 用非空默认对象，其他三家用 `undefined`。基类统一为 `undefined`，anthropic 子类在构造时覆盖。
+- **`thinkingEffort` 的 provider 差异**：每个 provider 的 getter 实现不同（映射逻辑不同），保留为 abstract。
+
+### H1
+- **switch 改注册表的 `routeSubagentEvent` 短路**：`byf-tui.ts:2049` 在进入 switch 前先 `if (this.routeSubagentEvent(event)) return;`，改注册表后这个短路必须保留（subagent 事件不进通用分发）。
+- **`handleEvent` 的 case 数量大（两 switch 合计 54）**：注册表化是机械替换，但要保证每个 case 的 handler 接收的 event 类型正确（TS 穷尽检查）。
+
+## 风险与缓解
+
+| 风险 | 影响 | 缓解 |
+|---|---|---|
+| H1 第一阶段删转发壳破坏事件路由 | 事件处理静默失败 | `byf-tui-message-flow.test.ts` 端到端覆盖；逐个 case 删除并跑测试 |
+| H1 第二阶段停在半途比 C 还糟 | 中间态更难读 | 第二阶段单独 PR，明确 DialogManager 为最小可交付；若评估后不值得做，停在第一阶段（已是净改善） |
+| H3 判别联合遗漏某个触碰 `proc` 的方法 | 运行时访问 undefined | TS 编译器强制 `kind` 守卫；`rg "entry\.proc\|\.proc\."` 全量审计 |
+| H3 `outputChunks` 上移到 TaskCommon 后两类任务语义混淆 | ~~进程输出（Buffer 流）vs agent 输出（结果字符串）混在一起~~ **grill 核实**：现状已是 `string[]`，两类任务无类型摩擦，语义统一为"任务输出文本" |
+| H4 基类 `_clone` 的 `Object.create(proto)` 在子类有额外字段时漏拷 | 子类状态丢失 | 各子类覆盖 `_clone` 追加特有字段清理（如 `_files`）；新增 `test` 验证 clone 深拷 |
+| H4 归一化配置驱动后 case 标签映射表写错 | finish reason 错判 | 各 provider 现有测试覆盖；保留 `rawFinishReason` 便于排查 |
+| 三个项同时进行导致 review 负担 | PR 过大 | 强制三个独立 PR，互不依赖 |
+
+## 关键决策记录
+
+架构级决策（H3/H4）已升级为正式 ADR，此处只留摘要 + 链接。其余决策保留完整论证。
+
+| 决策 | 结论 | 理由 / 链接 |
+|---|---|---|
+| H3 拆分方式 | **判别联合** | → `docs/adr/0014-task-entry-discriminated-union.md`。对外接口统一、对内区分，消除 `as unknown as KaosProcess`，TS 强制 kind 守卫 |
+| H3 类型重命名 | `ManagedProcess` → `TaskEntry` | 诚实反映"它可能是进程也可能是 promise"，~20 处引用批量更新（grill 决策 1） |
+| H3 outputChunks 位置 | 上移到 `TaskCommon` | 现状已是 `string[]`（grill 核实），两类任务无类型摩擦 |
+| H3 reconcile 路径 | **不动** | grill 核实：reconcile 不重建活动 entry（进程/promise 都无法恢复），判别联合只影响活动 entry 构造 |
+| H4 共享方式 | **抽象基类 BaseChatProvider** | → `docs/adr/0015-base-chat-provider.md`。样板（_clone/accessor/StreamedMessage 骨架）与 SDK 无关适合上移；归一化逻辑配置驱动 |
+| H4 归一化代码位置 | 新建 `provider-common.ts` | 跨 provider 归一化与 `openai-common.ts`（OpenAI 家族 wire-format）职责分离（grill 决策 2） |
+| H4 迁移顺序 | openai-completions + anthropic 先（tracer bullet） | 确立骨架 + 验证跨协议可用，再批量迁 responses/google（grill 决策 6） |
+| H4 google fetch 处理 | 保留为特化钩子 | google 的 `fetch failed`/TypeError 处理不是纯重复，`convertProviderError` 接受 `extraNetworkMatchers` 钩子（grill 修正） |
+| H4 保留 generate/消息映射在子类 | 不共享 | 协议特化，强行共享会泄漏抽象 |
+| H1 ByfTui 处理方式 | **瘦身组合根（诚实版）** | UI 根对象作为聚合点合理，问题是混入非 UI 职责。完全拆解会因状态共享（pendingExit/cancelInFlight 跨职责）制造新耦合。诚实目标 ~2800 行 |
+| H1 不抽 setupEditorHandlers | 保留在 ByfTui | Ctrl-C 状态机读写 ByfTui 的 pendingExit/cancelCurrentStream，抽出会变寄生类，违反深模块原则 |
+| H1 DialogManager 状态共享 | 注入 `FullscreenHost` 接口 + `TUIState` + `getSession()` 回调 | 只依赖接口，符合现有 `DialogHost` 模式（grill 决策 3） |
+| ADR 范围 | H3+H4 各立 ADR，H1 记 PRD | H3/H4 满足三条件（难逆转/无背景会困惑/真实权衡），H1 偏渐进重构（grill 决策 4） |
+| PRD vs ADR 边界 | PRD 留摘要 + ADR 链接 | 避免两处长文维护漂移（grill 决策 5） |
+| 三项独立 PR | 是 | 互不依赖，分属不同层，独立可交付 |
+| 低工作量项不走 PRD | 顺手修 | H2/M3/M6/M7 各 1-3 文件，无需 PRD 规划 |
+
+## 实现计划
+
+三个项各自独立。H4 迁移顺序已按 grill 决策 6 调整（tracer bullet 先行）。
+
+| 阶段 | 任务 | 依赖 |
+|---|---|---|
+| **H4-1** | 新增 `BaseChatProvider` + `BaseStreamedMessage` + `provider-common.ts`（归一化） | 无 |
+| **H4-2** | openai-completions（确立骨架）+ anthropic（跨协议验证）extends 基类 | H4-1 |
+| **H4-3** | openai-responses + google-genai extends 基类；google 传入 fetch 特化钩子 | H4-2 |
+| **H3-1** | 定义 `TaskEntry` 判别联合 + `TaskCommon`；`ManagedProcess` → `TaskEntry` 重命名 | 无 |
+| **H3-2** | `manager.ts` 内部存储改 `Map<string, TaskEntry>`；改造 `register`/`registerAgentTask`/`stop`/`toInfo`/`settleProcessExit`（6 处 proc 触碰点按 kind 分支） | H3-1 |
+| **H3-3** | 全量测试（reconcile 路径无需专门验证，已确认不受影响） | H3-2 |
+| **H1-1** | 删除 ~26 个转发壳，`handleEvent` switch 直接调 handler | 无 |
+| **H1-2** | 抽取 `DialogManager`（注入 FullscreenHost + TUIState + getSession），picker 方法外移 | H1-1 |
+| **顺手** | H2 footer formatTokenCount、M7 CONTEXT.md PlanMode | 任意阶段 |
+
+建议 H4 先做（纯加法 + 删重复，风险最低），H3 次之（一个文件内部改造），H1 最后（涉及最多调用点）。
+
+## Domain Terms
+
+本 PRD 未引入新的领域术语。复用 CONTEXT.md 中的既有术语：BackgroundProcessManager、TaskEntry（新，但属于实现术语非领域术语）、BaseChatProvider（同前）。
+
+## Traceability
+
+- **Created by**: `/think` (2026-06-17) — 基于 `improve-architecture` 扫描报告的 H1/H3/H4 三项设计债
+- **Grilled by**: `/grill` (2026-06-17) — 修正 3 处代码矛盾（google regex 非纯重复 / outputChunks 实为 string[] / case 数 54 非 76）、推翻 reconcile 重建 entry 的错误假设（消除 H3-2 slice）、敲定 6 个开放决策（类型重命名/共享文件位置/DialogManager 状态共享/ADR 范围/PRD-ADR 边界/H4 迁移顺序）、升级 H3+H4 为正式 ADR
+- **Sliced by**: `/story` (2026-06-17) → Child Issues above（8 片：H4 三片 #132/#137/#138、H3 一片 #133、H1 两片 #134/#139、收尾两片 #135/#136）
+
+## Expansion Considerations
+
+### Future Evolution
+
+- **H1 之后**：若 `ByfTui` 仍超 2500 行，评估 M1（`Agent.rpcMethods` 模式）—— 把 `handleEvent` 改成完全的事件总线订阅（handler 自注册），彻底去掉中心 switch。
+- **H3 之后**：`BackgroundProcessManager` 若再增第三类任务（如 webhook 任务），判别联合自然扩展加一个变体即可。
+- **H4 之后**：新增 provider（如 Mistral、Cohere）只需 extends `BaseChatProvider` + 实现 `generate`/`createRawClient`，样板自动获得。这是 ADR 0011 "新增 provider 只需新 adapter" 目标的真正达成。
+
+### 与既有 PRD 的关系
+
+- **`cache-observability-cli.md`**：H4 的 usage 归一化集中后，该 PRD 依赖的 `inputCacheRead`/`inputCacheCreation` 四字段模型有更可靠的单一来源。
+- **`ephemeral-injection-cache-optimization.md`** / **ADR 0011**：H4 让 cache hint 的 provider 适配更一致（归一化逻辑集中）。
+- **`approval-fullscreen-viewer.md`**：已 Done，H1 的 DialogManager 抽取不影响它（FileViewerComponent 已独立）。

--- a/packages/agent-core/src/tools/background/manager.ts
+++ b/packages/agent-core/src/tools/background/manager.ts
@@ -77,7 +77,7 @@ export interface BackgroundTaskInfo {
   readonly command: string;
   readonly description: string;
   readonly status: BackgroundTaskStatus;
-  readonly pid: number;
+  readonly pid: number | null;
   readonly exitCode: number | null;
   readonly startedAt: number;
   readonly endedAt: number | null;
@@ -104,11 +104,10 @@ export interface BackgroundTaskInfo {
   readonly failureReason?: string | undefined;
 }
 
-interface ManagedProcess {
+interface TaskCommon {
   readonly taskId: string;
   readonly command: string;
   readonly description: string;
-  readonly proc: KaosProcess;
   readonly outputChunks: string[];
   /** Total UTF-8 bytes observed, including chunks dropped from the live ring buffer. */
   outputSizeBytes: number;
@@ -142,6 +141,34 @@ interface ManagedProcess {
   persistWriteQueue: Promise<void>;
   outputWriteQueue: Promise<void>;
 }
+
+/**
+ * Real OS-process task. Lifecycle is driven by `proc.wait()`; cancellation is
+ * SIGTERM → 5s grace → SIGKILL.
+ *
+ * See ADR 0014 (TaskEntry discriminated union).
+ */
+interface ProcessTaskEntry extends TaskCommon {
+  readonly kind: 'process';
+  readonly proc: KaosProcess;
+}
+
+/**
+ * Agent / Promise-based task. Lifecycle is driven by `completion`; cancellation
+ * is the `abort` callback (idempotent). Has no pid and no process streams.
+ *
+ * See ADR 0014.
+ */
+interface PromiseTaskEntry extends TaskCommon {
+  readonly kind: 'promise';
+  /** Resolves with the agent's result text, written to outputChunks on success. */
+  completion: Promise<{ result: string }>;
+  /** Idempotent cancellation. Called on stop() and on deadline expiry. */
+  abort: () => void;
+}
+
+/** Active background task: a real process or a Promise-based agent task. */
+type TaskEntry = ProcessTaskEntry | PromiseTaskEntry;
 
 /**
  * Maximum bytes of combined output kept in the in-memory ring buffer per
@@ -220,7 +247,7 @@ function emptyOutputSnapshot(): BackgroundTaskOutputSnapshot {
 // ── Manager ──────────────────────────────────────────────────────────
 
 export class BackgroundProcessManager {
-  private readonly processes = new Map<string, ManagedProcess>();
+  private readonly processes = new Map<string, TaskEntry>();
   private reservedTaskSlots = 0;
   /**
    * Ghosts: tasks loaded from disk during reconcile that have no live
@@ -302,7 +329,7 @@ export class BackgroundProcessManager {
    * exit cannot yield duplicate notifications. This is the manager-side
    * half of the dedupe pact with `NotificationManager.dedupe_key`.
    */
-  private fireTerminalCallbacks(entry: ManagedProcess): void {
+  private fireTerminalCallbacks(entry: TaskEntry): void {
     if (entry.terminalFired) return;
     entry.terminalFired = true;
     const info = this.toInfo(entry);
@@ -331,7 +358,7 @@ export class BackgroundProcessManager {
     this.fireLifecycle('terminated', info);
   }
 
-  private resolveWaiters(entry: ManagedProcess): void {
+  private resolveWaiters(entry: TaskEntry): void {
     const waiters = entry.waiters.splice(0);
     for (const resolve of waiters) resolve();
   }
@@ -407,7 +434,8 @@ export class BackgroundProcessManager {
     }
     const kind = opts?.kind;
     const taskId = generateTaskId(kind ?? 'bash');
-    const entry: ManagedProcess = {
+    const entry: TaskEntry = {
+      kind: 'process',
       taskId,
       command,
       description,
@@ -669,10 +697,14 @@ export class BackgroundProcessManager {
     entry.stopRequested = true;
     entry.stopReason = stopReason;
 
-    try {
-      await entry.proc.kill('SIGTERM');
-    } catch {
-      /* process already gone */
+    if (entry.kind === 'process') {
+      try {
+        await entry.proc.kill('SIGTERM');
+      } catch {
+        /* process already gone */
+      }
+    } else {
+      entry.abort();
     }
 
     // Wait up to 5s for the lifecycle path to settle, then SIGKILL.
@@ -697,11 +729,18 @@ export class BackgroundProcessManager {
       return this.toInfo(entry);
     }
 
-    if (!graceful && entry.proc.exitCode === null) {
-      try {
-        await entry.proc.kill('SIGKILL');
-      } catch {
-        /* ignore */
+    if (!graceful) {
+      if (entry.kind === 'process') {
+        if (entry.proc.exitCode === null) {
+          try {
+            await entry.proc.kill('SIGKILL');
+          } catch {
+            /* ignore */
+          }
+        }
+      } else {
+        // Promise tasks have no SIGKILL; abort is idempotent, so re-issue.
+        entry.abort();
       }
     }
 
@@ -793,29 +832,22 @@ export class BackgroundProcessManager {
       this.assertCanRegister();
     }
     const taskId = generateTaskId('agent');
-    const entry: ManagedProcess = {
+    const entry: TaskEntry = {
+      // Agent tasks are Promise-based, not process-based — no KaosProcess.
+      // See ADR 0014 (TaskEntry discriminated union).
+      kind: 'promise',
       taskId,
       command: `[agent] ${description}`,
       description,
       timeoutMs: opts.timeoutMs,
+      completion,
+      abort: () => opts.abort?.(),
       // Fall back to defaults that satisfy callers reading these fields
       // without forcing every call site to supply them. The dedicated
       // dispatch path in AgentTool passes the real handle.agentId /
       // handle.profileName.
       agentId: opts.agentId ?? taskId,
       subagentType: opts.subagentType ?? 'agent',
-      // Dummy KaosProcess — agent tasks are Promise-based, not process-based
-      proc: {
-        stdin: { write: () => false, end: () => {} } as never,
-        stdout: { setEncoding: () => {}, on: () => {} } as never,
-        stderr: { setEncoding: () => {}, on: () => {} } as never,
-        pid: 0,
-        exitCode: null,
-        wait: () => completion.then(() => 0),
-        kill: async () => {
-          opts.abort?.();
-        },
-      } as unknown as KaosProcess,
       outputChunks: [],
       outputSizeBytes: 0,
       status: 'running',
@@ -1054,17 +1086,17 @@ export class BackgroundProcessManager {
   }
 
   /**
-   * Persist the current state of a live ManagedProcess. Called from
+   * Persist the current state of a live TaskEntry. Called from
    * `register()` and the lifecycle finally block. No-op unless attached.
    */
-  private persistLive(entry: ManagedProcess): Promise<void> {
+  private persistLive(entry: TaskEntry): Promise<void> {
     if (this.sessionDir === undefined) return Promise.resolve();
     const sessionDir = this.sessionDir;
     const task: PersistedTask = {
       task_id: entry.taskId,
       command: entry.command,
       description: entry.description,
-      pid: entry.proc.pid,
+      pid: entry.kind === 'process' ? entry.proc.pid : 0,
       started_at: entry.startedAt,
       ended_at: entry.endedAt,
       exit_code: entry.exitCode,
@@ -1079,7 +1111,7 @@ export class BackgroundProcessManager {
     return entry.persistWriteQueue;
   }
 
-  private appendOutput(entry: ManagedProcess, chunk: string): void {
+  private appendOutput(entry: TaskEntry, chunk: string): void {
     entry.outputSizeBytes += Buffer.byteLength(chunk, 'utf-8');
     entry.outputChunks.push(chunk);
     // Enforce output cap: drop oldest chunks when over budget.
@@ -1104,7 +1136,7 @@ export class BackgroundProcessManager {
     return undefined;
   }
 
-  private async settleProcessExit(entry: ManagedProcess, exitCode: number): Promise<void> {
+  private async settleProcessExit(entry: TaskEntry, exitCode: number): Promise<void> {
     if (TERMINAL_STATUSES.has(entry.status)) {
       if (entry.status === 'killed' && entry.exitCode === null) {
         entry.exitCode = exitCode;
@@ -1122,20 +1154,20 @@ export class BackgroundProcessManager {
   private observedExitCompletions(): Promise<void>[] {
     const completions: Promise<void>[] = [];
     for (const entry of this.processes.values()) {
-      if (!TERMINAL_STATUSES.has(entry.status) && entry.proc.exitCode !== null) {
+      if (entry.kind === 'process' && !TERMINAL_STATUSES.has(entry.status) && entry.proc.exitCode !== null) {
         completions.push(entry.lifecyclePromise);
       }
     }
     return completions;
   }
 
-  private toInfo(entry: ManagedProcess): BackgroundTaskInfo {
+  private toInfo(entry: TaskEntry): BackgroundTaskInfo {
     return {
       taskId: entry.taskId,
       command: entry.command,
       description: entry.description,
       status: entry.status,
-      pid: entry.proc.pid,
+      pid: entry.kind === 'process' ? entry.proc.pid : null,
       exitCode: entry.exitCode,
       startedAt: entry.startedAt,
       endedAt: entry.endedAt,
@@ -1150,7 +1182,7 @@ export class BackgroundProcessManager {
   }
 
   private async finalizeTerminal(
-    entry: ManagedProcess,
+    entry: TaskEntry,
     status: BackgroundTaskStatus,
     exitCode: number | null,
     options: { readonly timedOut?: boolean; readonly stopReason?: string } = {},
@@ -1198,7 +1230,7 @@ function infoToPersisted(info: BackgroundTaskInfo): PersistedTask {
     task_id: info.taskId,
     command: info.command,
     description: info.description,
-    pid: info.pid,
+    pid: info.pid ?? 0,
     started_at: info.startedAt,
     ended_at: info.endedAt,
     exit_code: info.exitCode,

--- a/packages/agent-core/test/tools/background/manager.test.ts
+++ b/packages/agent-core/test/tools/background/manager.test.ts
@@ -224,8 +224,9 @@ describe('BackgroundProcessManager', () => {
     const info = manager.getTask(taskId);
     expect(info).toBeDefined();
     expect(info!.status).toBe('running');
-    // Agent tasks use pid=0 (dummy KaosProcess).
-    expect(info!.pid).toBe(0);
+    // Agent tasks have no real pid — BackgroundTaskInfo.pid is null for
+    // Promise-based tasks (ADR 0014 TaskEntry discriminated union).
+    expect(info!.pid).toBeNull();
     // Spec marker: command includes the `[agent]` tag so LLM renderers
     // can distinguish bash vs agent entries when scrolling tasks.
     expect(info!.command).toContain('[agent]');

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -7,7 +7,6 @@ import {
 } from '#/errors';
 import type { ContentPart, Message, StreamedMessagePart, ToolCall } from '#/message';
 import type {
-  ChatProvider,
   FinishReason,
   GenerateOptions,
   ProviderRequestAuth,
@@ -16,7 +15,6 @@ import type {
 } from '#/provider';
 import type { PromptPlan } from '#/prompt-plan';
 import type { Tool } from '#/tool';
-import type { TokenUsage } from '#/usage';
 import Anthropic, {
   APIError as AnthropicAPIError,
   APIConnectionError as AnthropicConnectionError,
@@ -44,6 +42,17 @@ import {
   mergeRequestHeaders,
 } from './request-auth';
 import { BaseChatProvider, type ResolvedAuth } from './base-chat-provider';
+import { BaseStreamedMessage } from './base-streamed-message';
+import { makeFinishReasonNormalizer } from './provider-common';
+
+const ANTHROPIC_STOP_REASON_MAP: Readonly<Record<string, FinishReason>> = {
+  end_turn: 'completed',
+  stop_sequence: 'completed',
+  max_tokens: 'truncated',
+  tool_use: 'tool_calls',
+  pause_turn: 'paused',
+  refusal: 'filtered',
+};
 
 /**
  * Normalize an Anthropic `stop_reason` string to the unified
@@ -52,29 +61,7 @@ import { BaseChatProvider, type ResolvedAuth } from './base-chat-provider';
  * Source: `message.stop_reason` (non-stream) or the last `message_delta`
  * event's `delta.stop_reason` (stream).
  */
-function normalizeAnthropicStopReason(raw: string | null | undefined): {
-  finishReason: FinishReason | null;
-  rawFinishReason: string | null;
-} {
-  if (raw === null || raw === undefined) {
-    return { finishReason: null, rawFinishReason: null };
-  }
-  switch (raw) {
-    case 'end_turn':
-    case 'stop_sequence':
-      return { finishReason: 'completed', rawFinishReason: raw };
-    case 'max_tokens':
-      return { finishReason: 'truncated', rawFinishReason: raw };
-    case 'tool_use':
-      return { finishReason: 'tool_calls', rawFinishReason: raw };
-    case 'pause_turn':
-      return { finishReason: 'paused', rawFinishReason: raw };
-    case 'refusal':
-      return { finishReason: 'filtered', rawFinishReason: raw };
-    default:
-      return { finishReason: 'other', rawFinishReason: raw };
-  }
-}
+const normalizeAnthropicStopReason = makeFinishReasonNormalizer(ANTHROPIC_STOP_REASON_MAP);
 export interface AnthropicOptions {
   apiKey?: string | undefined;
   baseUrl?: string | undefined;
@@ -522,65 +509,50 @@ export function convertAnthropicError(error: unknown): ChatProviderError {
   }
   return new ChatProviderError(`Error: ${String(error)}`);
 }
-class AnthropicStreamedMessage implements StreamedMessage {
-  private _id: string | null = null;
-  private _usage: TokenUsage = {
-    inputOther: 0,
-    output: 0,
-    inputCacheRead: 0,
-    inputCacheCreation: 0,
-  };
-  private _finishReason: FinishReason | null = null;
-  private _rawFinishReason: string | null = null;
-  private readonly _iter: AsyncGenerator<StreamedMessagePart>;
+class AnthropicStreamedMessage extends BaseStreamedMessage {
+  private readonly _response: unknown;
+  private readonly _isStream: boolean;
 
   constructor(response: unknown, isStream: boolean) {
-    if (isStream) {
-      this._iter = this._convertStreamResponse(response as AsyncIterable<MessageStreamEvent>);
-    } else {
-      this._iter = this._convertNonStreamResponse(
-        response as {
-          id: string;
-          stop_reason?: string | null;
-          usage: {
-            input_tokens: number;
-            output_tokens: number;
-            cache_read_input_tokens?: number;
-            cache_creation_input_tokens?: number;
-          };
-          content: Array<{
-            type: string;
-            text?: string;
-            thinking?: string;
-            signature?: string;
-            data?: string;
-            id?: string;
-            name?: string;
-            input?: unknown;
-          }>;
-        },
-      );
+    super();
+    this._response = response;
+    this._isStream = isStream;
+    // Anthropic reports usage on every response, so default to a zeroed
+    // usage object rather than null until the first event arrives.
+    this._usage = {
+      inputOther: 0,
+      output: 0,
+      inputCacheRead: 0,
+      inputCacheCreation: 0,
+    };
+  }
+
+  protected _buildIter(): AsyncGenerator<StreamedMessagePart> {
+    if (this._isStream) {
+      return this._convertStreamResponse(this._response as AsyncIterable<MessageStreamEvent>);
     }
-  }
-
-  get id(): string | null {
-    return this._id;
-  }
-
-  get usage(): TokenUsage | null {
-    return this._usage;
-  }
-
-  get finishReason(): FinishReason | null {
-    return this._finishReason;
-  }
-
-  get rawFinishReason(): string | null {
-    return this._rawFinishReason;
-  }
-
-  async *[Symbol.asyncIterator](): AsyncIterator<StreamedMessagePart> {
-    yield* this._iter;
+    return this._convertNonStreamResponse(
+      this._response as {
+        id: string;
+        stop_reason?: string | null;
+        usage: {
+          input_tokens: number;
+          output_tokens: number;
+          cache_read_input_tokens?: number;
+          cache_creation_input_tokens?: number;
+        };
+        content: Array<{
+          type: string;
+          text?: string;
+          thinking?: string;
+          signature?: string;
+          data?: string;
+          id?: string;
+          name?: string;
+          input?: unknown;
+        }>;
+      },
+    );
   }
 
   private _captureStopReason(raw: string | null | undefined): void {
@@ -749,16 +721,16 @@ class AnthropicStreamedMessage implements StreamedMessage {
           const deltaUsage = (evt as { usage?: Record<string, unknown> }).usage;
           if (deltaUsage !== undefined) {
             if (typeof deltaUsage['output_tokens'] === 'number') {
-              this._usage.output = deltaUsage['output_tokens'];
+              this._usage!.output = deltaUsage['output_tokens'];
             }
             if (typeof deltaUsage['cache_read_input_tokens'] === 'number') {
-              this._usage.inputCacheRead = deltaUsage['cache_read_input_tokens'];
+              this._usage!.inputCacheRead = deltaUsage['cache_read_input_tokens'];
             }
             if (typeof deltaUsage['cache_creation_input_tokens'] === 'number') {
-              this._usage.inputCacheCreation = deltaUsage['cache_creation_input_tokens'];
+              this._usage!.inputCacheCreation = deltaUsage['cache_creation_input_tokens'];
             }
             if (typeof deltaUsage['input_tokens'] === 'number') {
-              this._usage.inputOther = deltaUsage['input_tokens'];
+              this._usage!.inputOther = deltaUsage['input_tokens'];
             }
           }
           // The terminal `stop_reason` lives on `delta.stop_reason` of the

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -962,12 +962,12 @@ export class AnthropicChatProvider extends BaseChatProvider<AnthropicGenerationK
 
   protected createRawClient(
     auth: ResolvedAuth,
-    _defaultHeaders: Record<string, string> | undefined,
+    defaultHeaders: Record<string, string> | undefined,
   ): Anthropic {
     return new Anthropic({
       apiKey: auth.apiKey,
       baseURL: this._baseUrl,
-      defaultHeaders: this._defaultHeaders,
+      defaultHeaders,
     });
   }
 

--- a/packages/kosong/src/providers/anthropic.ts
+++ b/packages/kosong/src/providers/anthropic.ts
@@ -42,9 +42,8 @@ import type {
 import { getAnthropicModelCapability } from './capability-registry';
 import {
   mergeRequestHeaders,
-  requireProviderApiKey,
-  resolveAuthBackedClient,
 } from './request-auth';
+import { BaseChatProvider, type ResolvedAuth } from './base-chat-provider';
 
 /**
  * Normalize an Anthropic `stop_reason` string to the unified
@@ -90,6 +89,7 @@ export interface AnthropicOptions {
 }
 
 interface AnthropicGenerationKwargs {
+  [key: string]: unknown;
   max_tokens?: number | undefined;
   temperature?: number | undefined;
   top_k?: number | undefined;
@@ -782,40 +782,42 @@ class AnthropicStreamedMessage implements StreamedMessage {
     }
   }
 }
-export class AnthropicChatProvider implements ChatProvider {
+export class AnthropicChatProvider extends BaseChatProvider<AnthropicGenerationKwargs> {
   readonly name: string = 'anthropic';
 
-  private _model: string;
   private _stream: boolean;
-  private _client: Anthropic | undefined;
-  private _generationKwargs: AnthropicGenerationKwargs;
   private _metadata: Record<string, string> | undefined;
-  private _apiKey: string | undefined;
-  private _baseUrl: string | undefined;
-  private _defaultHeaders: Record<string, string> | undefined;
-  private _clientFactory: ((auth: ProviderRequestAuth) => Anthropic) | undefined;
 
   constructor(options: AnthropicOptions) {
-    this._model = options.model;
-    this._stream = options.stream ?? true;
-    this._metadata = options.metadata;
-    const apiKey = options.apiKey ?? process.env['ANTHROPIC_API_KEY'];
-    this._apiKey = apiKey === undefined || apiKey.length === 0 ? undefined : apiKey;
-    this._baseUrl = options.baseUrl;
-    this._defaultHeaders = options.defaultHeaders;
-    this._clientFactory = options.clientFactory;
-    this._client = this._apiKey === undefined ? undefined : this._buildClient(this._apiKey);
-    this._generationKwargs = {
+    const apiKey =
+      options.apiKey === undefined || options.apiKey.length === 0
+        ? (process.env['ANTHROPIC_API_KEY'] ?? undefined)
+        : options.apiKey;
+    const apiKeyResolved = apiKey === undefined || apiKey.length === 0 ? undefined : apiKey;
+    const baseUrl = options.baseUrl;
+    const client = apiKeyResolved === undefined ? undefined : AnthropicChatProvider.buildClient(apiKeyResolved, baseUrl, options.defaultHeaders);
+    const generationKwargs: AnthropicGenerationKwargs = {
       max_tokens: resolveDefaultMaxTokens(options.model, options.defaultMaxTokens),
       betaFeatures: options.betaFeatures ?? [INTERLEAVED_THINKING_BETA],
     };
+    super(
+      options.model,
+      generationKwargs,
+      apiKeyResolved,
+      baseUrl ?? '',
+      options.defaultHeaders,
+      client,
+      options.clientFactory,
+    );
+    this._stream = options.stream ?? true;
+    this._metadata = options.metadata;
   }
 
-  get modelName(): string {
+  override get modelName(): string {
     return this._model;
   }
 
-  get thinkingEffort(): ThinkingEffort | null {
+  override get thinkingEffort(): ThinkingEffort | null {
     const thinkingConfig = this._generationKwargs.thinking;
     if (thinkingConfig === undefined || thinkingConfig === null) {
       return null;
@@ -839,18 +841,18 @@ export class AnthropicChatProvider implements ChatProvider {
     return 'high';
   }
 
-  get modelParameters(): Record<string, unknown> {
+  override get modelParameters(): Record<string, unknown> {
     return {
       model: this._model,
       ...this._generationKwargs,
     };
   }
 
-  getCapability(model?: string): ModelCapability {
+  override getCapability(model?: string): ModelCapability {
     return getAnthropicModelCapability(model ?? this._model);
   }
 
-  async generate(
+  override async generate(
     systemPrompt: string,
     tools: Tool[],
     history: Message[],
@@ -949,7 +951,7 @@ export class AnthropicChatProvider implements ChatProvider {
       requestOptions['signal'] = options.signal;
     }
     const finalRequestOptions = Object.keys(requestOptions).length > 0 ? requestOptions : undefined;
-    const client = this._createClient(options?.auth);
+    const client = this._createClient(options?.auth) as Anthropic;
 
     if (this._stream) {
       // Use the raw Messages stream instead of the SDK MessageStream helper.
@@ -978,27 +980,30 @@ export class AnthropicChatProvider implements ChatProvider {
     }
   }
 
-  private _createClient(auth: ProviderRequestAuth | undefined): Anthropic {
-    return resolveAuthBackedClient(
-      { cachedClient: this._client, clientFactory: this._clientFactory },
-      auth,
-      (a) => this._buildClient(requireProviderApiKey('AnthropicChatProvider', a, this._apiKey)),
-    );
+  private static buildClient(
+    apiKey: string,
+    baseUrl: string | undefined,
+    defaultHeaders: Record<string, string> | undefined,
+  ): Anthropic {
+    return new Anthropic({ apiKey, baseURL: baseUrl, defaultHeaders });
   }
 
-  private _buildClient(apiKey: string): Anthropic {
+  protected createRawClient(
+    auth: ResolvedAuth,
+    _defaultHeaders: Record<string, string> | undefined,
+  ): Anthropic {
     return new Anthropic({
-      apiKey,
+      apiKey: auth.apiKey,
       baseURL: this._baseUrl,
       defaultHeaders: this._defaultHeaders,
     });
   }
 
-  withThinking(effort: ThinkingEffort): AnthropicChatProvider {
+  override withThinking(effort: ThinkingEffort): AnthropicChatProvider {
     if (effort === 'off') {
       let newBetas = [...(this._generationKwargs.betaFeatures ?? [])];
       newBetas = newBetas.filter((b) => b !== INTERLEAVED_THINKING_BETA);
-      const clone = this._withGenerationKwargs({
+      const clone = this.withGenerationKwargs({
         thinking: { type: 'disabled' },
         betaFeatures: newBetas,
       });
@@ -1014,29 +1019,11 @@ export class AnthropicChatProvider implements ChatProvider {
     let newBetas = [...(this._generationKwargs.betaFeatures ?? [])];
     newBetas = newBetas.filter((b) => b !== INTERLEAVED_THINKING_BETA);
 
-    return this._withGenerationKwargs({
+    return this.withGenerationKwargs({
       thinking: { type: 'adaptive', display: 'summarized' },
       output_config: { effort: effectiveEffort },
       betaFeatures: newBetas,
     });
   }
 
-  withGenerationKwargs(kwargs: Partial<AnthropicGenerationKwargs>): AnthropicChatProvider {
-    return this._withGenerationKwargs(kwargs);
-  }
-
-  private _withGenerationKwargs(kwargs: Partial<AnthropicGenerationKwargs>): AnthropicChatProvider {
-    const clone = this._clone();
-    clone._generationKwargs = { ...clone._generationKwargs, ...kwargs };
-    return clone;
-  }
-
-  private _clone(): AnthropicChatProvider {
-    const clone = Object.assign(
-      Object.create(Object.getPrototypeOf(this) as object) as AnthropicChatProvider,
-      this,
-    );
-    clone._generationKwargs = { ...this._generationKwargs };
-    return clone;
-  }
 }

--- a/packages/kosong/src/providers/base-chat-provider.ts
+++ b/packages/kosong/src/providers/base-chat-provider.ts
@@ -10,12 +10,16 @@
  * See ADR 0015 for the rationale.
  */
 
-import type { ChatProvider, GenerateOptions, ThinkingEffort } from '#/provider';
+import type {
+  ChatProvider,
+  GenerateOptions,
+  ProviderRequestAuth,
+  StreamedMessage,
+  ThinkingEffort,
+} from '#/provider';
 import type { Message } from '#/message';
 import type { ModelCapability } from '#/capability';
 import type { Tool } from '#/tool';
-import type { StreamedMessage } from '#/provider';
-import type { ProviderRequestAuth } from '#/provider';
 import {
   mergeRequestHeaders,
   requireProviderApiKey,

--- a/packages/kosong/src/providers/base-chat-provider.ts
+++ b/packages/kosong/src/providers/base-chat-provider.ts
@@ -1,0 +1,152 @@
+/**
+ * Shared abstract base for the four ChatProvider adapters.
+ *
+ * Holds the SDK-agnostic boilerplate (`_clone`, `withGenerationKwargs`, the
+ * accessor trio, the `_createClient` shell) that was previously copy-pasted
+ * across `anthropic.ts`, `openai-responses.ts`, `google-genai.ts`, and
+ * `openai-completions.ts`. Protocol-specific logic (`generate`, message
+ * mapping, streaming parsing, cache-control injection) stays in subclasses.
+ *
+ * See ADR 0015 for the rationale.
+ */
+
+import type { ChatProvider, GenerateOptions, ThinkingEffort } from '#/provider';
+import type { Message } from '#/message';
+import type { ModelCapability } from '#/capability';
+import type { Tool } from '#/tool';
+import type { StreamedMessage } from '#/provider';
+import type { ProviderRequestAuth } from '#/provider';
+import {
+  mergeRequestHeaders,
+  requireProviderApiKey,
+  resolveAuthBackedClient,
+} from '#/providers/request-auth';
+
+/**
+ * Per-provider generation-keyword bag. Each subclass constrains this to its
+ * own interface (e.g. `GenerationKwargs`, `AnthropicGenerationKwargs`).
+ * The index signature is the common supertype all four share.
+ */
+export type BaseGenerationKwargs = Record<string, unknown>;
+
+/**
+ * Resolved auth handed to {@link BaseChatProvider.createRawClient}.
+ */
+export interface ResolvedAuth {
+  readonly apiKey: string;
+  readonly headers: Record<string, string> | undefined;
+}
+
+/**
+ * Abstract base implementing the SDK-agnostic ChatProvider boilerplate.
+ *
+ * Subclasses must implement:
+ * - `generate(...)` — the streaming/dispatch loop (protocol-specific)
+ * - `createRawClient(auth, defaultHeaders)` — `new OpenAI(...)` / `new Anthropic(...)` / etc.
+ * - `thinkingEffort` getter — per-provider effort mapping
+ * - `getCapability(model?)` — per-provider capability registry lookup
+ * - `withThinking(effort)` — per-provider thinking configuration
+ *
+ * Subclasses inherit: `_clone`, `withGenerationKwargs`, `modelName`,
+ * `modelParameters`, and the `_createClient` shell.
+ */
+export abstract class BaseChatProvider<TKwargs extends BaseGenerationKwargs>
+  implements ChatProvider
+{
+  /** Provider name; subclasses set via constructor. */
+  abstract readonly name: string;
+
+  protected constructor(
+    protected readonly _model: string,
+    protected _generationKwargs: TKwargs,
+    protected readonly _apiKey: string | undefined = undefined,
+    protected readonly _baseUrl: string = '',
+    protected readonly _defaultHeaders: Record<string, string> | undefined = undefined,
+    protected _client: unknown = undefined,
+    protected readonly _clientFactory:
+      | ((auth: ProviderRequestAuth) => unknown)
+      | undefined = undefined,
+  ) {}
+
+  get modelName(): string {
+    return this._model;
+  }
+
+  get modelParameters(): Record<string, unknown> {
+    return { model: this._model, ...this._generationKwargs };
+  }
+
+  abstract get thinkingEffort(): ThinkingEffort | null;
+
+  abstract getCapability(model?: string): ModelCapability;
+
+  abstract generate(
+    systemPrompt: string,
+    tools: Tool[],
+    history: Message[],
+    options?: GenerateOptions,
+  ): Promise<StreamedMessage>;
+
+  abstract withThinking(effort: ThinkingEffort): ChatProvider;
+
+  /**
+   * Return a shallow copy of this provider with `kwargs` merged into the
+   * generation-keyword bag. The clone shares transport state (client) with
+   * the original; only `_generationKwargs` is deep-copied.
+   */
+  withGenerationKwargs(kwargs: TKwargs): this {
+    const clone = this._clone();
+    clone._generationKwargs = { ...clone._generationKwargs, ...kwargs };
+    return clone;
+  }
+
+  /**
+   * Shallow clone preserving prototype and instance state, with a fresh
+   * `_generationKwargs` copy. Subclasses with extra clone-time cleanup
+   * (e.g. resetting a lazy `_files` cache) override and call `super._clone()`
+   * then apply their cleanup.
+   */
+  protected _clone(): this {
+    const clone = Object.assign(
+      Object.create(Object.getPrototypeOf(this) as object) as this,
+      this,
+    );
+    clone._generationKwargs = { ...this._generationKwargs };
+    return clone;
+  }
+
+  /**
+   * Resolve the SDK client for the current request, using cached/client-factory
+   * auth resolution. Delegates the actual SDK construction to
+   * {@link createRawClient}. The provider name passed to `requireProviderApiKey`
+   * is the subclass's `name`.
+   */
+  protected _createClient(auth: ProviderRequestAuth | undefined): unknown {
+    return resolveAuthBackedClient(
+      {
+        cachedClient: this._client,
+        clientFactory: this._clientFactory,
+      },
+      auth,
+      (a) => {
+        const defaultHeaders = mergeRequestHeaders(this._defaultHeaders, a?.headers);
+        return this.createRawClient(
+          {
+            apiKey: requireProviderApiKey(this.name, a, this._apiKey),
+            headers: defaultHeaders,
+          },
+          defaultHeaders,
+        );
+      },
+    );
+  }
+
+  /**
+   * Construct the provider-specific SDK client. Implemented by each subclass
+   * (e.g. `new OpenAI({...})`, `new Anthropic({...})`, `new GoogleGenAI({...})`).
+   */
+  protected abstract createRawClient(
+    auth: ResolvedAuth,
+    defaultHeaders: Record<string, string> | undefined,
+  ): unknown;
+}

--- a/packages/kosong/src/providers/base-streamed-message.ts
+++ b/packages/kosong/src/providers/base-streamed-message.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared abstract base for the per-provider `StreamedMessage` implementations.
+ *
+ * Holds the field quartet (`_id` / `_usage` / `_finishReason` /
+ * `_rawFinishReason`), the backing `_iter`, `[Symbol.asyncIterator]`
+ * forwarding, and the four getters — boilerplate that was previously
+ * copy-pasted across the four adapters. Subclasses own the protocol-specific
+ * stream-conversion generator and populate the fields as the stream progresses.
+ *
+ * See ADR 0015 for the rationale.
+ */
+
+import type { FinishReason, StreamedMessage } from '#/provider';
+import type { StreamedMessagePart } from '#/message';
+import type { TokenUsage } from '#/usage';
+
+export abstract class BaseStreamedMessage implements StreamedMessage {
+  protected _id: string | null = null;
+  protected _usage: TokenUsage | null = null;
+  protected _finishReason: FinishReason | null = null;
+  protected _rawFinishReason: string | null = null;
+  protected readonly _iter: AsyncIterable<StreamedMessagePart>;
+
+  /**
+   * @param iter The protocol-specific async iterable of message parts. The
+   *   subclass constructs this (typically an async generator that drives the
+   *   provider's stream and populates `_id` / `_usage` / `_finishReason` /
+   *   `_rawFinishReason` as it runs).
+   */
+  constructor(iter: AsyncIterable<StreamedMessagePart>) {
+    this._iter = iter;
+  }
+
+  get id(): string | null {
+    return this._id;
+  }
+
+  get usage(): TokenUsage | null {
+    return this._usage;
+  }
+
+  get finishReason(): FinishReason | null {
+    return this._finishReason;
+  }
+
+  get rawFinishReason(): string | null {
+    return this._rawFinishReason;
+  }
+
+  async *[Symbol.asyncIterator](): AsyncIterator<StreamedMessagePart> {
+    yield* this._iter;
+  }
+}

--- a/packages/kosong/src/providers/base-streamed-message.ts
+++ b/packages/kosong/src/providers/base-streamed-message.ts
@@ -2,10 +2,12 @@
  * Shared abstract base for the per-provider `StreamedMessage` implementations.
  *
  * Holds the field quartet (`_id` / `_usage` / `_finishReason` /
- * `_rawFinishReason`), the backing `_iter`, `[Symbol.asyncIterator]`
- * forwarding, and the four getters — boilerplate that was previously
+ * `_rawFinishReason`) and the four getters — boilerplate that was previously
  * copy-pasted across the four adapters. Subclasses own the protocol-specific
- * stream-conversion generator and populate the fields as the stream progresses.
+ * stream-conversion generator and implement `_buildIter()`.
+ *
+ * The iterator is built lazily on first iteration so subclasses can initialize
+ * any instance state after `super()` and before the generator runs.
  *
  * See ADR 0015 for the rationale.
  */
@@ -19,17 +21,7 @@ export abstract class BaseStreamedMessage implements StreamedMessage {
   protected _usage: TokenUsage | null = null;
   protected _finishReason: FinishReason | null = null;
   protected _rawFinishReason: string | null = null;
-  protected readonly _iter: AsyncIterable<StreamedMessagePart>;
-
-  /**
-   * @param iter The protocol-specific async iterable of message parts. The
-   *   subclass constructs this (typically an async generator that drives the
-   *   provider's stream and populates `_id` / `_usage` / `_finishReason` /
-   *   `_rawFinishReason` as it runs).
-   */
-  constructor(iter: AsyncIterable<StreamedMessagePart>) {
-    this._iter = iter;
-  }
+  private _iter: AsyncIterable<StreamedMessagePart> | undefined;
 
   get id(): string | null {
     return this._id;
@@ -48,6 +40,14 @@ export abstract class BaseStreamedMessage implements StreamedMessage {
   }
 
   async *[Symbol.asyncIterator](): AsyncIterator<StreamedMessagePart> {
+    this._iter ??= this._buildIter();
     yield* this._iter;
   }
+
+  /**
+   * Build the protocol-specific async iterable of message parts. The subclass
+   * drives the provider's stream and populates `_id` / `_usage` /
+   * `_finishReason` / `_rawFinishReason` as it runs.
+   */
+  protected abstract _buildIter(): AsyncIterable<StreamedMessagePart>;
 }

--- a/packages/kosong/src/providers/google-genai.ts
+++ b/packages/kosong/src/providers/google-genai.ts
@@ -9,13 +9,13 @@ import type {
   ThinkingEffort,
 } from '#/provider';
 import type { Tool } from '#/tool';
-import type { TokenUsage } from '#/usage';
 import { ApiError as GoogleApiError, GoogleGenAI as GenAIClient } from '@google/genai';
 
 import { getGoogleGenAIModelCapability } from './capability-registry';
 import { requireProviderApiKey, resolveAuthBackedClient } from './request-auth';
 import { convertProviderError, extractCacheUsage } from './provider-common';
 import { BaseChatProvider, type ResolvedAuth } from './base-chat-provider';
+import { BaseStreamedMessage } from './base-streamed-message';
 
 /**
  * Normalize a Google GenAI (Gemini) `finishReason` value to the unified
@@ -446,46 +446,30 @@ export function messagesToGoogleGenAIContents(messages: Message[]): GoogleConten
 
   return contents;
 }
-export class GoogleGenAIStreamedMessage implements StreamedMessage {
-  private _id: string | null = null;
-  private _usage: TokenUsage | null = null;
-  private _finishReason: FinishReason | null = null;
-  private _rawFinishReason: string | null = null;
-  private readonly _iter: AsyncGenerator<StreamedMessagePart>;
+export class GoogleGenAIStreamedMessage extends BaseStreamedMessage {
+  private readonly _response: AsyncIterable<Record<string, unknown>> | Record<string, unknown>;
+  private readonly _isStream: boolean;
+  private readonly _signal: AbortSignal | undefined;
 
   constructor(
     response: AsyncIterable<Record<string, unknown>> | Record<string, unknown>,
     isStream: boolean,
     signal?: AbortSignal,
   ) {
-    if (isStream) {
-      this._iter = this._convertStreamResponse(
-        response as AsyncIterable<Record<string, unknown>>,
-        signal,
+    super();
+    this._response = response;
+    this._isStream = isStream;
+    this._signal = signal;
+  }
+
+  protected _buildIter(): AsyncGenerator<StreamedMessagePart> {
+    if (this._isStream) {
+      return this._convertStreamResponse(
+        this._response as AsyncIterable<Record<string, unknown>>,
+        this._signal,
       );
-    } else {
-      this._iter = this._convertNonStreamResponse(response as Record<string, unknown>, signal);
     }
-  }
-
-  get id(): string | null {
-    return this._id;
-  }
-
-  get usage(): TokenUsage | null {
-    return this._usage;
-  }
-
-  get finishReason(): FinishReason | null {
-    return this._finishReason;
-  }
-
-  get rawFinishReason(): string | null {
-    return this._rawFinishReason;
-  }
-
-  async *[Symbol.asyncIterator](): AsyncIterator<StreamedMessagePart> {
-    yield* this._iter;
+    return this._convertNonStreamResponse(this._response as Record<string, unknown>, this._signal);
   }
 
   private _captureFinishReason(response: Record<string, unknown>): void {
@@ -843,7 +827,7 @@ export class GoogleGenAIChatProvider extends BaseChatProvider<GoogleGenAIGenerat
             headers: undefined,
           },
           undefined,
-        ) as GenAIClient;
+        );
       },
     );
   }

--- a/packages/kosong/src/providers/google-genai.ts
+++ b/packages/kosong/src/providers/google-genai.ts
@@ -1,13 +1,7 @@
 import type { ModelCapability } from '#/capability';
-import {
-  APIConnectionError,
-  APITimeoutError,
-  ChatProviderError,
-  normalizeAPIStatusError,
-} from '#/errors';
+import { ChatProviderError, normalizeAPIStatusError } from '#/errors';
 import type { Message, StreamedMessagePart, ToolCall } from '#/message';
 import type {
-  ChatProvider,
   FinishReason,
   GenerateOptions,
   ProviderRequestAuth,
@@ -20,6 +14,8 @@ import { ApiError as GoogleApiError, GoogleGenAI as GenAIClient } from '@google/
 
 import { getGoogleGenAIModelCapability } from './capability-registry';
 import { requireProviderApiKey, resolveAuthBackedClient } from './request-auth';
+import { convertProviderError, extractCacheUsage } from './provider-common';
+import { BaseChatProvider, type ResolvedAuth } from './base-chat-provider';
 
 /**
  * Normalize a Google GenAI (Gemini) `finishReason` value to the unified
@@ -567,12 +563,8 @@ export class GoogleGenAIStreamedMessage implements StreamedMessage {
         typeof usageMetadata['cachedContentTokenCount'] === 'number'
           ? usageMetadata['cachedContentTokenCount']
           : 0;
-      this._usage = {
-        inputOther: Math.max(promptTokenCount - cachedContentTokenCount, 0),
-        output: (usageMetadata['candidatesTokenCount'] as number) ?? 0,
-        inputCacheRead: cachedContentTokenCount,
-        inputCacheCreation: 0,
-      };
+      const output = (usageMetadata['candidatesTokenCount'] as number) ?? 0;
+      this._usage = extractCacheUsage(promptTokenCount, cachedContentTokenCount, output);
     }
   }
 
@@ -634,9 +626,6 @@ export class GoogleGenAIStreamedMessage implements StreamedMessage {
     }
   }
 }
-const NETWORK_RE = /network|connection|connect|disconnect|fetch failed/i;
-const TIMEOUT_RE = /timed?\s*out|timeout|deadline/i;
-
 /**
  * Convert a Google GenAI SDK error (or raw Error) to a kosong `ChatProviderError`.
  */
@@ -645,71 +634,75 @@ export function convertGoogleGenAIError(error: unknown): ChatProviderError {
   if (error instanceof GoogleApiError) {
     return normalizeAPIStatusError(error.status, error.message);
   }
-  if (error instanceof Error) {
-    const msg = error.message;
-    // Timeout takes priority over network (a timeout is also a connection issue)
-    if (TIMEOUT_RE.test(msg)) {
-      return new APITimeoutError(msg);
-    }
-    // Network / fetch errors (e.g. TypeError: fetch failed)
-    if (NETWORK_RE.test(msg) || (error instanceof TypeError && msg.includes('fetch'))) {
-      return new APIConnectionError(msg);
-    }
-    // Try to extract status code from unknown error shapes
-    const statusCode = (error as { code?: number }).code;
-    if (typeof statusCode === 'number') {
-      return normalizeAPIStatusError(statusCode, msg);
-    }
-    return new ChatProviderError(`GoogleGenAI error: ${msg}`);
+
+  // Non-GoogleApiError values may still carry a numeric status code.
+  const statusCode = (error as { code?: number }).code;
+  if (error instanceof Error && typeof statusCode === 'number') {
+    return normalizeAPIStatusError(statusCode, error.message);
   }
-  return new ChatProviderError(`GoogleGenAI error: ${String(error)}`);
+
+  // Preserve Google's fetch-specific network classification via the shared
+  // provider error converter; everything else falls through to the standard
+  // NETWORK_RE / TIMEOUT_RE ladder.
+  return convertProviderError(error, {
+    extraNetworkMatchers: [/^fetch failed$/i],
+    extraTypeErrorMatch: 'fetch',
+  });
 }
-export class GoogleGenAIChatProvider implements ChatProvider {
+export class GoogleGenAIChatProvider extends BaseChatProvider<GoogleGenAIGenerationKwargs> {
   readonly name: string = 'google_genai';
 
-  private _model: string;
-  private _client: GenAIClient | undefined;
-  private _generationKwargs: GoogleGenAIGenerationKwargs;
-  private _vertexai: boolean;
   private _stream: boolean;
-  private _apiKey: string | undefined;
+  private _vertexai: boolean;
   private _project: string | undefined;
   private _location: string | undefined;
-  private _clientFactory: ((auth: ProviderRequestAuth) => GenAIClient) | undefined;
 
   constructor(options: GoogleGenAIOptions) {
-    this._model = options.model;
-    this._vertexai = options.vertexai ?? false;
-    this._stream = options.stream ?? true;
-    this._generationKwargs = {};
-
     const apiKey = options.apiKey ?? process.env['GOOGLE_API_KEY'];
-    this._apiKey = apiKey === undefined || apiKey.length === 0 ? undefined : apiKey;
+    const apiKeyResolved = apiKey === undefined || apiKey.length === 0 ? undefined : apiKey;
+    const client =
+      (options.vertexai ?? false) || apiKeyResolved !== undefined
+        ? GoogleGenAIChatProvider.buildClient(
+            apiKeyResolved,
+            options.vertexai ?? false,
+            options.project,
+            options.location,
+          )
+        : undefined;
+    super(
+      options.model,
+      {},
+      apiKeyResolved,
+      '',
+      undefined,
+      client,
+      options.clientFactory,
+    );
+    this._stream = options.stream ?? true;
+    this._vertexai = options.vertexai ?? false;
     this._project = options.project;
     this._location = options.location;
-    this._clientFactory = options.clientFactory;
-    this._client =
-      this._vertexai || this._apiKey !== undefined ? this._buildClient(this._apiKey) : undefined;
   }
 
-  private _buildClient(apiKey: string | undefined): GenAIClient {
+  private static buildClient(
+    apiKey: string | undefined,
+    vertexai: boolean,
+    project: string | undefined,
+    location: string | undefined,
+  ): GenAIClient {
     return new GenAIClient({
       apiKey,
-      ...(this._vertexai
+      ...(vertexai
         ? {
             vertexai: true,
-            project: this._project,
-            location: this._location,
+            project,
+            location,
           }
         : {}),
     });
   }
 
-  get modelName(): string {
-    return this._model;
-  }
-
-  get thinkingEffort(): ThinkingEffort | null {
+  override get thinkingEffort(): ThinkingEffort | null {
     const thinkingConfig = this._generationKwargs.thinking_config;
     if (thinkingConfig === undefined) return null;
 
@@ -742,14 +735,14 @@ export class GoogleGenAIChatProvider implements ChatProvider {
     return null;
   }
 
-  get modelParameters(): Record<string, unknown> {
+  override get modelParameters(): Record<string, unknown> {
     return {
       model: this._model,
       ...this._generationKwargs,
     };
   }
 
-  getCapability(model?: string): ModelCapability {
+  override getCapability(model?: string): ModelCapability {
     return getGoogleGenAIModelCapability(model ?? this._model);
   }
 
@@ -815,9 +808,19 @@ export class GoogleGenAIChatProvider implements ChatProvider {
     }
   }
 
-  private _createClient(auth: ProviderRequestAuth | undefined): GenAIClient {
+  /**
+   * Override the base auth-resolution path to preserve the Vertex AI
+   * short-circuit: Vertex uses service credentials, not request-scoped keys
+   * or headers, so `requireProviderApiKey` must not be enforced there.
+   */
+  protected override _createClient(auth: ProviderRequestAuth | undefined): GenAIClient {
     return resolveAuthBackedClient(
-      { cachedClient: this._client, clientFactory: this._clientFactory },
+      {
+        cachedClient: this._client as GenAIClient | undefined,
+        clientFactory: this._clientFactory as
+          | ((auth: ProviderRequestAuth) => GenAIClient)
+          | undefined,
+      },
       auth,
       (a) => {
         // Vertex AI auth flows through google-auth-library service credentials,
@@ -826,13 +829,38 @@ export class GoogleGenAIChatProvider implements ChatProvider {
         // `auth.headers` is propagated in vertexai mode. Callers that need
         // request-scoped credentials should instead point their service
         // account at the right principal.
-        if (this._vertexai) return this._buildClient(this._apiKey);
-        return this._buildClient(requireProviderApiKey('GoogleGenAIChatProvider', a, this._apiKey));
+        if (this._vertexai) {
+          return GoogleGenAIChatProvider.buildClient(
+            this._apiKey,
+            this._vertexai,
+            this._project,
+            this._location,
+          );
+        }
+        return this.createRawClient(
+          {
+            apiKey: requireProviderApiKey('GoogleGenAIChatProvider', a, this._apiKey),
+            headers: undefined,
+          },
+          undefined,
+        ) as GenAIClient;
       },
     );
   }
 
-  withThinking(effort: ThinkingEffort): GoogleGenAIChatProvider {
+  protected createRawClient(
+    auth: ResolvedAuth,
+    _defaultHeaders: Record<string, string> | undefined,
+  ): GenAIClient {
+    return GoogleGenAIChatProvider.buildClient(
+      auth.apiKey,
+      this._vertexai,
+      this._project,
+      this._location,
+    );
+  }
+
+  override withThinking(effort: ThinkingEffort): GoogleGenAIChatProvider {
     const thinkingConfig: ThinkingConfig = { include_thoughts: true };
 
     if (this._model.includes('gemini-3')) {
@@ -880,20 +908,5 @@ export class GoogleGenAIChatProvider implements ChatProvider {
     }
 
     return this.withGenerationKwargs({ thinking_config: thinkingConfig });
-  }
-
-  withGenerationKwargs(kwargs: GoogleGenAIGenerationKwargs): GoogleGenAIChatProvider {
-    const clone = this._clone();
-    clone._generationKwargs = { ...clone._generationKwargs, ...kwargs };
-    return clone;
-  }
-
-  private _clone(): GoogleGenAIChatProvider {
-    const clone = Object.assign(
-      Object.create(Object.getPrototypeOf(this) as object) as GoogleGenAIChatProvider,
-      this,
-    );
-    clone._generationKwargs = { ...this._generationKwargs };
-    return clone;
   }
 }

--- a/packages/kosong/src/providers/openai-common.ts
+++ b/packages/kosong/src/providers/openai-common.ts
@@ -9,6 +9,7 @@ import type { ContentPart, Message } from '#/message';
 import type { FinishReason, ThinkingEffort } from '#/provider';
 import type { Tool } from '#/tool';
 import type { TokenUsage } from '#/usage';
+import { makeFinishReasonNormalizer } from './provider-common';
 import {
   APIConnectionError as OpenAIConnectionError,
   APIConnectionTimeoutError as OpenAITimeoutError,
@@ -260,6 +261,14 @@ export function extractUsage(usage: unknown): TokenUsage | null {
     inputCacheCreation: 0,
   };
 }
+const OPENAI_FINISH_REASON_MAP: Readonly<Record<string, FinishReason>> = {
+  stop: 'completed',
+  tool_calls: 'tool_calls',
+  function_call: 'tool_calls',
+  length: 'truncated',
+  content_filter: 'filtered',
+};
+
 /**
  * Normalize an OpenAI Chat Completions–style `finish_reason` string to the
  * unified {@link FinishReason} enum.
@@ -277,27 +286,7 @@ export function extractUsage(usage: unknown): TokenUsage | null {
  * - `'content_filter'` → `'filtered'`
  * - any other non-null string → `'other'`
  */
-export function normalizeOpenAIFinishReason(raw: string | null | undefined): {
-  finishReason: FinishReason | null;
-  rawFinishReason: string | null;
-} {
-  if (raw === null || raw === undefined) {
-    return { finishReason: null, rawFinishReason: null };
-  }
-  switch (raw) {
-    case 'stop':
-      return { finishReason: 'completed', rawFinishReason: raw };
-    case 'tool_calls':
-    case 'function_call':
-      return { finishReason: 'tool_calls', rawFinishReason: raw };
-    case 'length':
-      return { finishReason: 'truncated', rawFinishReason: raw };
-    case 'content_filter':
-      return { finishReason: 'filtered', rawFinishReason: raw };
-    default:
-      return { finishReason: 'other', rawFinishReason: raw };
-  }
-}
+export const normalizeOpenAIFinishReason = makeFinishReasonNormalizer(OPENAI_FINISH_REASON_MAP);
 /**
  * Strategy for converting tool-role message content.
  *

--- a/packages/kosong/src/providers/openai-completions.ts
+++ b/packages/kosong/src/providers/openai-completions.ts
@@ -35,11 +35,7 @@ import {
   toolToOpenAI,
   type ToolMessageConversion,
 } from './openai-common';
-import {
-  mergeRequestHeaders,
-  requireProviderApiKey,
-  resolveAuthBackedClient,
-} from './request-auth';
+import { BaseChatProvider, type ResolvedAuth } from './base-chat-provider';
 
 // Inbound: scan in priority order; first string value wins. Outbound: the first
 // entry doubles as the default field we serialize ThinkPart back into. Both
@@ -417,29 +413,27 @@ class OpenAICompletionsStreamedMessage implements StreamedMessage {
   }
 }
 
-export class OpenAICompletionsChatProvider implements ChatProvider {
+export class OpenAICompletionsChatProvider extends BaseChatProvider<GenerationKwargs> {
   readonly name: string = 'openai-completions';
 
-  private _model: string;
   private _stream: boolean;
-  private _apiKey: string | undefined;
-  private _baseUrl: string;
-  private _defaultHeaders: Record<string, string> | undefined;
-  private _generationKwargs: GenerationKwargs;
   private _thinkingEffortKey: string;
   private _reasoningKey: string | undefined;
   private _toolMessageConversion: ToolMessageConversion;
-  private _client: OpenAI | undefined;
-  private _clientFactory: ((auth: ProviderRequestAuth) => OpenAI) | undefined;
   private _files: OpenAICompatFiles | undefined;
 
   constructor(options: OpenAICompletionsOptions) {
-    const apiKey = options.apiKey;
-    this._apiKey = apiKey === undefined || apiKey.length === 0 ? undefined : apiKey;
-    this._baseUrl = options.baseUrl ?? '';
-    this._defaultHeaders = options.defaultHeaders;
-    this._clientFactory = options.clientFactory;
-    this._model = options.model;
+    const apiKey = options.apiKey === undefined || options.apiKey.length === 0 ? undefined : options.apiKey;
+    const baseUrl = options.baseUrl ?? '';
+    const generationKwargs = { ...options.generationKwargs };
+    const client =
+      apiKey === undefined
+        ? undefined
+        : new OpenAI({ apiKey, baseURL: baseUrl, defaultHeaders: options.defaultHeaders });
+    // Shared fields (_model, _generationKwargs, _apiKey, _baseUrl,
+    // _defaultHeaders, _client, _clientFactory) live on BaseChatProvider.
+    super(options.model, generationKwargs, apiKey, baseUrl, options.defaultHeaders, client, options.clientFactory);
+    // OpenAI-specific fields stay here.
     this._stream = options.stream ?? true;
     const normalizedThinkingEffortKey = options.thinkingEffortKey?.trim();
     this._thinkingEffortKey =
@@ -451,23 +445,10 @@ export class OpenAICompletionsChatProvider implements ChatProvider {
       normalizedReasoningKey !== undefined && normalizedReasoningKey.length > 0
         ? normalizedReasoningKey
         : undefined;
-    this._generationKwargs = { ...options.generationKwargs };
     this._toolMessageConversion = options.toolMessageConversion ?? null;
-    this._client =
-      this._apiKey === undefined
-        ? undefined
-        : new OpenAI({
-            apiKey: this._apiKey,
-            baseURL: this._baseUrl,
-            defaultHeaders: this._defaultHeaders,
-          });
   }
 
-  get modelName(): string {
-    return this._model;
-  }
-
-  get thinkingEffort(): ThinkingEffort | null {
+  override get thinkingEffort(): ThinkingEffort | null {
     const customValue = this._generationKwargs[this._thinkingEffortKey];
     if (typeof customValue === 'string') {
       return reasoningEffortToThinkingEffort(customValue);
@@ -481,7 +462,7 @@ export class OpenAICompletionsChatProvider implements ChatProvider {
       apiKey: this._apiKey,
       baseUrl: this._baseUrl,
       defaultHeaders: this._defaultHeaders,
-      clientFactory: this._clientFactory,
+      clientFactory: this._clientFactory as ((auth: ProviderRequestAuth) => OpenAI) | undefined,
     });
     return this._files;
   }
@@ -490,7 +471,7 @@ export class OpenAICompletionsChatProvider implements ChatProvider {
     return this.files.uploadVideo(input, options);
   }
 
-  get modelParameters(): Record<string, unknown> {
+  override get modelParameters(): Record<string, unknown> {
     return {
       model: this._model,
       baseUrl: this._baseUrl,
@@ -498,11 +479,11 @@ export class OpenAICompletionsChatProvider implements ChatProvider {
     };
   }
 
-  getCapability(model?: string): ModelCapability {
+  override getCapability(model?: string): ModelCapability {
     return getOpenAILegacyModelCapability(model ?? this._model);
   }
 
-  async generate(
+  override async generate(
     systemPrompt: string,
     tools: Tool[],
     history: Message[],
@@ -577,7 +558,7 @@ export class OpenAICompletionsChatProvider implements ChatProvider {
     }
 
     try {
-      const client = this._createClient(options?.auth);
+      const client = this._createClient(options?.auth) as OpenAI;
       const response = (await client.chat.completions.create(
         createParams as unknown as OpenAI.Chat.ChatCompletionCreateParamsNonStreaming,
         options?.signal ? { signal: options.signal } : undefined,
@@ -588,7 +569,7 @@ export class OpenAICompletionsChatProvider implements ChatProvider {
     }
   }
 
-  withThinking(effort: ThinkingEffort): OpenAICompletionsChatProvider {
+  override withThinking(effort: ThinkingEffort): OpenAICompletionsChatProvider {
     const thinking: ThinkingConfig = {
       type: effort === 'off' ? 'disabled' : 'enabled',
     };
@@ -617,10 +598,6 @@ export class OpenAICompletionsChatProvider implements ChatProvider {
     });
   }
 
-  withGenerationKwargs(kwargs: GenerationKwargs): OpenAICompletionsChatProvider {
-    return this._withGenerationKwargs(kwargs);
-  }
-
   withMaxCompletionTokens(maxCompletionTokens: number): OpenAICompletionsChatProvider {
     return this._withGenerationKwargs({ max_completion_tokens: maxCompletionTokens });
   }
@@ -636,34 +613,28 @@ export class OpenAICompletionsChatProvider implements ChatProvider {
     return this._withGenerationKwargs({ extra_body: merged });
   }
 
-  private _createClient(auth: ProviderRequestAuth | undefined): OpenAI {
-    return resolveAuthBackedClient(
-      { cachedClient: this._client, clientFactory: this._clientFactory },
-      auth,
-      (a) => {
-        const defaultHeaders = mergeRequestHeaders(this._defaultHeaders, a?.headers);
-        return new OpenAI({
-          apiKey: requireProviderApiKey('OpenAICompletionsChatProvider', a, this._apiKey),
-          baseURL: this._baseUrl,
-          defaultHeaders,
-        });
-      },
-    );
-  }
-
   private _withGenerationKwargs(kwargs: GenerationKwargs): OpenAICompletionsChatProvider {
-    const clone = this._clone();
-    clone._generationKwargs = { ...clone._generationKwargs, ...kwargs };
+    // Inherited withGenerationKwargs does the clone+merge; the _files reset
+    // is handled by our _clone override below.
+    return this.withGenerationKwargs(kwargs);
+  }
+
+  protected override _clone(): this {
+    const clone = super._clone();
+    // Reset the lazy OpenAICompatFiles cache on every clone so the clone
+    // does not share file-upload state with the original.
+    (clone as OpenAICompletionsChatProvider)._files = undefined;
     return clone;
   }
 
-  private _clone(): OpenAICompletionsChatProvider {
-    const clone = Object.assign(
-      Object.create(Object.getPrototypeOf(this) as object) as OpenAICompletionsChatProvider,
-      this,
-    );
-    clone._generationKwargs = { ...this._generationKwargs };
-    clone._files = undefined;
-    return clone;
+  protected createRawClient(
+    auth: ResolvedAuth,
+    defaultHeaders: Record<string, string> | undefined,
+  ): OpenAI {
+    return new OpenAI({
+      apiKey: auth.apiKey,
+      baseURL: this._baseUrl,
+      defaultHeaders,
+    });
   }
 }

--- a/packages/kosong/src/providers/openai-completions.ts
+++ b/packages/kosong/src/providers/openai-completions.ts
@@ -3,8 +3,6 @@ import { normalizeOpenAICompatToolSchema } from './openai-compat-schema';
 import type { ContentPart, Message, StreamedMessagePart, ToolCall } from '#/message';
 import type { PromptPlan } from '#/prompt-plan';
 import type {
-  ChatProvider,
-  FinishReason,
   GenerateOptions,
   ProviderRequestAuth,
   StreamedMessage,
@@ -12,7 +10,6 @@ import type {
   VideoUploadInput,
 } from '#/provider';
 import type { Tool } from '#/tool';
-import type { TokenUsage } from '#/usage';
 import OpenAI from 'openai';
 import { createHash } from 'node:crypto';
 
@@ -36,6 +33,7 @@ import {
   type ToolMessageConversion,
 } from './openai-common';
 import { BaseChatProvider, type ResolvedAuth } from './base-chat-provider';
+import { BaseStreamedMessage } from './base-streamed-message';
 
 // Inbound: scan in priority order; first string value wins. Outbound: the first
 // entry doubles as the default field we serialize ThinkPart back into. Both
@@ -275,49 +273,35 @@ export function extractUsageFromChunk(
   return null;
 }
 
-class OpenAICompletionsStreamedMessage implements StreamedMessage {
-  private _id: string | null = null;
-  private _usage: TokenUsage | null = null;
-  private _finishReason: FinishReason | null = null;
-  private _rawFinishReason: string | null = null;
-  private readonly _iter: AsyncGenerator<StreamedMessagePart>;
+class OpenAICompletionsStreamedMessage extends BaseStreamedMessage {
+  private readonly _response:
+    | OpenAI.Chat.ChatCompletion
+    | AsyncIterable<OpenAI.Chat.ChatCompletionChunk>;
+  private readonly _isStream: boolean;
+  private readonly _reasoningKey: string | undefined;
 
   constructor(
     response: OpenAI.Chat.ChatCompletion | AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
     isStream: boolean,
     reasoningKey: string | undefined,
   ) {
-    if (isStream) {
-      this._iter = this._convertStreamResponse(
-        response as AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
-        reasoningKey,
-      );
-    } else {
-      this._iter = this._convertNonStreamResponse(
-        response as OpenAI.Chat.ChatCompletion,
-        reasoningKey,
+    super();
+    this._response = response;
+    this._isStream = isStream;
+    this._reasoningKey = reasoningKey;
+  }
+
+  protected _buildIter(): AsyncGenerator<StreamedMessagePart> {
+    if (this._isStream) {
+      return this._convertStreamResponse(
+        this._response as AsyncIterable<OpenAI.Chat.ChatCompletionChunk>,
+        this._reasoningKey,
       );
     }
-  }
-
-  get id(): string | null {
-    return this._id;
-  }
-
-  get usage(): TokenUsage | null {
-    return this._usage;
-  }
-
-  get finishReason(): FinishReason | null {
-    return this._finishReason;
-  }
-
-  get rawFinishReason(): string | null {
-    return this._rawFinishReason;
-  }
-
-  async *[Symbol.asyncIterator](): AsyncIterator<StreamedMessagePart> {
-    yield* this._iter;
+    return this._convertNonStreamResponse(
+      this._response as OpenAI.Chat.ChatCompletion,
+      this._reasoningKey,
+    );
   }
 
   private _captureFinishReason(raw: string | null | undefined): void {

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -12,7 +12,6 @@ import type {
   ThinkingEffort,
 } from '#/provider';
 import type { Tool } from '#/tool';
-import type { TokenUsage } from '#/usage';
 import OpenAI from 'openai';
 
 import {
@@ -27,6 +26,7 @@ import {
 } from './openai-common';
 import { extractCacheUsage } from './provider-common';
 import { BaseChatProvider, type ResolvedAuth } from './base-chat-provider';
+import { BaseStreamedMessage } from './base-streamed-message';
 
 /**
  * Normalize the Responses API status / incomplete_details into the unified
@@ -489,39 +489,21 @@ function convertTool(tool: Tool): ResponseToolParam {
     strict: false,
   };
 }
-export class OpenAIResponsesStreamedMessage implements StreamedMessage {
-  private _id: string | null = null;
-  private _usage: TokenUsage | null = null;
-  private _finishReason: FinishReason | null = null;
-  private _rawFinishReason: string | null = null;
-  private readonly _iter: AsyncGenerator<StreamedMessagePart>;
+export class OpenAIResponsesStreamedMessage extends BaseStreamedMessage {
+  private readonly _response: unknown;
+  private readonly _isStream: boolean;
 
   constructor(response: unknown, isStream: boolean) {
-    if (isStream) {
-      this._iter = this._convertStreamResponse(response as AsyncIterable<RawObject>);
-    } else {
-      this._iter = this._convertNonStreamResponse(response as RawObject);
+    super();
+    this._response = response;
+    this._isStream = isStream;
+  }
+
+  protected _buildIter(): AsyncGenerator<StreamedMessagePart> {
+    if (this._isStream) {
+      return this._convertStreamResponse(this._response as AsyncIterable<RawObject>);
     }
-  }
-
-  get id(): string | null {
-    return this._id;
-  }
-
-  get usage(): TokenUsage | null {
-    return this._usage;
-  }
-
-  get finishReason(): FinishReason | null {
-    return this._finishReason;
-  }
-
-  get rawFinishReason(): string | null {
-    return this._rawFinishReason;
-  }
-
-  async *[Symbol.asyncIterator](): AsyncIterator<StreamedMessagePart> {
-    yield* this._iter;
+    return this._convertNonStreamResponse(this._response as RawObject);
   }
 
   private _captureFinishReasonFromResponse(response: RawObject): void {

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -5,7 +5,6 @@ import { ChatProviderError } from '#/errors';
 import type { ContentPart, Message, StreamedMessagePart, ToolCall } from '#/message';
 import { extractText } from '#/message';
 import type {
-  ChatProvider,
   FinishReason,
   GenerateOptions,
   ProviderRequestAuth,
@@ -26,11 +25,8 @@ import {
   reasoningEffortToThinkingEffort,
   thinkingEffortToReasoningEffort,
 } from './openai-common';
-import {
-  mergeRequestHeaders,
-  requireProviderApiKey,
-  resolveAuthBackedClient,
-} from './request-auth';
+import { extractCacheUsage } from './provider-common';
+import { BaseChatProvider, type ResolvedAuth } from './base-chat-provider';
 
 /**
  * Normalize the Responses API status / incomplete_details into the unified
@@ -542,12 +538,7 @@ export class OpenAIResponsesStreamedMessage implements StreamedMessage {
     const outputTokens = readNumberField(usage, 'output_tokens') ?? 0;
     const details = readObjectField(usage, 'input_tokens_details');
     const cached = details ? (readNumberField(details, 'cached_tokens') ?? 0) : 0;
-    this._usage = {
-      inputOther: inputTokens - cached,
-      output: outputTokens,
-      inputCacheRead: cached,
-      inputCacheCreation: 0,
-    };
+    this._usage = extractCacheUsage(inputTokens, cached, outputTokens);
   }
 
   private async *_convertNonStreamResponse(
@@ -824,48 +815,46 @@ export class OpenAIResponsesStreamedMessage implements StreamedMessage {
     }
   }
 }
-export class OpenAIResponsesChatProvider implements ChatProvider {
+export class OpenAIResponsesChatProvider extends BaseChatProvider<OpenAIResponsesGenerationKwargs> {
   readonly name: string = 'openai-responses';
 
-  private _model: string;
   private _stream: boolean;
-  private _apiKey: string | undefined;
-  private _baseUrl: string | undefined;
-  private _defaultHeaders: Record<string, string> | undefined;
-  private _generationKwargs: OpenAIResponsesGenerationKwargs;
   private _toolMessageConversion: ToolMessageConversion;
-  private _client: OpenAI | undefined;
   private _httpClient: unknown;
-  private _clientFactory: ((auth: ProviderRequestAuth) => OpenAI) | undefined;
 
   constructor(options: OpenAIResponsesOptions) {
     const apiKey = options.apiKey ?? process.env['OPENAI_API_KEY'];
-    this._apiKey = apiKey === undefined || apiKey.length === 0 ? undefined : apiKey;
-    this._baseUrl = options.baseUrl ?? 'https://api.openai.com/v1';
-    this._defaultHeaders = options.defaultHeaders;
-    this._model = options.model;
+    const apiKeyResolved = apiKey === undefined || apiKey.length === 0 ? undefined : apiKey;
+    const baseUrl = options.baseUrl ?? 'https://api.openai.com/v1';
+    const generationKwargs: OpenAIResponsesGenerationKwargs = {};
+    if (options.maxOutputTokens !== undefined) {
+      generationKwargs.max_output_tokens = options.maxOutputTokens;
+    }
+    const client = apiKeyResolved === undefined ? undefined : OpenAIResponsesChatProvider.buildClient(
+      apiKeyResolved,
+      baseUrl,
+      options.defaultHeaders,
+      options.httpClient,
+    );
+    super(
+      options.model,
+      generationKwargs,
+      apiKeyResolved,
+      baseUrl,
+      options.defaultHeaders,
+      client,
+      options.clientFactory,
+    );
     this._stream = true; // Responses API always supports streaming
-    this._generationKwargs = {};
     this._toolMessageConversion = options.toolMessageConversion ?? null;
     this._httpClient = options.httpClient;
-    this._clientFactory = options.clientFactory;
-
-    if (options.maxOutputTokens !== undefined) {
-      this._generationKwargs.max_output_tokens = options.maxOutputTokens;
-    }
-
-    this._client = this._apiKey === undefined ? undefined : this._buildClient(this._apiKey);
   }
 
-  get modelName(): string {
-    return this._model;
-  }
-
-  get thinkingEffort(): ThinkingEffort | null {
+  override get thinkingEffort(): ThinkingEffort | null {
     return reasoningEffortToThinkingEffort(this._generationKwargs.reasoning_effort);
   }
 
-  get modelParameters(): Record<string, unknown> {
+  override get modelParameters(): Record<string, unknown> {
     return {
       model: this._model,
       baseUrl: this._baseUrl,
@@ -873,7 +862,7 @@ export class OpenAIResponsesChatProvider implements ChatProvider {
     };
   }
 
-  getCapability(model?: string): ModelCapability {
+  override getCapability(model?: string): ModelCapability {
     return getOpenAIResponsesModelCapability(model ?? this._model);
   }
 
@@ -917,7 +906,7 @@ export class OpenAIResponsesChatProvider implements ChatProvider {
     }
 
     try {
-      const client = this._createClient(options?.auth);
+      const client = this._createClient(options?.auth) as OpenAI;
       const createParams: Record<string, unknown> = {
         model: this._model,
         input,
@@ -955,52 +944,35 @@ export class OpenAIResponsesChatProvider implements ChatProvider {
     }
   }
 
-  withThinking(effort: ThinkingEffort): OpenAIResponsesChatProvider {
+  override withThinking(effort: ThinkingEffort): OpenAIResponsesChatProvider {
     const reasoningEffort = thinkingEffortToReasoningEffort(effort, this._model);
-    const clone = this._clone();
-    clone._generationKwargs = {
-      ...clone._generationKwargs,
-      reasoning_effort: reasoningEffort,
-    };
-    return clone;
+    return this.withGenerationKwargs({ reasoning_effort: reasoningEffort });
   }
 
-  withGenerationKwargs(kwargs: OpenAIResponsesGenerationKwargs): OpenAIResponsesChatProvider {
-    const clone = this._clone();
-    clone._generationKwargs = { ...clone._generationKwargs, ...kwargs };
-    return clone;
-  }
-
-  private _clone(): OpenAIResponsesChatProvider {
-    const clone = Object.assign(
-      Object.create(Object.getPrototypeOf(this) as object) as OpenAIResponsesChatProvider,
-      this,
-    );
-    clone._generationKwargs = { ...this._generationKwargs };
-    return clone;
-  }
-
-  private _createClient(auth: ProviderRequestAuth | undefined): OpenAI {
-    return resolveAuthBackedClient(
-      { cachedClient: this._client, clientFactory: this._clientFactory },
-      auth,
-      (a) =>
-        this._buildClient(requireProviderApiKey('OpenAIResponsesChatProvider', a, this._apiKey), a),
+  protected createRawClient(
+    auth: ResolvedAuth,
+    defaultHeaders: Record<string, string> | undefined,
+  ): OpenAI {
+    return OpenAIResponsesChatProvider.buildClient(
+      auth.apiKey,
+      this._baseUrl,
+      defaultHeaders,
+      this._httpClient,
     );
   }
 
-  private _buildClient(apiKey: string, auth?: ProviderRequestAuth): OpenAI {
+  private static buildClient(
+    apiKey: string,
+    baseURL: string,
+    defaultHeaders: Record<string, string> | undefined,
+    httpClient: unknown,
+  ): OpenAI {
     const clientOpts: Record<string, unknown> = {
       apiKey,
-      baseURL: this._baseUrl,
+      baseURL,
+      ...(defaultHeaders !== undefined ? { defaultHeaders } : {}),
+      ...(httpClient !== undefined ? { httpClient } : {}),
     };
-    const defaultHeaders = mergeRequestHeaders(this._defaultHeaders, auth?.headers);
-    if (defaultHeaders !== undefined) {
-      clientOpts['defaultHeaders'] = defaultHeaders;
-    }
-    if (this._httpClient !== undefined) {
-      clientOpts['httpClient'] = this._httpClient;
-    }
     return new OpenAI(clientOpts as ConstructorParameters<typeof OpenAI>[0]);
   }
 }

--- a/packages/kosong/src/providers/provider-common.ts
+++ b/packages/kosong/src/providers/provider-common.ts
@@ -1,0 +1,144 @@
+/**
+ * Cross-provider normalization helpers shared by all ChatProvider adapters.
+ *
+ * Distinct from `openai-common.ts`, which holds OpenAI-family wire-format
+ * conversion. This module holds helpers whose logic is structurally identical
+ * across providers, parameterized only by per-provider tables or field names.
+ *
+ * See ADR 0015 (BaseChatProvider) for the rationale.
+ */
+
+import type { FinishReason } from '#/provider';
+import type { TokenUsage } from '#/usage';
+import {
+  APIConnectionError,
+  APITimeoutError,
+  ChatProviderError,
+  normalizeAPIStatusError,
+} from '#/errors';
+
+/**
+ * Build a finish-reason normalizer from a per-provider raw-string → FinishReason table.
+ *
+ * Mirrors the shape of the per-adapter `normalizeXxxFinishReason` functions:
+ * - `null` / `undefined` raw → `{ finishReason: null, rawFinishReason: null }`
+ * - raw present and in the table → mapped FinishReason, raw echoed back
+ * - raw present but not in the table → `'other'`, raw echoed back
+ *
+ * The returned function is stateless and safe to call repeatedly.
+ */
+export function makeFinishReasonNormalizer(
+  mapping: Readonly<Record<string, FinishReason>>,
+): (raw: string | null | undefined) => {
+  finishReason: FinishReason | null;
+  rawFinishReason: string | null;
+} {
+  return (raw) => {
+    if (raw === null || raw === undefined) {
+      return { finishReason: null, rawFinishReason: null };
+    }
+    const finishReason = mapping[raw] ?? 'other';
+    return { finishReason, rawFinishReason: raw };
+  };
+}
+
+/**
+ * Build the four-field `TokenUsage` from already-parsed per-provider numbers,
+ * applying the `inputOther = total - cached` formula shared by OpenAI-style and
+ * Google providers (which expose only a total prompt count and a cached subset).
+ *
+ * `inputOther` is clamped to ≥ 0 when `cached` exceeds `total` (defensive — a
+ * provider should never report more cached than total, but we never emit a
+ * negative usage field). Anthropic is excluded: it reports a real
+ * `inputCacheCreation` field that does not fit this formula.
+ */
+export function extractCacheUsage(
+  total: number,
+  cached: number,
+  output: number,
+): TokenUsage {
+  return {
+    inputOther: Math.max(0, total - cached),
+    output,
+    inputCacheRead: cached,
+    inputCacheCreation: 0,
+  };
+}
+
+const NETWORK_RE = /network|connection|connect|disconnect/i;
+const TIMEOUT_RE = /timed?\s*out|timeout|deadline/i;
+
+/** Options for {@link convertProviderError}. */
+export interface ConvertProviderErrorOptions {
+  /** Numeric HTTP status code extracted from a provider-specific error, if any. */
+  readonly status?: number;
+  /** Request id to attach to a status error, if any. */
+  readonly requestId?: string | null;
+  /**
+   * Extra network-classification matchers the default `NETWORK_RE` does not
+   * cover. Google's SDK throws `fetch failed`, which is not in the default
+   * regex; Google supplies it here. Each matcher is tested against the
+   * lowercased message.
+   */
+  readonly extraNetworkMatchers?: readonly RegExp[];
+  /**
+   * When set, a `TypeError` whose message includes this substring is also
+   * classified as a connection error (Google's fetch layer throws TypeError).
+   */
+  readonly extraTypeErrorMatch?: string;
+}
+
+/**
+ * Convert a raw thrown value into a kosong `ChatProviderError` using the
+ * shared message-based classification ladder:
+ *
+ * 1. already a `ChatProviderError` → returned as-is (identity)
+ * 2. `status` provided → `normalizeAPIStatusError` (status + message + requestId)
+ * 3. message matches `TIMEOUT_RE` → `APITimeoutError`
+ * 4. message matches `NETWORK_RE` or any `extraNetworkMatchers`, or the value
+ *    is a `TypeError` matching `extraTypeErrorMatch` → `APIConnectionError`
+ * 5. otherwise → `ChatProviderError` wrapping the message
+ *
+ * Provider adapters that recognize SDK-specific error classes (e.g. OpenAI's
+ * `APIConnectionTimeoutError`, Google's `GoogleApiError`) should unwrap them
+ * into `(message, status?, requestId?)` before calling this function. The
+ * SDK-class detection itself is provider-specific and stays in the adapter.
+ */
+export function convertProviderError(
+  error: unknown,
+  opts: ConvertProviderErrorOptions = {},
+): ChatProviderError {
+  if (error instanceof ChatProviderError) {
+    return error;
+  }
+  const message =
+    error instanceof Error ? error.message : String(error);
+
+  if (typeof opts.status === 'number') {
+    return normalizeAPIStatusError(opts.status, message, opts.requestId);
+  }
+
+  // Timeout takes priority over network (a timeout is also a connection issue).
+  if (TIMEOUT_RE.test(message)) {
+    return new APITimeoutError(message);
+  }
+
+  if (NETWORK_RE.test(message)) {
+    return new APIConnectionError(message);
+  }
+  if (opts.extraNetworkMatchers?.some((re) => re.test(message))) {
+    return new APIConnectionError(message);
+  }
+  if (
+    opts.extraTypeErrorMatch !== undefined &&
+    error instanceof TypeError &&
+    message.includes(opts.extraTypeErrorMatch)
+  ) {
+    return new APIConnectionError(message);
+  }
+
+  if (error instanceof Error) {
+    return new ChatProviderError(`Error: ${message}`);
+  }
+  return new ChatProviderError(`Error: ${String(error)}`);
+}

--- a/packages/kosong/test/base-provider.test.ts
+++ b/packages/kosong/test/base-provider.test.ts
@@ -66,12 +66,18 @@ class FakeProvider extends BaseChatProvider<FakeKwargs> implements ChatProvider 
 // --- BaseStreamedMessage: a minimal concrete subclass must compile ---
 
 class FakeStreamedMessage extends BaseStreamedMessage {
+  private readonly parts: StreamedMessagePart[];
+
   constructor(parts: StreamedMessagePart[]) {
-    super({
-      async *[Symbol.asyncIterator]() {
-        for (const p of parts) yield p;
-      },
-    });
+    super();
+    this.parts = parts;
+  }
+
+  protected _buildIter(): AsyncIterable<StreamedMessagePart> {
+    const parts = this.parts;
+    return (async function* () {
+      for (const p of parts) yield p;
+    })();
   }
 }
 

--- a/packages/kosong/test/base-provider.test.ts
+++ b/packages/kosong/test/base-provider.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Compile-time type tests for the BaseChatProvider / BaseStreamedMessage
+ * skeletons (#132, ADR 0015).
+ *
+ * These exist primarily to fail compilation if the abstract contract drifts:
+ * a minimal concrete subclass must satisfy every abstract member, and the
+ * inherited boilerplate must be reachable. The runtime assertions are a
+ * secondary guard that the inherited behavior actually works.
+ *
+ * Convention follows `type-safety.test.ts`: the file must compile, and a few
+ * runtime checks assert behavior of the inherited boilerplate.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ChatProvider, GenerateOptions, StreamedMessage, ThinkingEffort } from '#/provider';
+import type { Message, StreamedMessagePart } from '#/message';
+import { UNKNOWN_CAPABILITY } from '#/capability';
+import type { ModelCapability } from '#/capability';
+import type { Tool } from '#/tool';
+import { BaseChatProvider, type ResolvedAuth } from '#/providers/base-chat-provider';
+import { BaseStreamedMessage } from '#/providers/base-streamed-message';
+
+// --- BaseChatProvider: a minimal concrete subclass must compile ---
+
+interface FakeKwargs {
+  temperature?: number;
+  [key: string]: unknown;
+}
+
+class FakeProvider extends BaseChatProvider<FakeKwargs> implements ChatProvider {
+  readonly name = 'fake';
+
+  constructor() {
+    super('fake-model', { temperature: 0.5 }, 'key', 'https://example', { X: '1' });
+  }
+
+  get thinkingEffort(): ThinkingEffort | null {
+    return null;
+  }
+
+  getCapability(_model?: string): ModelCapability {
+    return UNKNOWN_CAPABILITY;
+  }
+
+  async generate(
+    _systemPrompt: string,
+    _tools: Tool[],
+    _history: Message[],
+    _options?: GenerateOptions,
+  ): Promise<StreamedMessage> {
+    throw new Error('not implemented in fake');
+  }
+
+  withThinking(_effort: ThinkingEffort): ChatProvider {
+    return this;
+  }
+
+  protected createRawClient(
+    _auth: ResolvedAuth,
+    _defaultHeaders: Record<string, string> | undefined,
+  ): unknown {
+    return {};
+  }
+}
+
+// --- BaseStreamedMessage: a minimal concrete subclass must compile ---
+
+class FakeStreamedMessage extends BaseStreamedMessage {
+  constructor(parts: StreamedMessagePart[]) {
+    super({
+      async *[Symbol.asyncIterator]() {
+        for (const p of parts) yield p;
+      },
+    });
+  }
+}
+
+describe('BaseChatProvider skeleton (#132)', () => {
+  it('exposes the inherited modelName accessor', () => {
+    const p = new FakeProvider();
+    expect(p.modelName).toBe('fake-model');
+  });
+
+  it('exposes the inherited modelParameters accessor (model + kwargs merged)', () => {
+    const p = new FakeProvider();
+    expect(p.modelParameters).toEqual({ model: 'fake-model', temperature: 0.5 });
+  });
+
+  it('withGenerationKwargs returns a clone with merged kwargs, not mutating the original', () => {
+    const p = new FakeProvider();
+    const next = p.withGenerationKwargs({ temperature: 0.9 });
+    expect(next).not.toBe(p);
+    expect(p.modelParameters).toEqual({ model: 'fake-model', temperature: 0.5 });
+    expect(next.modelParameters).toEqual({ model: 'fake-model', temperature: 0.9 });
+  });
+
+  it('_clone produces a deep-copied _generationKwargs (mutating clone does not affect original)', () => {
+    const p = new FakeProvider();
+    const clone = p.withGenerationKwargs({ temperature: 0.2 });
+    // Mutate the clone's kwargs via another merge; original must be untouched.
+    clone.withGenerationKwargs({ foo: 'bar' });
+    expect(p.modelParameters).toEqual({ model: 'fake-model', temperature: 0.5 });
+  });
+});
+
+describe('BaseStreamedMessage skeleton (#132)', () => {
+  it('defaults all fields to null and forwards iteration', async () => {
+    const parts: StreamedMessagePart[] = [{ type: 'text', text: 'hi' }];
+    const msg = new FakeStreamedMessage(parts);
+    expect(msg.id).toBeNull();
+    expect(msg.usage).toBeNull();
+    expect(msg.finishReason).toBeNull();
+    expect(msg.rawFinishReason).toBeNull();
+
+    const collected: StreamedMessagePart[] = [];
+    for await (const part of msg) collected.push(part);
+    expect(collected).toEqual(parts);
+  });
+});

--- a/packages/kosong/test/provider-common.test.ts
+++ b/packages/kosong/test/provider-common.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import type { FinishReason } from '#/provider';
+import {
+  APIConnectionError,
+  APIStatusError,
+  APITimeoutError,
+  ChatProviderError,
+} from '#/errors';
+import {
+  convertProviderError,
+  extractCacheUsage,
+  makeFinishReasonNormalizer,
+} from '#/providers/provider-common';
+
+describe('makeFinishReasonNormalizer', () => {
+  it('returns the mapped FinishReason and echoes the raw string when the raw is in the table', () => {
+    const normalize = makeFinishReasonNormalizer({
+      stop: 'completed',
+      tool_calls: 'tool_calls',
+    });
+    expect(normalize('stop')).toEqual({ finishReason: 'completed', rawFinishReason: 'stop' });
+  });
+
+  it('maps several raw strings to the same FinishReason (e.g. OpenAI tool_calls + function_call)', () => {
+    const normalize = makeFinishReasonNormalizer({
+      tool_calls: 'tool_calls',
+      function_call: 'tool_calls',
+    });
+    expect(normalize('function_call')).toEqual({
+      finishReason: 'tool_calls',
+      rawFinishReason: 'function_call',
+    });
+  });
+
+  it('falls back to "other" and echoes the raw string when the raw is not in the table', () => {
+    const normalize = makeFinishReasonNormalizer({ stop: 'completed' });
+    expect(normalize('some_unknown_reason')).toEqual({
+      finishReason: 'other',
+      rawFinishReason: 'some_unknown_reason',
+    });
+  });
+
+  it('returns null FinishReason and null raw when input is null', () => {
+    const normalize = makeFinishReasonNormalizer({ stop: 'completed' });
+    expect(normalize(null)).toEqual({ finishReason: null, rawFinishReason: null });
+  });
+
+  it('returns null FinishReason and null raw when input is undefined', () => {
+    const normalize = makeFinishReasonNormalizer({ stop: 'completed' });
+    expect(normalize(undefined)).toEqual({ finishReason: null, rawFinishReason: null });
+  });
+
+  it('maps every raw to "other" when the mapping table is empty', () => {
+    const normalize = makeFinishReasonNormalizer({});
+    expect(normalize('stop')).toEqual({ finishReason: 'other', rawFinishReason: 'stop' });
+  });
+
+  it('falls back to "other" for an empty-string raw (empty is not null)', () => {
+    const normalize = makeFinishReasonNormalizer({ stop: 'completed' });
+    expect(normalize('')).toEqual({ finishReason: 'other', rawFinishReason: '' });
+  });
+
+  it('produces a stateless normalizer that gives identical results across repeated calls', () => {
+    const normalize = makeFinishReasonNormalizer({ stop: 'completed' });
+    const expected = { finishReason: 'completed' as FinishReason, rawFinishReason: 'stop' };
+    expect(normalize('stop')).toEqual(expected);
+    expect(normalize('stop')).toEqual(expected);
+  });
+});
+
+describe('extractCacheUsage', () => {
+  it('splits total input into cache-read and other when some tokens were cached', () => {
+    // total 1000, 700 cached → 300 other
+    expect(extractCacheUsage(1000, 700, 50)).toEqual({
+      inputOther: 300, output: 50, inputCacheRead: 700, inputCacheCreation: 0,
+    });
+  });
+
+  it('puts all input into inputOther when nothing was cached', () => {
+    expect(extractCacheUsage(1000, 0, 50)).toEqual({
+      inputOther: 1000, output: 50, inputCacheRead: 0, inputCacheCreation: 0,
+    });
+  });
+
+  it('reports zero inputOther when everything was cached', () => {
+    expect(extractCacheUsage(800, 800, 20)).toEqual({
+      inputOther: 0, output: 20, inputCacheRead: 800, inputCacheCreation: 0,
+    });
+  });
+
+  it('clamps inputOther to 0 when cached exceeds total (defensive)', () => {
+    // raw subtraction would be negative; ADR 0015 mandates clamp
+    expect(extractCacheUsage(500, 700, 10)).toEqual({
+      inputOther: 0, output: 10, inputCacheRead: 700, inputCacheCreation: 0,
+    });
+  });
+
+  it('handles a zero-token response', () => {
+    expect(extractCacheUsage(0, 0, 0)).toEqual({
+      inputOther: 0, output: 0, inputCacheRead: 0, inputCacheCreation: 0,
+    });
+  });
+});
+
+describe('convertProviderError', () => {
+  it('classifies a timeout-keyword message as APITimeoutError', () => {
+    const out = convertProviderError(new Error('Request timed out after 30s'));
+    expect(out).toBeInstanceOf(APITimeoutError);
+    expect(out.message).toContain('timed out');
+  });
+
+  it('classifies a network-keyword message as APIConnectionError', () => {
+    const out = convertProviderError(new Error('connection reset by peer'));
+    expect(out).toBeInstanceOf(APIConnectionError);
+  });
+
+  it('timeout takes priority over network when a message matches both', () => {
+    // "connect timeout" matches both regexes; timeout must win
+    const out = convertProviderError(new Error('connect timeout'));
+    expect(out).toBeInstanceOf(APITimeoutError);
+  });
+
+  it('classifies via an extraNetworkMatcher the default regex misses (e.g. Google fetch failed)', () => {
+    // "fetch failed" is NOT in the default NETWORK_RE; google supplies it via the hook
+    const out = convertProviderError(
+      new TypeError('fetch failed'),
+      { extraNetworkMatchers: [/^fetch failed$/] },
+    );
+    expect(out).toBeInstanceOf(APIConnectionError);
+  });
+
+  it('classifies a TypeError matching the extra matcher as a connection error (Google case)', () => {
+    // Google: TypeError + msg includes 'fetch' → connection error
+    const out = convertProviderError(
+      new TypeError('TypeError: fetch failed'),
+      { extraNetworkMatchers: [/^fetch failed$/], extraTypeErrorMatch: 'fetch' },
+    );
+    expect(out).toBeInstanceOf(APIConnectionError);
+  });
+
+  it('normalizes a numeric status code into an APIStatusError', () => {
+    const out = convertProviderError(new Error('rate limited'), { status: 429 });
+    expect(out).toBeInstanceOf(APIStatusError);
+  });
+
+  it('passes requestId through to the status error when supplied', () => {
+    const out = convertProviderError(new Error('boom'), { status: 500, requestId: 'req-42' });
+    expect(out).toBeInstanceOf(APIStatusError);
+    expect((out as APIStatusError).requestId).toBe('req-42');
+  });
+
+  it('falls back to ChatProviderError for a plain message that matches no pattern', () => {
+    const out = convertProviderError(new Error('something weird happened'));
+    expect(out).toBeInstanceOf(ChatProviderError);
+    expect(out).not.toBeInstanceOf(APITimeoutError);
+    expect(out).not.toBeInstanceOf(APIConnectionError);
+  });
+
+  it('returns the same instance when given an already-ChatProviderError', () => {
+    const existing = new APITimeoutError('already');
+    expect(convertProviderError(existing)).toBe(existing);
+  });
+
+  it('wraps a non-Error thrown value into a ChatProviderError', () => {
+    const out = convertProviderError('a bare string');
+    expect(out).toBeInstanceOf(ChatProviderError);
+  });
+});
+
+


### PR DESCRIPTION
## Related

N/A

## Changes

### Kosong (provider layer)

- **Add BaseChatProvider + BaseStreamedMessage + provider-common** — introduce a unified base class for chat providers with a shared finish reason normalizer
- **Migrate openai-completions + anthropic** to BaseChatProvider
- **Migrate openai-responses + google-genai** to BaseChatProvider
- **Adopt BaseStreamedMessage and makeFinishReasonNormalizer** across all providers
- **Use merged defaultHeaders** in Anthropic createRawClient

### CLI / TUI

- **Extract DialogManager** for picker/show* methods
- **Remove byf-tui event forwarding shims**, route directly to handlers
- Clean up DialogManager and ByfTui imports after extraction
- Use canonical formatTokenCount in footer

### Agent Core

- **TaskEntry discriminated union**, eliminate as-unknown-as-KaosProcess

### Docs & Tests

- Fix CONTEXT.md stale PlanMode reference
- Update domain.md to include docs/prd directory structure
- Update thinking spinner assertions to match current frames

## Why

Reduce duplication across providers by unifying them under BaseChatProvider, and clean up CLI event forwarding by extracting DialogManager into its own module.