### PR TITLE
feat(login): add Anthropic native model fetching #146

### DIFF
--- a/.changeset/login-anthropic-native.md
+++ b/.changeset/login-anthropic-native.md
@@ -1,0 +1,14 @@
+---
+'@byfriends/sdk': minor
+---
+
+Add Anthropic native model fetching to `/login` (PRD-0002, issue #146)
+
+Selecting the `anthropic` interface type in `/login` now lists models from the
+native Anthropic endpoint instead of impersonating OpenAI-compatible:
+`fetchModelsByType('anthropic', ...)` calls `{baseUrl}/models` with `x-api-key`
++ `anthropic-version: 2023-06-01` headers (not Bearer), follows `has_more` /
+`last_id` pagination with `?after_id=`, and maps `display_name`. Defensive
+guards: stops pagination when `has_more` is true but `last_id` is missing, and a
+10-page cap bounds the loop. The runtime already consumes the provider
+`baseUrl` for anthropic (verified), so custom/gateway URLs take effect end-to-end.

--- a/.changeset/login-api-type-selector.md
+++ b/.changeset/login-api-type-selector.md
@@ -1,0 +1,23 @@
+---
+'@byfriends/sdk': minor
+'@byfriends/cli': minor
+---
+
+Add API interface-type selection as the first `/login` step (PRD-0002, issue #145)
+
+Foundation slice for multi-type `/login`. The flow now starts with a type picker
+(`openai-completions` / `openai_responses` / `anthropic`); selecting a type
+prefills the Base URL placeholder with the official default, and leaving Base URL
+empty falls back to that default. This release wires the scaffolding end-to-end
+for the existing `openai-completions` type with zero behavior regression —
+per-type native fetchers land in follow-up issues (#146 anthropic, #149 responses).
+
+- `@byfriends/oauth`: `applyProviderConfig` accepts an optional `type` (defaults
+  to `'openai-completions'`, so existing callers are unaffected); new
+  `fetchModelsByType(type, baseUrl, apiKey)` dispatches to the OpenAI-compatible
+  fetcher for `openai-completions` / `openai_responses`. Both re-exported via SDK.
+- `@byfriends/cli`: new `promptApiTypeSelection`; `LoginFlow` runs the type step
+  first, threads the selected type into `applyProviderConfig`, and
+  `LoginFlowDeps.fetchModels` is now `(type, baseUrl, apiKey)`.
+- `TextInputDialog` gains an opt-in `allowEmpty` so the Base URL prompt can be
+  submitted empty (= use the official default).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -32,7 +32,7 @@ The unified provider type for any OpenAI Chat Completions-compatible API (OpenAI
 A well-known provider (OpenAI, Anthropic, etc.) configured through `/connect`, which fetches metadata from the models.dev catalog. Distinct from user-configured providers from `/login`.
 
 ### /login
-CLI command to add a custom OpenAI-compatible provider. Flow: name → base_url → api_key → select model. Supports multiple providers.
+CLI command to add a custom provider via BYO API key + base URL. Supports three interface types: `openai-completions` (OpenAI Chat Completions-compatible), `openai_responses` (OpenAI Responses API), and `anthropic` (Anthropic native). `google-genai` and `vertexai` are deferred until the base-URL propagation to the runtime provider is implemented. Flow: type → name → base_url → api_key → select model. Supports multiple providers. Catalog enrichment (ADR 0012) applies to all types.
 
 ### /connect
 CLI command to configure a catalog provider from models.dev. Complements `/login`.
@@ -75,6 +75,15 @@ A permission gate before a tool is executed. The agent presents a tool call to t
 
 ### Sub-agent Activity Trace
 A user-visible account of what a sub-agent did while working: lifecycle status, visible assistant output, tool activity, approval waits, errors, and final result. It is not the model's private chain-of-thought.
+
+### Foreground Sub-agent
+A sub-agent spawned via the Agent tool call that blocks the parent agent. Its events are routed via `routeSubagentEvent` to the parent `ToolCallComponent`. While running it lives in `pendingToolComponents`; after completion the component survives in `transcriptContainer` (solo or inside an `AgentGroupComponent`). Distinct from background agents (covered by `/tasks` via `listBackgroundTasks()`).
+
+### Live Viewer
+The full-screen, scrollable, real-time viewer of a foreground sub-agent's activity, opened via `/agent`. Subscribes to the parent `ToolCallComponent`'s live state (not a one-shot snapshot). The rendering carrier of the Sub-agent Activity Trace.
+
+### /agent
+CLI command to open the foreground sub-agent list + live viewer. Singular form, aligned with Codex's `/agent` (single-session sub-agent threads). Distinct from Claude Code's plural `/agents` (cross-session independent sessions).
 
 ### Context Minimization
 A first-class engineering concern in the agent engine. The discipline of curating the smallest set of high-signal tokens that maximize the likelihood of desired outcomes. Encompasses system prompt size, tool definition tokens, conversation history, tool outputs, and prompt caching.

--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -21,7 +21,7 @@ import { homedir } from 'node:os';
 import { resolve as resolvePath } from 'node:path';
 import {
   applyProviderConfig,
-  fetchModels,
+  fetchModelsByType,
   log,
 } from '@byfriends/sdk';
 import { BUILT_IN_CATALOG_JSON } from '../built-in-catalog';
@@ -3819,7 +3819,7 @@ export class ByfTui implements DialogHost {
       dialogHost: this,
       getConfig: () => this.harness.getConfig(),
       setConfig: (cfg) => this.harness.setConfig(cfg),
-      fetchModels: (baseUrl, apiKey) => fetchModels(baseUrl, apiKey),
+      fetchModels: (type, baseUrl, apiKey) => fetchModelsByType(type, baseUrl, apiKey),
       applyProviderConfig: (config, opts) => applyProviderConfig(config, opts),
       refreshConfigAfterLogin: () => this.refreshConfigAfterLogin(),
       showStatus: (msg, color?) =>{  this.showStatus(msg, color); },

--- a/apps/cli/src/tui/components/dialogs/text-input-dialog.ts
+++ b/apps/cli/src/tui/components/dialogs/text-input-dialog.ts
@@ -26,6 +26,7 @@ export class TextInputDialogComponent extends Container implements Focusable {
   private readonly title: string;
   private readonly subtitle: string;
   private readonly placeholder: string;
+  private readonly allowEmpty: boolean;
   private done = false;
   private emptyHinted = false;
 
@@ -35,6 +36,7 @@ export class TextInputDialogComponent extends Container implements Focusable {
       readonly subtitle: string;
       readonly placeholder?: string;
       readonly initialValue?: string;
+      readonly allowEmpty?: boolean;
       readonly colors: ColorPalette;
       readonly onDone: (result: TextInputDialogResult) => void;
     },
@@ -45,6 +47,7 @@ export class TextInputDialogComponent extends Container implements Focusable {
     this.title = opts.title;
     this.subtitle = opts.subtitle;
     this.placeholder = opts.placeholder ?? '';
+    this.allowEmpty = opts.allowEmpty ?? false;
     if (opts.initialValue) {
       this.input.handleInput(opts.initialValue);
     }
@@ -120,7 +123,7 @@ export class TextInputDialogComponent extends Container implements Focusable {
   private submit(value: string): void {
     if (this.done) return;
     const trimmed = value.trim();
-    if (trimmed.length === 0) {
+    if (trimmed.length === 0 && !this.allowEmpty) {
       this.emptyHinted = true;
       return;
     }

--- a/apps/cli/src/tui/flows/dialog-prompts.ts
+++ b/apps/cli/src/tui/flows/dialog-prompts.ts
@@ -18,6 +18,7 @@ export function promptTextInput(
     readonly subtitle: string;
     readonly initialValue?: string;
     readonly placeholder?: string;
+    readonly allowEmpty?: boolean;
   },
 ): Promise<string | undefined> {
   return new Promise((resolve) => {
@@ -26,6 +27,7 @@ export function promptTextInput(
       subtitle: opts.subtitle,
       initialValue: opts.initialValue,
       placeholder: opts.placeholder,
+      allowEmpty: opts.allowEmpty,
       colors,
       onDone: (result) => {
         host.close();
@@ -78,6 +80,37 @@ export function promptConfiguredProviderSelection(
       title: 'Select a provider to log out',
       options,
       currentValue: defaultProvider,
+      colors,
+      searchable: false,
+      onSelect: (value) => {
+        host.close();
+        resolve(value);
+      },
+      onCancel: () => {
+        host.close();
+        resolve(undefined);
+      },
+    });
+    host.show(picker);
+  });
+}
+
+/**
+ * Opens the API interface-type picker shown as the first `/login` step.
+ * Returns the chosen ProviderType string, or `undefined` when cancelled.
+ *
+ * Options are owned by the caller (`options`) so login-flow can keep the
+ * per-type base-URL defaults next to the dispatch logic.
+ */
+export function promptApiTypeSelection(
+  host: DialogHost,
+  colors: ColorPalette,
+  options: readonly ChoiceOption[],
+): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    const picker = new ChoicePickerComponent({
+      title: 'Select API type',
+      options,
       colors,
       searchable: false,
       onSelect: (value) => {

--- a/apps/cli/src/tui/flows/login-flow.ts
+++ b/apps/cli/src/tui/flows/login-flow.ts
@@ -21,7 +21,9 @@ import {
   promptTextInput as promptTextInputViaHost,
   promptApiKey as promptApiKeyViaHost,
   promptModelSelector as promptModelSelectorViaHost,
+  promptApiTypeSelection as promptApiTypeSelectionViaHost,
 } from '#/tui/flows/dialog-prompts';
+import type { ChoiceOption } from '#/tui/components/dialogs/choice-picker';
 
 export interface ModelSelection {
   alias: string;
@@ -32,12 +34,42 @@ export interface SpinnerHandle {
   stop(opts: { ok: boolean; label: string }): void;
 }
 
+/**
+ * Interface types offered by `/login`. Each entry maps to its native
+ * model-listing fetcher and its official default base URL (used when the user
+ * leaves the base-URL input empty). `google-genai` / `vertexai` are deferred —
+ * their runtime does not consume a user-supplied baseUrl (ADR 0016).
+ */
+const API_TYPE_OPTIONS: readonly ChoiceOption[] = [
+  {
+    value: 'openai-completions',
+    label: 'OpenAI Chat Completions 兼容',
+    description: 'https://api.openai.com/v1',
+  },
+  {
+    value: 'openai_responses',
+    label: 'OpenAI Responses API',
+    description: 'https://api.openai.com/v1',
+  },
+  {
+    value: 'anthropic',
+    label: 'Anthropic 原生',
+    description: 'https://api.anthropic.com/v1',
+  },
+];
+
+const DEFAULT_BASE_URL: Record<string, string> = {
+  'openai-completions': 'https://api.openai.com/v1',
+  'openai_responses': 'https://api.openai.com/v1',
+  'anthropic': 'https://api.anthropic.com/v1',
+};
+
 export interface LoginFlowDeps {
   readonly colors: ColorPalette;
   readonly dialogHost: DialogHost;
   getConfig(): Promise<ByfConfig>;
   setConfig(config: ByfConfigPatch): Promise<unknown>;
-  fetchModels(baseUrl: string, apiKey: string): Promise<OAuthModelInfo[]>;
+  fetchModels(type: string, baseUrl: string, apiKey: string): Promise<OAuthModelInfo[]>;
   applyProviderConfig: typeof applyProviderConfig;
   refreshConfigAfterLogin(): Promise<void>;
   showStatus(message: string, color?: string): void;
@@ -52,6 +84,10 @@ export class LoginFlow {
 
   async run(): Promise<void> {
     const { dialogHost, colors } = this.deps;
+
+    const type = await promptApiTypeSelectionViaHost(dialogHost, colors, API_TYPE_OPTIONS);
+    if (type === undefined) return;
+
     const name = await promptTextInputViaHost(dialogHost, colors, {
       title: 'Provider name',
       subtitle: 'A short name for this provider (e.g. deepseek, openrouter)',
@@ -69,12 +105,15 @@ export class LoginFlow {
       return;
     }
 
-    const baseUrl = await promptTextInputViaHost(dialogHost, colors, {
+    const defaultUrl = DEFAULT_BASE_URL[type] ?? '';
+    const baseUrlInput = await promptTextInputViaHost(dialogHost, colors, {
       title: 'Base URL',
-      subtitle: 'The OpenAI-compatible API endpoint',
-      placeholder: 'https://api.openai.com/v1',
+      subtitle: 'The API endpoint (leave empty for the official default)',
+      placeholder: defaultUrl,
+      allowEmpty: true,
     });
-    if (baseUrl === undefined) return;
+    if (baseUrlInput === undefined) return;
+    const baseUrl = baseUrlInput.length > 0 ? baseUrlInput : defaultUrl;
 
     const apiKey = await promptApiKeyViaHost(dialogHost, colors, name);
     if (apiKey === undefined) return;
@@ -82,7 +121,7 @@ export class LoginFlow {
     let models: OAuthModelInfo[];
     const spinner = this.deps.showLoginProgressSpinner(`Fetching models from ${baseUrl}`);
     try {
-      models = await this.deps.fetchModels(baseUrl, apiKey);
+      models = await this.deps.fetchModels(type, baseUrl, apiKey);
       spinner.stop({ ok: true, label: `Found ${String(models.length)} model(s).` });
     } catch (error: unknown) {
       spinner.stop({ ok: false, label: 'Failed' });
@@ -91,12 +130,12 @@ export class LoginFlow {
       } else {
         this.deps.showError(`Failed to fetch models: ${formatErrorMessage(error)}`);
       }
-      return this.handleManualModelEntry(name, baseUrl, apiKey);
+      return this.handleManualModelEntry(type, name, baseUrl, apiKey);
     }
 
     if (models.length === 0) {
       this.deps.showStatus('No models found at this endpoint. Enter model ID manually.');
-      return this.handleManualModelEntry(name, baseUrl, apiKey);
+      return this.handleManualModelEntry(type, name, baseUrl, apiKey);
     }
 
     const catalog = await this.fetchCatalogWithFallback();
@@ -129,12 +168,13 @@ export class LoginFlow {
     const selectedModel = models.find((m) => m.id === selectedId);
     if (selectedModel === undefined) return;
 
-    await this.applyConfig(name, baseUrl, apiKey, models, selectedModel, selection.thinkingEffort !== 'off', enriched);
+    await this.applyConfig(type, name, baseUrl, apiKey, models, selectedModel, selection.thinkingEffort !== 'off', enriched);
     this.deps.track('login', { provider: name, model: selectedModel.id });
     this.deps.showStatus(`Connected: ${name} · ${selectedModel.id}`);
   }
 
   private async handleManualModelEntry(
+    type: string,
     name: string,
     baseUrl: string,
     apiKey: string,
@@ -168,12 +208,13 @@ export class LoginFlow {
       supportsVideoIn: false,
     };
 
-    await this.applyConfig(name, baseUrl, apiKey, [manualModelInfo], manualModelInfo, false, {});
+    await this.applyConfig(type, name, baseUrl, apiKey, [manualModelInfo], manualModelInfo, false, {});
     this.deps.track('login', { provider: name, model: manualModel });
     this.deps.showStatus(`Connected: ${name} · ${manualModel}`);
   }
 
   private async applyConfig(
+    type: string,
     name: string,
     baseUrl: string,
     apiKey: string,
@@ -185,6 +226,7 @@ export class LoginFlow {
     const config = await this.deps.getConfig();
     this.deps.applyProviderConfig(config, {
       name,
+      type,
       baseUrl,
       apiKey,
       models,

--- a/apps/cli/test/tui/flows/login-flow.test.ts
+++ b/apps/cli/test/tui/flows/login-flow.test.ts
@@ -94,6 +94,13 @@ function selectHighlighted(host: FakeDialogHost): void {
   activePanel(host).handleInput('\r');
 }
 
+/** Move the ChoicePicker highlight down `n` items, then select. */
+function selectNth(host: FakeDialogHost, n: number): void {
+  const panel = activePanel(host);
+  for (let i = 0; i < n; i += 1) panel.handleInput('\x1b[B'); // Down arrow
+  panel.handleInput('\r');
+}
+
 function makeDeps(overrides: Partial<LoginFlowDeps> = {}): LoginFlowDeps {
   return {
     colors: COLORS as any,
@@ -161,6 +168,54 @@ describe('LoginFlow', () => {
     expect(deps.refreshConfigAfterLogin).toHaveBeenCalled();
     expect(deps.track).toHaveBeenCalledWith('login', { provider: 'myprovider', model: 'gpt-4o' });
     expect(deps.showStatus).toHaveBeenCalledWith('Connected: myprovider · gpt-4o');
+  });
+
+  it('completes the full flow when the anthropic type is selected', async () => {
+    const deps = makeDeps({
+      fetchModels: vi.fn(async () => [
+        { id: 'claude-opus-4-7', contextLength: 200000, supportsReasoning: true, supportsImageIn: true, supportsVideoIn: false, displayName: 'Claude Opus 4.7' },
+      ]),
+    });
+    const host = getHost(deps);
+
+    const flowPromise = new LoginFlow(deps).run();
+
+    // Step 1: select anthropic (3rd option → down x2)
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectNth(host, 2);
+
+    // Provider name
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    await typeAndEnter(host, 'anthropic');
+
+    // Base URL left empty → anthropic default
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    activePanel(host).handleInput('\r');
+
+    // API key
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    await typeAndEnter(host, 'sk-ant-test');
+
+    // Model select
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    activePanel(host).handleInput('\r');
+
+    await flowPromise;
+
+    // Empty base URL fell back to the anthropic official default.
+    expect(deps.fetchModels).toHaveBeenCalledWith(
+      'anthropic',
+      'https://api.anthropic.com/v1',
+      'sk-ant-test',
+    );
+    expect(deps.applyProviderConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        name: 'anthropic',
+        type: 'anthropic',
+        baseUrl: 'https://api.anthropic.com/v1',
+      }),
+    );
   });
 
   it('uses the type default base URL when left empty', async () => {

--- a/apps/cli/test/tui/flows/login-flow.test.ts
+++ b/apps/cli/test/tui/flows/login-flow.test.ts
@@ -89,6 +89,11 @@ function pressEscape(host: FakeDialogHost): void {
   activePanel(host).handleInput('\u001B');
 }
 
+/** Select the currently-highlighted option (first by default) in a ChoicePicker. */
+function selectHighlighted(host: FakeDialogHost): void {
+  activePanel(host).handleInput('\r');
+}
+
 function makeDeps(overrides: Partial<LoginFlowDeps> = {}): LoginFlowDeps {
   return {
     colors: COLORS as any,
@@ -120,25 +125,29 @@ describe('LoginFlow', () => {
     // Run flow in background since each prompt step is async
     const flowPromise = new LoginFlow(deps).run();
 
-    // Step 1: type provider name
+    // Step 1: select API type (first option = openai-completions)
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
+
+    // Step 2: type provider name
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     await typeAndEnter(host, 'myprovider');
 
-    // Step 2: type base URL
+    // Step 3: type base URL
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     await typeAndEnter(host, 'https://api.example.com/v1');
 
-    // Step 3: type API key
+    // Step 4: type API key
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     await typeAndEnter(host, 'sk-test-key');
 
-    // Step 4: select model (first item is already highlighted, press Enter)
+    // Step 5: select model (first item is already highlighted, press Enter)
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     activePanel(host).handleInput('\r');
 
     await flowPromise;
 
-    expect(deps.fetchModels).toHaveBeenCalledWith('https://api.example.com/v1', 'sk-test-key');
+    expect(deps.fetchModels).toHaveBeenCalledWith('openai-completions', 'https://api.example.com/v1', 'sk-test-key');
     expect(deps.applyProviderConfig).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({
@@ -154,11 +163,105 @@ describe('LoginFlow', () => {
     expect(deps.showStatus).toHaveBeenCalledWith('Connected: myprovider · gpt-4o');
   });
 
+  it('uses the type default base URL when left empty', async () => {
+    const deps = makeDeps({
+      fetchModels: vi.fn(async () => [
+        { id: 'gpt-4o', contextLength: 128000, supportsReasoning: false, supportsImageIn: false, supportsVideoIn: false },
+      ]),
+    });
+    const host = getHost(deps);
+
+    const flowPromise = new LoginFlow(deps).run();
+
+    // Select openai-completions (first option)
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
+
+    // Provider name
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    await typeAndEnter(host, 'openai');
+
+    // Base URL: leave empty (press Enter on empty text input)
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    activePanel(host).handleInput('\r');
+
+    // API key
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    await typeAndEnter(host, 'sk-test');
+
+    // Model select
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    activePanel(host).handleInput('\r');
+
+    await flowPromise;
+
+    // Empty base URL falls back to the openai-completions official default.
+    expect(deps.fetchModels).toHaveBeenCalledWith(
+      'openai-completions',
+      'https://api.openai.com/v1',
+      'sk-test',
+    );
+    expect(deps.applyProviderConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ baseUrl: 'https://api.openai.com/v1' }),
+    );
+  });
+
+  it('passes the selected type to applyProviderConfig', async () => {
+    const deps = makeDeps({
+      fetchModels: vi.fn(async () => [
+        { id: 'gpt-4o', contextLength: 128000, supportsReasoning: false, supportsImageIn: false, supportsVideoIn: false },
+      ]),
+    });
+    const host = getHost(deps);
+
+    const flowPromise = new LoginFlow(deps).run();
+
+    // Select openai-completions (first option)
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
+
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    await typeAndEnter(host, 'myprovider');
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    await typeAndEnter(host, 'https://api.example.com/v1');
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    await typeAndEnter(host, 'sk-test-key');
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    activePanel(host).handleInput('\r');
+
+    await flowPromise;
+
+    expect(deps.applyProviderConfig).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: 'openai-completions' }),
+    );
+  });
+
+  it('cancels at the API type selection step', async () => {
+    const deps = makeDeps();
+    const host = getHost(deps);
+
+    const flowPromise = new LoginFlow(deps).run();
+
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    pressEscape(host);
+
+    await flowPromise;
+
+    expect(deps.showStatus).not.toHaveBeenCalled();
+    expect(deps.fetchModels).not.toHaveBeenCalled();
+  });
+
   it('rejects invalid provider names', async () => {
     const deps = makeDeps();
     const host = getHost(deps);
 
     const flowPromise = new LoginFlow(deps).run();
+
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
 
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     await typeAndEnter(host, 'bad name!');
@@ -181,6 +284,10 @@ describe('LoginFlow', () => {
 
     const flowPromise = new LoginFlow(deps).run();
 
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
+
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     await typeAndEnter(host, 'existing');
 
@@ -197,6 +304,10 @@ describe('LoginFlow', () => {
 
     const flowPromise = new LoginFlow(deps).run();
 
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
+
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     pressEscape(host);
 
@@ -210,6 +321,10 @@ describe('LoginFlow', () => {
     const host = getHost(deps);
 
     const flowPromise = new LoginFlow(deps).run();
+
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
 
     // Type provider name
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -227,6 +342,10 @@ describe('LoginFlow', () => {
     const host = getHost(deps);
 
     const flowPromise = new LoginFlow(deps).run();
+
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
 
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     await typeAndEnter(host, 'myprovider');
@@ -252,6 +371,10 @@ describe('LoginFlow', () => {
     const host = getHost(deps);
 
     const flowPromise = new LoginFlow(deps).run();
+
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
 
     // Provider name
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -295,6 +418,10 @@ describe('LoginFlow', () => {
 
     const flowPromise = new LoginFlow(deps).run();
 
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
+
     // Provider name
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     await typeAndEnter(host, 'myprovider');
@@ -333,6 +460,10 @@ describe('LoginFlow', () => {
 
     const flowPromise = new LoginFlow(deps).run();
 
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
+
     // Provider name
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     await typeAndEnter(host, 'myprovider');
@@ -364,6 +495,10 @@ describe('LoginFlow', () => {
 
     const flowPromise = new LoginFlow(deps).run();
 
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
+
     // Provider name
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     await typeAndEnter(host, 'myprovider');
@@ -392,6 +527,10 @@ describe('LoginFlow', () => {
     const host = getHost(deps);
 
     const flowPromise = new LoginFlow(deps).run();
+
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
 
     // Provider name
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -425,6 +564,10 @@ describe('LoginFlow', () => {
     const host = getHost(deps);
 
     const flowPromise = new LoginFlow(deps).run();
+
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
 
     // Provider name
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
@@ -465,6 +608,10 @@ describe('LoginFlow', () => {
 
     const flowPromise = new LoginFlow(deps).run();
 
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
+
     // Provider name
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
     await typeAndEnter(host, 'myprovider');
@@ -503,6 +650,10 @@ describe('LoginFlow', () => {
     const host = getHost(deps);
 
     const flowPromise = new LoginFlow(deps).run();
+
+    // Select openai-completions type
+    await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });
+    selectHighlighted(host);
 
     // Provider name
     await vi.waitFor(() =>{  expect(host.panel).not.toBeNull(); });

--- a/docs/adr/0002-user-configurable-providers.md
+++ b/docs/adr/0002-user-configurable-providers.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Accepted — **partially superseded by [ADR 0016](0016-login-multi-type-providers.md)**: the decision "Provider type is always `'openai-compat'`" (decision point #7 below) was reversed; `/login` now supports multiple interface types. All other decisions in this ADR remain in force.
 
 ## Context
 

--- a/docs/adr/0016-login-multi-type-providers.md
+++ b/docs/adr/0016-login-multi-type-providers.md
@@ -1,0 +1,61 @@
+# ADR 0016: Multi-Type Providers in /login
+
+Date: 2026-06-18
+
+## Status
+
+Accepted
+
+## Context
+
+ADR 0002 established `/login` as the entry point for user-configured providers, with one hard constraint (decision point #7): "Provider type is always `'openai-compat'`." At the time this was sufficient — the only path to non-OpenAI providers was `/connect`, which derives the wire type from the models.dev catalog.
+
+The gap surfaced in practice: users who want to connect to the native Anthropic endpoint (or a custom Anthropic-compatible gateway) via BYO base URL cannot do so through `/login`. They must either impersonate OpenAI-compatible (relying on a proxy to translate the wire format) or abandon `/login` for `/connect` (which requires the target provider to be catalog-listed). Neither fits the "custom provider, my own endpoint" workflow that is `/login`'s reason to exist.
+
+A code review during `/grill` revealed an additional constraint that bounds the first version: `google-genai` and `vertexai` providers do not consume a user-supplied `baseUrl` at runtime — `runtime-provider.ts` does not pass `baseUrl` into the google-genai kosong config, and `GoogleGenAIChatProvider` ignores it. So exposing a base-URL field for those types would persist a value to TOML that the runtime silently drops, breaking the "custom URL must take effect" promise. This is deferred, not designed away.
+
+## Decision
+
+`/login` no longer hardcodes a single interface type. The flow gains a type-selection step as its first prompt, offering the types whose base-URL propagation is end-to-end functional:
+
+1. `openai-completions` — OpenAI Chat Completions-compatible (unchanged behavior)
+2. `openai_responses` — OpenAI Responses API (shares the `/models` endpoint with openai-completions)
+3. `anthropic` — Anthropic native endpoint
+
+For each type:
+- A native model-listing fetcher is used (`fetchModelsByType` in `@byfriends/oauth`), rather than the OpenAI-compatible shape for all. The Anthropic fetcher uses `x-api-key` + `anthropic-version` headers and handles `has_more`/`last_id` pagination.
+- The provider's `type` field written to TOML matches the user's choice.
+- Base URL is entered via a placeholder hint (the type's official default), left empty = use the official default.
+
+`google-genai` and `vertexai` are explicitly deferred from the selector until base-URL propagation to those runtime providers is implemented (separate work). This supersedes ADR 0002 decision point #7 only; all other ADR 0002 decisions (multiple providers, `/logout <name>`, `/connect` for catalog providers, manual model entry on fetch failure) remain in force.
+
+Catalog enrichment (ADR 0012) continues to apply uniformly across all `/login` types — model IDs are matched against models.dev regardless of type, since catalog metadata for claude models is authoritative.
+
+## Consequences
+
+### Positive
+
+- Users can connect to the native Anthropic endpoint and Anthropic-compatible gateways directly through `/login`, without an OpenAI-compat translation proxy.
+- The `type` field in TOML accurately reflects the wire protocol, eliminating the latent mismatch where an Anthropic endpoint was mislabeled `openai-completions`.
+- The base-URL promise ("custom URL takes effect") holds for every offered type — no silent drops, because types that cannot honor it are excluded.
+
+### Negative
+
+- `/login` gains a step. Users connecting to OpenAI-compatible providers (the common case today) make one extra selection.
+- Per-type native fetchers add maintenance surface in `@byfriends/oauth` (Anthropic pagination, OpenAI Responses quirks). A future provider type needs its own fetcher.
+- `google-genai` / `vertexai` users still cannot use `/login` for BYO endpoints; they must use `/connect` (catalog) or wait for the base-URL propagation work.
+- The base-URL convention (baseUrl contains the version path, e.g. `/v1`; fetcher appends `/models`) is end-to-end: a custom proxy that does not follow this convention will fail both listing and runtime chat consistently.
+
+## Alternatives Considered
+
+* **Keep ADR 0002 as-is (always openai-compat):** rejected — leaves the native-endpoint workflow unsupported, the original problem.
+* **Implement all five types including google-genai/vertexai now:** rejected — google-genai's runtime ignores `baseUrl` (verified in `runtime-provider.ts` + `GoogleGenAIChatProvider`), so shipping it would persist a silently-ignored config value, violating the custom-URL promise. Better to defer until the propagation fix lands.
+* **Derive type from the base URL heuristically:** rejected — fragile (many proxies impersonate multiple wire types) and removes the user's ability to be explicit about a non-obvious gateway.
+* **Route all non-OpenAI types through `/connect` only:** rejected — `/connect` requires the provider to be catalog-listed; custom/private Anthropic gateways are exactly the case `/login` exists for.
+
+## References
+
+* [ADR 0002 — User-Configurable Providers via /login](0002-user-configurable-providers.md) (decision point #7 superseded)
+* [ADR 0012 — Login-Time Catalog Enrichment](0012-login-catalog-enrichment.md) (enrichment continues to apply)
+* `packages/agent-core/src/providers/runtime-provider.ts:280-285` (google-genai omits baseUrl — the deferral trigger)
+* `packages/oauth/src/provider-config.ts:183-227` (`applyProviderConfig` hardcodes type today)

--- a/docs/prd/PRD-0002-login-api-type-selector.md
+++ b/docs/prd/PRD-0002-login-api-type-selector.md
@@ -160,7 +160,7 @@
 - **Grilled by**: `/grill` (completed 2026-06-18) — 9 items resolved: 3 代码矛盾验证（google-genai baseUrl 静默丢弃→范围收缩至 3 类型；anthropic/openai_responses baseUrl 已验证端到端生效）；1 术语冲突（CONTEXT.md `/login` 定义过时→已同步）；1 分页边界（anthropic has_more/last_id 防御性处理）；1 降级体验（自定义代理版本路径约定写入 Consequences）；1 changeset 级别（定为 minor，代码可答）；1 ADR 关系（新建 ADR-0016，ADR-0002 决策 #7 标记部分被取代）；1 enrichment 交互（对 anthropic 自动生效）。
 - **Sliced by**: `/story` → Child Issues below
 - **Sliced into**:
-  - #145 — [PRD-0002] 类型选择步骤 + openai-completions 端到端贯通 (AFK)
+  - #145 — [PRD-0002] 类型选择步骤 + openai-completions 端到端贯通 (AFK) — Done (#153)
   - #146 — [PRD-0002] Anthropic 原生类型支持 (AFK, blocked by #145)
   - #149 — [PRD-0002] OpenAI Responses 类型支持 (AFK, blocked by #145)
   - #152 — [PRD-0002] Catalog enrichment 与手填 fallback 跨类型回归 (AFK, blocked by #145, #146)

--- a/docs/prd/PRD-0002-login-api-type-selector.md
+++ b/docs/prd/PRD-0002-login-api-type-selector.md
@@ -1,0 +1,172 @@
+# PRD-0002: /login API Type Selector
+
+**Status**: Sliced
+**Created**: 2026-06-18
+**Author**: BYF
+**Related**: ADR 0006 (monorepo layered architecture), ADR 0012 (login-time catalog enrichment), ADR 0016 (supersedes ADR 0002 decision point #7)
+
+## Problem
+
+`/login` 命令把 provider 的接口类型硬编码为 `openai-completions`：`apps/cli/src/tui/flows/login-flow.ts` 调用 `applyProviderConfig`（`packages/oauth/src/provider-config.ts:197-202`），后者始终写入 `type: 'openai-completions'`；Base URL 提示语也写死为 "The OpenAI-compatible API endpoint"。Schema 里其实已经支持 5 种类型（`anthropic` / `openai-completions` / `google-genai` / `openai_responses` / `vertexai`，见 `packages/agent-core/src/config/schema.ts:6-12`），但 `/login` 流程没有让用户选。
+
+`/connect` 走的是 models.dev 目录路线，靠 `inferWireType` 自动推断类型；`/login` 是手填 URL 的 BYO 路线，两者分工不同。问题只存在于 `/login`：用户无法通过 `/login` 接入 Anthropic / Google 原生端点，只能被迫伪装成 OpenAI 兼容（依赖代理转换）或改用 `/connect`（但目录未必收录目标 provider）。
+
+## Goal
+
+为 `/login` 在流程最前面新增「接口类型选择」步骤，并按所选类型：
+
+1. **预填 Base URL 提示**：placeholder 显示该类型的官方默认值作为格式提示（用户初始输入框为空，不改 = 用官方默认）。
+2. **原生拉取模型列表**：对 `openai-completions` / `openai_responses` / `anthropic` 各自实现正确的模型列举端点调用，而非统一走 OpenAI 兼容形态。
+3. **写入正确的 `type`**：生成的 `config.toml` 中 provider 的 `type` 字段与用户选择一致。
+
+> **范围收缩（grill 决议）**：第一版只支持 3 种类型。`google-genai` 和 `vertexai` 被排除——`google-genai` 的运行时不消费 `baseUrl`（`packages/agent-core/src/providers/runtime-provider.ts:280-285` 不传 baseUrl，`GoogleGenAIChatProvider` 忽略它），暴露 base URL 字段会持久化一个被运行时静默丢弃的值，违反"自定义 URL 要能生效"的核心诉求。详见 ADR 0016。
+
+## Not Building (Out of Scope)
+
+- **`google-genai` 支持**：运行时不消费 `baseUrl`（已验证）。待 base-URL 传递链路（runtime-provider + kosong GoogleGenAIChatProvider）补齐后再加。**Deferred，非永久排除。**
+- **`vertexai` 支持**：依赖 GCP OAuth/ADC（服务账号或 `gcloud auth application-default login`），不是 API key 手填流程。**Deferred。**
+- **改动 `/connect`**：它已有 `inferWireType` 走 catalog 路线，与 `/login` 分工明确，不合并。
+- **更深的认证/校验**：只做"拉模型列表"这一步的原生化，不做各 provider 的额外能力探测或健康检查。
+- **Anthropic 的 chat 请求路径改造**：kosong 里 `AnthropicChatProvider` 的 chat 实现已存在且消费 baseUrl，本期只动 login 时的模型列举和 type 写入，不动运行时 chat。
+
+## What I Already Know (ground truth from code)
+
+### `/login` 流程现状
+- `LoginFlow.run()`（`login-flow.ts:53-135`）顺序：provider 名 → Base URL → API key → fetchModels → catalog enrichment → 模型选择 → `applyConfig`。
+- `LoginFlowDeps.fetchModels(baseUrl, apiKey)`（`login-flow.ts:40`）是 ByfTUI 注入的双参数函数，统一返回 OpenAI 兼容形态的 `OAuthModelInfo[]`。
+- 失败路径：`login-flow.ts:87-95` catch 后 fallback 到 `handleManualModelEntry`；空模型列表（`login-flow.ts:97-100`）也走手填。降级路径健全，新 fetcher 失败时零行为回归。
+
+### `applyProviderConfig` 现状
+- `packages/oauth/src/provider-config.ts:183-227`：写入 `config.providers[name] = { type: 'openai-completions', baseUrl, apiKey, thinkingEffortKey }`。
+- 已被 SDK 导出（`packages/node-sdk/src/index.ts:56`），是公共 API，签名变更需谨慎。
+
+### `fetchModels` 现状（唯一存在的 fetcher）
+- `provider-config.ts:117-144`：`{baseUrl}/models` + `Authorization: Bearer` + 解析 `{ data: [{id, context_length, ...}] }`。
+- 拼接约定：`${baseUrl.replace(/\/+$/, '')}/models` —— **baseUrl 含版本路径**（`/v1`），fetcher 只追加 `/models`。
+
+### 各原生 API 的形态差异（需新增 fetcher）
+
+| 类型 | 端点 | 认证头 | 响应形态 |
+|---|---|---|---|
+| `openai-completions` / `openai_responses` | `{baseUrl}/models` | `Authorization: Bearer {key}` | `{ data: [{id, context_length, ...}] }` |
+| `anthropic` | `{baseUrl}/models` | `x-api-key: {key}` + `anthropic-version: 2023-06-01` | `{ data: [{id, type, display_name}], has_more, last_id }` — **分页** |
+
+> `google-genai` 行已移除：见上方范围收缩说明。
+
+### 现成 UI 原语
+- `ChoicePickerComponent` + `promptProviderSelection`（`dialog-prompts.ts:96-135`）已是 catalog 路径的类型选择范式，可直接照搬。
+- `promptTextInput` 已支持 `initialValue` 和 `placeholder`（`dialog-prompts.ts:13-37`），后者用于本 PRD 的 Base URL 占位提示。
+- `ChoiceOption` 带 `value` / `label` / `description`（`choice-picker.ts:24-31`），可在类型项下展示官方默认 URL 作为说明。
+
+### 分层约束（ADR 0006）
+- `apps/cli` 只能通过 `@byfriends/sdk` 用核心能力（`apps/cli/AGENTS.md:43`），不得直接 import `@byfriends/agent-core`。
+- 新 fetcher 落在 `@byfriends/oauth` → 经 `@byfriends/sdk` 导出 → `/login` 注入调用，符合现有 `fetchModels` 的分层。
+
+## Requirements
+
+1. **R1 — 类型选择步骤**：`/login` 流程第一步为类型选择器，含 3 个选项：`openai-completions`（OpenAI Chat Completions 兼容）、`openai_responses`（OpenAI Responses API）、`anthropic`（Anthropic 原生）。
+2. **R2 — Base URL 占位提示**：选完类型后，Base URL 输入框初始为空，placeholder 显示该类型的官方默认值作为格式提示。
+3. **R3 — 留空回退默认**：用户留空 Base URL 时，自动使用该类型的官方默认值（等同"不改就用官方"）。
+   - `openai-completions` / `openai_responses` → `https://api.openai.com/v1`
+   - `anthropic` → `https://api.anthropic.com/v1`
+4. **R4 — 原生模型拉取**：按所选类型调用对应的原生 fetcher；失败时仍 fallback 到 `handleManualModelEntry`。
+5. **R5 — 正确写入 type**：生成的 provider 配置 `type` 字段与所选一致。
+6. **R6 — 回归**：选 `openai-completions` 时行为与现状完全一致。
+
+## Acceptance Criteria
+
+- **AC1**：运行 `/login`，第一步出现类型选择器，含 3 个选项，每项 description 显示官方默认 URL。
+- **AC2**：选 `anthropic`，Base URL 框为空且 placeholder = `https://api.anthropic.com/v1`；填 key 后能从官方端点原生拉到 claude 模型列表（不走 OpenAI 兼容 Bearer 头）。
+- **AC3**：选 `openai_responses`，能拉到模型列表（与 openai-completions 共享 `/models` 端点）。
+- **AC4**：Base URL 留空时，请求实际打到该类型的官方默认端点（留空 = 用默认）。
+- **AC5**：Base URL 填自定义值时，按「版本路径 + `/models`」拼接，请求打到自定义端点；运行时 chat 同样打到该自定义端点（端到端一致）。
+- **AC6**：生成的 `config.toml` 中 provider `type` 与所选一致（非全部 `openai-completions`）。
+- **AC7**：原生拉取失败时，仍能走手填 fallback（context size 提示等不变）。
+- **AC8**：选 `openai-completions` 端到端行为与改造前一致（现有测试回归通过）。
+
+## Definition of Done
+
+- 所有实现切片合并，`pnpm test` 在 `packages/oauth`、`packages/node-sdk`、`apps/cli` 相关模块通过。
+- 按 `AGENTS.md` 跑 `gen-changesets` 生成 changeset：**`minor`**（grill 已定）。理由：`fetchModels(baseUrl,apiKey)` 是 `LoginFlowDeps` 注入字段，仅 `apps/cli` 内部，非 SDK 公共 API；`applyProviderConfig` 新增的 `type` 参数默认 `openai-completions`，旧调用方零改动；`fetchModelsByType` 是纯新增。均非破坏性。
+- PR 标题遵循 Conventional Commit（如 `feat(login): add API type selector with native model fetching`）。
+- PR 描述按 `.github/pull_request_template.md` 填写，链接本 PRD。
+
+## Technical Approach
+
+### 切片 1 — `@byfriends/oauth`：新增 `fetchModelsByType`
+- 新增 `fetchModelsByType(type, baseUrl, apiKey, fetchImpl?, signal?)`：按 `type` 分派。
+- 抽出 `fetchOpenAICompatModels`（现 `fetchModels` 的实现复用，openai-completions / openai_responses 共用）。
+- 新增 `fetchAnthropicModels`：`{baseUrl}/models` + `x-api-key` + `anthropic-version: 2023-06-01`；分页处理（见下方约定）；映射 `display_name` → `displayName`。
+- 统一返回 `ModelInfo[]`（现有类型，`provider-config.ts:8-18`），保持 `fetchModels` 原样不动作为别名/向后兼容。
+- **baseUrl 拼接约定**：统一 `${baseUrl.replace(/\/+$/, '')}/models`，baseUrl 含版本路径（`/v1`），fetcher 只追加 `/models`。两种类型共用同一段逻辑。
+- **Anthropic 分页约定**：以 `has_more === true && last_id` 非空为继续循环条件；设防御性上限（最多 10 页 / 1000 个模型）防止死循环；若某页 `has_more === true` 但 `last_id` 为空/缺失，视为异常，停止分页并返回已收集模型（不抛错，走降级）。
+- 经 `packages/node-sdk/src/index.ts` 导出 `fetchModelsByType`。
+
+### 切片 2 — `@byfriends/oauth`：`applyProviderConfig` 增加 `type` 参数
+- `applyProviderConfig`（`provider-config.ts:183-227`）options 新增 `type: ProviderType`，默认 `'openai-completions'`（兼容现有调用方）。
+- 写入 `config.providers[name].type = options.type`。
+- 经 SDK 导出类型无变化（`ProviderType` 已在 kosong 导出）。
+
+### 切片 3 — `apps/cli`：新增 `promptApiTypeSelection`
+- `dialog-prompts.ts` 新增 `promptApiTypeSelection(host, colors)`：返回所选 `ProviderType | undefined`。
+- 基于 `ChoicePickerComponent`，3 个 `ChoiceOption`：
+  - `openai-completions` / "OpenAI Chat Completions 兼容" / desc 含 `https://api.openai.com/v1`
+  - `openai_responses` / "OpenAI Responses API" / desc 含 `https://api.openai.com/v1`
+  - `anthropic` / "Anthropic 原生" / desc 含 `https://api.anthropic.com/v1`
+
+### 切片 4 — `apps/cli`：`login-flow.ts` 改造
+- `LoginFlowDeps.fetchModels` 签名改为 `fetchModels(type, baseUrl, apiKey)`（感知类型），ByfTUI 注入处改为传 `fetchModelsByType`。
+- `run()` 第一步调用 `promptApiTypeSelection`，返回 `undefined` 则中止。
+- 每类型配一个 `DEFAULT_BASE_URL` 常量（`apps/cli/src/tui/flows/login-flow.ts` 内或同目录常量文件）。
+- Base URL 步骤：placeholder = 所选类型默认 URL，**不传 initialValue**；留空时回退 `DEFAULT_BASE_URL[type]`。
+- 提示语按类型调整（不再是写死的 "OpenAI-compatible"）。
+- `applyConfig` 透传所选 `type` 到 `applyProviderConfig`。
+- `handleManualModelEntry` 同步透传 `type`。
+
+### 切片 5 — 测试
+- `packages/oauth/test/provider-config.test.ts`：
+  - `fetchModelsByType` 各类型的 HTTP 请求头/响应解析用例（mock fetch）。
+  - `applyProviderConfig` 透传 `type` 用例。
+- `apps/cli/test/tui/flows/login-flow.test.ts`：
+  - 新增"先选类型 → 再走后续步骤"的驱动（FakeDialogHost 驱动 ChoicePicker）。
+  - Base URL 留空回退默认值的用例。
+  - `openai-completions` 路径回归用例。
+
+## Decision (ADR-lite)
+
+1. **类型选择放最前面（第一步）**：选完类型才能预填 Base URL 提示和调整后续提示语，流程最顺，避免回填。
+2. **3 种类型（grill 收缩）**：`openai-completions` / `openai_responses` / `anthropic`。`google-genai` 和 `vertexai` 被排除——`google-genai` 运行时不消费 baseUrl（已验证 `runtime-provider.ts:280-285` + `GoogleGenAIChatProvider`），暴露会持久化被静默丢弃的值，违反"自定义 URL 要能生效"。详见 ADR 0016。
+3. **Base URL 用 placeholder 而非 initialValue**：避免用户改 URL 时需先清空已填内容；placeholder 仅作格式提示，输入框初始为空。
+4. **留空回退默认**：placeholder 已标明默认，留空 = "接受默认"是自然表达，避免强制重复输入。
+5. **fetcher 扩展在 `@byfriends/oauth`**：沿用现有 `fetchModels` 的分层（oauth 包 → SDK 导出 → app 注入），最小改动符合现有边界。
+6. **`applyProviderConfig` 的 `type` 默认 `openai-completions`**：兼容任何未更新的现有调用方与公共 API。
+7. **保留 catalog enrichment + 手填 fallback**：原生拉取失败时降级路径不变，零行为回归。enrichment（ADR 0012）对 anthropic 自动生效，无需特殊处理——claude 模型 ID 在 catalog 中权威，displayName 仍取 provider 值。
+8. **baseUrl 拼接约定统一且端到端**：两种类型共用「去尾斜杠 + `/models`」，baseUrl 含版本路径。此约定与运行时 SDK 一致（anthropic `baseURL` 也含 `/v1`），故自定义代理若不遵循，listing 与 chat 会**一致地**失败，行为自洽。
+
+## Consequences
+
+- 用户可经 `/login` 直连 Anthropic 原生端点及 Anthropic 兼容网关，无需 OpenAI 兼容转换代理。
+- TOML 中 `type` 字段准确反映 wire 协议，消除过去 Anthropic 端点被误标 `openai-completions` 的隐患。
+- "自定义 URL 生效"承诺对每个支持的类型都成立——不支持的类型（google-genai/vertexai）被显式排除，不会出现静默丢弃。
+- **baseUrl 版本路径约定是端到端的**：自定义代理必须遵循「版本路径 + `/models`」，否则 listing 和 chat 一致失败。
+- `google-genai` / `vertexai` 用户仍只能用 `/connect`（catalog）或等待 base-URL 传递链路补齐。
+
+## Open Questions
+
+无。所有决策已在 brainstorm + grill 阶段解决（grill 决议见下方 Traceability）。
+
+## Traceability
+
+- **Grilled by**: `/grill` (completed 2026-06-18) — 9 items resolved: 3 代码矛盾验证（google-genai baseUrl 静默丢弃→范围收缩至 3 类型；anthropic/openai_responses baseUrl 已验证端到端生效）；1 术语冲突（CONTEXT.md `/login` 定义过时→已同步）；1 分页边界（anthropic has_more/last_id 防御性处理）；1 降级体验（自定义代理版本路径约定写入 Consequences）；1 changeset 级别（定为 minor，代码可答）；1 ADR 关系（新建 ADR-0016，ADR-0002 决策 #7 标记部分被取代）；1 enrichment 交互（对 anthropic 自动生效）。
+- **Sliced by**: `/story` → Child Issues below
+- **Sliced into**:
+  - #145 — [PRD-0002] 类型选择步骤 + openai-completions 端到端贯通 (AFK)
+  - #146 — [PRD-0002] Anthropic 原生类型支持 (AFK, blocked by #145)
+  - #149 — [PRD-0002] OpenAI Responses 类型支持 (AFK, blocked by #145)
+  - #152 — [PRD-0002] Catalog enrichment 与手填 fallback 跨类型回归 (AFK, blocked by #145, #146)
+
+## Domain Terms
+
+- **接口类型（API type / wire type）**：provider 与 LLM 服务通信的协议形态，对应 `ProviderType`（`packages/agent-core/src/config/schema.ts:6-12`）。决定请求头、端点路径、响应解析方式。
+- **原生模型拉取（native model fetching）**：按 provider 的官方文档端点和认证方式列举可用模型，而非统一伪装成 OpenAI 兼容形态。
+- **Base URL 占位提示（placeholder default）**：输入框为空时显示的格式提示，非实际值；留空时由代码回退到该类型的官方默认值。

--- a/packages/node-sdk/src/index.ts
+++ b/packages/node-sdk/src/index.ts
@@ -53,5 +53,5 @@ export type * from '#/types';
 
 // Provider config — re-exported from @byfriends/oauth so consumers don't
 // need a direct dependency on the oauth package.
-export { applyProviderConfig, fetchModels } from '@byfriends/oauth';
+export { applyProviderConfig, fetchModels, fetchModelsByType } from '@byfriends/oauth';
 export type { ModelInfo } from '@byfriends/oauth';

--- a/packages/oauth/src/index.ts
+++ b/packages/oauth/src/index.ts
@@ -1,6 +1,7 @@
 export {
   capabilitiesForModel,
   fetchModels,
+  fetchModelsByType,
   filterModelsByPrefix,
   ProviderApiError,
   removeProviderConfig,

--- a/packages/oauth/src/provider-config.ts
+++ b/packages/oauth/src/provider-config.ts
@@ -156,7 +156,8 @@ async function fetchOpenAICompatModels(
  * Lists models from a provider using its native wire-type endpoint. Dispatches
  * per `type` so each protocol gets its correct auth header and response shape.
  * `openai-completions` and `openai_responses` share the OpenAI-compatible
- * `/models` endpoint; other types have dedicated native fetchers (added in
+ * `/models` endpoint; `anthropic` uses its native `x-api-key` endpoint with
+ * pagination. Other types have dedicated native fetchers (added in
  * later slices).
  */
 export async function fetchModelsByType(
@@ -170,9 +171,82 @@ export async function fetchModelsByType(
     case 'openai-completions':
     case 'openai_responses':
       return fetchOpenAICompatModels(baseUrl, apiKey, fetchImpl, signal);
+    case 'anthropic':
+      return fetchAnthropicModels(baseUrl, apiKey, fetchImpl, signal);
     default:
       throw new Error(`fetchModelsByType: unsupported provider type "${type}".`);
   }
+}
+
+/**
+ * Anthropic native `/v1/models` listing. Uses `x-api-key` + `anthropic-version`
+ * headers (not Bearer). Response is paginated via `has_more` + `last_id`;
+ * follow pages by passing `?after_id=<last_id>`. Defensive guards: a page that
+ * claims `has_more` but omits `last_id` stops pagination (returns what we have)
+ * rather than looping forever; a hard cap (10 pages) also bounds the loop.
+ */
+async function fetchAnthropicModels(
+  baseUrl: string,
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+  signal?: AbortSignal,
+): Promise<ModelInfo[]> {
+  const base = baseUrl.replace(/\/+$/, '');
+  const ANTHROPIC_VERSION = '2023-06-01';
+  const MAX_PAGES = 10;
+  const collected: ModelInfo[] = [];
+  let afterId: string | undefined;
+
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    const url = afterId === undefined
+      ? `${base}/models`
+      : `${base}/models?after_id=${encodeURIComponent(afterId)}`;
+    const res = await fetchImpl(url, {
+      headers: {
+        'x-api-key': apiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+        Accept: 'application/json',
+      },
+      signal,
+    });
+    if (!res.ok) {
+      throw new ProviderApiError(
+        await readApiErrorMessage(res, `Failed to list models (HTTP ${res.status}).`),
+        res.status,
+      );
+    }
+    const payload: unknown = await res.json();
+    if (!isRecord(payload) || !Array.isArray(payload['data'])) {
+      throw new Error(`Unexpected models response for ${baseUrl}.`);
+    }
+    for (const item of payload['data']) {
+      const info = anthropicModelToInfo(item);
+      if (info !== undefined) collected.push(info);
+    }
+
+    const hasMore = payload['has_more'] === true;
+    const lastId = typeof payload['last_id'] === 'string' ? payload['last_id'] : undefined;
+    if (!hasMore || lastId === undefined || lastId.length === 0) break;
+    afterId = lastId;
+  }
+  return collected;
+}
+
+function anthropicModelToInfo(item: unknown): ModelInfo | undefined {
+  if (!isRecord(item) || typeof item['id'] !== 'string' || item['id'].length === 0) {
+    return undefined;
+  }
+  const displayName = item['display_name'];
+  return {
+    id: item['id'],
+    // Anthropic /v1/models does not report context_length; default to a safe
+    // ceiling. Catalog enrichment (ADR 0012) overrides this when a match exists.
+    contextLength: 200_000,
+    supportsReasoning: true,
+    supportsImageIn: true,
+    supportsVideoIn: false,
+    displayName: typeof displayName === 'string' && displayName.length > 0 ? displayName : undefined,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/oauth/src/provider-config.ts
+++ b/packages/oauth/src/provider-config.ts
@@ -120,6 +120,15 @@ export async function fetchModels(
   fetchImpl: typeof fetch = fetch,
   signal?: AbortSignal,
 ): Promise<ModelInfo[]> {
+  return fetchOpenAICompatModels(baseUrl, apiKey, fetchImpl, signal);
+}
+
+async function fetchOpenAICompatModels(
+  baseUrl: string,
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+  signal?: AbortSignal,
+): Promise<ModelInfo[]> {
   const url = `${baseUrl.replace(/\/+$/, '')}/models`;
   const res = await fetchImpl(url, {
     headers: {
@@ -141,6 +150,29 @@ export async function fetchModels(
   return payload['data']
     .map((item) => toModelInfo(item))
     .filter((item): item is ModelInfo => item !== undefined);
+}
+
+/**
+ * Lists models from a provider using its native wire-type endpoint. Dispatches
+ * per `type` so each protocol gets its correct auth header and response shape.
+ * `openai-completions` and `openai_responses` share the OpenAI-compatible
+ * `/models` endpoint; other types have dedicated native fetchers (added in
+ * later slices).
+ */
+export async function fetchModelsByType(
+  type: string,
+  baseUrl: string,
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+  signal?: AbortSignal,
+): Promise<ModelInfo[]> {
+  switch (type) {
+    case 'openai-completions':
+    case 'openai_responses':
+      return fetchOpenAICompatModels(baseUrl, apiKey, fetchImpl, signal);
+    default:
+      throw new Error(`fetchModelsByType: unsupported provider type "${type}".`);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -184,6 +216,7 @@ export function applyProviderConfig(
   config: ConfigShape,
   options: {
     readonly name: string;
+    readonly type?: string | undefined;
     readonly baseUrl: string;
     readonly apiKey: string;
     readonly models: readonly ModelInfo[];
@@ -195,7 +228,7 @@ export function applyProviderConfig(
   const modelKey = `${providerKey}/${options.selectedModel.id}`;
 
   config.providers[providerKey] = {
-    type: 'openai-completions',
+    type: options.type ?? 'openai-completions',
     baseUrl: options.baseUrl,
     apiKey: options.apiKey,
     thinkingEffortKey: options.selectedModel.reasoningEffortKey,

--- a/packages/oauth/test/provider-config.test.ts
+++ b/packages/oauth/test/provider-config.test.ts
@@ -284,6 +284,104 @@ describe('fetchModelsByType', () => {
 
     expect(models).toHaveLength(3);
   });
+
+  it('fetches anthropic models with x-api-key + anthropic-version headers', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          data: [
+            { id: 'claude-opus-4-7', type: 'model', display_name: 'Claude Opus 4.7' },
+            { id: 'claude-sonnet-4-5', type: 'model', display_name: 'Claude Sonnet 4.5' },
+          ],
+          has_more: false,
+          last_id: 'claude-sonnet-4-5',
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const models = await fetchModelsByType(
+      'anthropic',
+      'https://api.anthropic.com/v1',
+      'sk-ant-test',
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(models).toHaveLength(2);
+    expect(models[0]).toMatchObject({
+      id: 'claude-opus-4-7',
+      displayName: 'Claude Opus 4.7',
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.anthropic.com/v1/models',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'x-api-key': 'sk-ant-test',
+          'anthropic-version': '2023-06-01',
+        }),
+      }),
+    );
+    // Must NOT use Bearer auth.
+    const firstCallHeaders = (fetchMock.mock.calls[0]![1] as { headers: Record<string, string> }).headers;
+    expect(firstCallHeaders['Authorization']).toBeUndefined();
+  });
+
+  it('follows anthropic pagination via has_more + after_id', async () => {
+    const page1 = {
+      data: [{ id: 'claude-opus-4-7', type: 'model', display_name: 'Claude Opus 4.7' }],
+      has_more: true,
+      last_id: 'claude-opus-4-7',
+    };
+    const page2 = {
+      data: [{ id: 'claude-sonnet-4-5', type: 'model', display_name: 'Claude Sonnet 4.5' }],
+      has_more: false,
+      last_id: 'claude-sonnet-4-5',
+    };
+    const responses = [page1, page2];
+    const fetchMock = vi.fn(async () =>
+      new Response(JSON.stringify(responses.shift()), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    const models = await fetchModelsByType(
+      'anthropic',
+      'https://api.anthropic.com/v1',
+      'sk-ant-test',
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(models).toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // Second request carries after_id from the first page's last_id.
+    expect(fetchMock.mock.calls[1]![0]).toBe(
+      'https://api.anthropic.com/v1/models?after_id=claude-opus-4-7',
+    );
+  });
+
+  it('stops pagination when has_more is true but last_id is missing (defensive)', async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          data: [{ id: 'claude-opus-4-7', type: 'model', display_name: 'Claude Opus 4.7' }],
+          has_more: true,
+          // last_id missing — must not loop forever
+        }),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      ),
+    );
+
+    const models = await fetchModelsByType(
+      'anthropic',
+      'https://api.anthropic.com/v1',
+      'sk-ant-test',
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(models).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('capabilitiesForModel', () => {

--- a/packages/oauth/test/provider-config.test.ts
+++ b/packages/oauth/test/provider-config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   fetchModels,
+  fetchModelsByType,
   ProviderApiError,
   applyProviderConfig,
   removeProviderConfig,
@@ -207,6 +208,81 @@ describe('applyProviderConfig', () => {
 
     expect(config.models?.['deepseek/stale']).toBeUndefined();
     expect(config.models?.['other/model']).toBeDefined();
+  });
+
+  it('writes the provider type from the `type` option when provided', () => {
+    const config: ConfigShape = { providers: {} };
+    const models: ModelInfo[] = [
+      { id: 'claude-opus-4-7', contextLength: 200000, supportsReasoning: true, supportsImageIn: false, supportsVideoIn: false },
+    ];
+
+    applyProviderConfig(config, {
+      name: 'anthropic',
+      type: 'anthropic',
+      baseUrl: 'https://api.anthropic.com/v1',
+      apiKey: 'sk-ant-test',
+      models,
+      selectedModel: models[0]!,
+      thinking: false,
+    });
+
+    expect(config.providers['anthropic']).toMatchObject({
+      type: 'anthropic',
+      baseUrl: 'https://api.anthropic.com/v1',
+      apiKey: 'sk-ant-test',
+    });
+  });
+
+  it('defaults the provider type to openai-completions when `type` is omitted', () => {
+    const config: ConfigShape = { providers: {} };
+    const models: ModelInfo[] = [
+      { id: 'gpt-4o', contextLength: 128000, supportsReasoning: false, supportsImageIn: false, supportsVideoIn: false },
+    ];
+
+    applyProviderConfig(config, {
+      name: 'openai',
+      baseUrl: 'https://api.openai.com/v1',
+      apiKey: 'sk-test',
+      models,
+      selectedModel: models[0]!,
+      thinking: false,
+    });
+
+    expect(config.providers['openai']?.type).toBe('openai-completions');
+  });
+});
+
+describe('fetchModelsByType', () => {
+  it('dispatches openai-completions to the OpenAI-compatible fetcher', async () => {
+    const fetchMock = vi.fn(async () => makeModelsResponse(SAMPLE_MODELS));
+
+    const models = await fetchModelsByType(
+      'openai-completions',
+      'https://api.deepseek.com/v1',
+      'sk-test',
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(models).toHaveLength(3);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.deepseek.com/v1/models',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer sk-test' }),
+      }),
+    );
+  });
+
+  it('dispatches openai_responses to the OpenAI-compatible fetcher', async () => {
+    const fetchMock = vi.fn(async () => makeModelsResponse(SAMPLE_MODELS));
+
+    const models = await fetchModelsByType(
+      'openai_responses',
+      'https://api.openai.com/v1',
+      'sk-test',
+      fetchMock as unknown as typeof fetch,
+    );
+
+    expect(models).toHaveLength(3);
   });
 });
 


### PR DESCRIPTION
## Problem

PRD-0002 slice #146. With the type-selection scaffolding landed in #145, selecting `anthropic` in `/login` still dispatched to the OpenAI-compatible fetcher (Bearer auth, `{ data: [] }` shape), which fails against the native Anthropic endpoint. Users selecting anthropic could only fall back to manual model entry.

## What changed

`fetchModelsByType('anthropic', ...)` now calls the native Anthropic endpoint:
- `{baseUrl}/models` with `x-api-key` + `anthropic-version: 2023-06-01` headers (**not** Bearer).
- Follows `has_more` / `last_id` pagination via `?after_id=<last_id>`.
- Maps `display_name` → `displayName`.
- **Defensive guards** (from grill): stops pagination when `has_more === true` but `last_id` is missing/empty (returns collected models instead of looping forever); a 10-page cap also bounds the loop.

The runtime already consumes the provider `baseUrl` for anthropic (verified during `/grill`: `runtime-provider.ts` anthropic branch passes baseUrl → kosong `new Anthropic({ baseURL })`), so custom/gateway URLs take effect end-to-end — both for listing and chat.

## Verification

- `packages/oauth` tests: 25 passing (added anthropic fetcher header/pagination/defensive-stop cases).
- `apps/cli` `login-flow` tests: 18 passing (added end-to-end anthropic-flow test: 3rd picker option via ↓↓, empty base URL → `https://api.anthropic.com/v1`, type written as `anthropic`).

## Refs

- Closes #146
- PRD: `docs/prd/PRD-0002-login-api-type-selector.md`
- Builds on #145 (PR #153)
- Changeset: `minor` for `@byfriends/sdk`