### PR TITLE
feat(cli): let Escape cancel the in-flight operation like Ctrl-C

### DIFF
--- a/.changeset/escape-cancels-inflight.md
+++ b/.changeset/escape-cancels-inflight.md
@@ -1,0 +1,5 @@
+---
+'@byfriends/cli': patch
+---
+
+修复 Esc 在 /login、/connect 等待目录响应期间无效的问题，按 Esc 现在与 Ctrl-C 一样可中止进行中的操作。

--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -1194,6 +1194,13 @@ export class ByfTui implements DialogHost {
     };
 
     editor.onEscape = () => {
+      if (this.cancelInFlight !== undefined) {
+        const cancel = this.cancelInFlight;
+        this.cancelInFlight = undefined;
+        this.clearPendingExit();
+        cancel();
+        return;
+      }
       if (this.pendingExit) this.clearPendingExit();
       if (this.state.showingSessionPicker) {
         this.dialogManager.hideSessionPicker();

--- a/apps/cli/test/tui/byf-tui-message-flow.test.ts
+++ b/apps/cli/test/tui/byf-tui-message-flow.test.ts
@@ -12,6 +12,7 @@ import {
 import { afterEach, describe, expect, it, vi, afterAll } from 'vitest';
 
 import { ByfTui, type ByfTuiStartupInput, type TUIState } from '#/tui/byf-tui';
+import type { SlashCommandHost } from '#/tui/commands/handlers/slash-host';
 import { BtwViewer } from '#/tui/components/dialogs/btw-viewer';
 import { ChoicePickerComponent } from '#/tui/components/dialogs/choice-picker';
 import { ModelSelectorComponent } from '#/tui/components/dialogs/model-selector';
@@ -940,6 +941,59 @@ describe('ByfTui message flow', () => {
     driver.state.editor.onCtrlC?.();
 
     expect(session.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape cancels the registered in-flight operation exactly once without falling through', async () => {
+    const { driver, session } = await makeDriver();
+    const cancel = vi.fn();
+
+    // `cancelInFlight` is a private ByfTui field with no public accessor and
+    // DialogHost (types.ts) exposes only show/close. The public-surface route
+    // to arm it is the SlashCommandHost capability bag (slash-host.ts
+    // `setCancelInFlight`), which the driver stores in its private
+    // `slashHost` field — same cast pattern as getBtwViewer above.
+    const slashHost = (driver as unknown as { slashHost: SlashCommandHost }).slashHost;
+    slashHost.setCancelInFlight(cancel);
+
+    // Streaming is also active: Esc must take the cancel-in-flight branch and
+    // NOT fall through to the stream-cancel branch (AC1).
+    driver.state.appState.isStreaming = true;
+
+    driver.state.editor.onEscape?.();
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(session.cancel).not.toHaveBeenCalled();
+
+    // The handler was cleared by the first Esc, so the second Esc falls
+    // through to the existing streaming branch.
+    driver.state.editor.onEscape?.();
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(session.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('Escape clears a pending Ctrl-C exit hint', async () => {
+    const { driver } = await makeDriver();
+
+    // Arm the exit-confirmation window exactly the way Ctrl-C arms it today:
+    // empty editor, nothing streaming/compacting, no in-flight cancel.
+    driver.state.editor.onCtrlC?.();
+
+    const renderHint = () => stripSgr(driver.state.footer.render(120)[1]);
+    expect(renderHint()).toContain('Press Ctrl+C again to exit');
+
+    driver.state.editor.onEscape?.();
+
+    expect(renderHint()).not.toContain('Press Ctrl+C again to exit');
+  });
+
+  it('Escape hides the session picker when shown', async () => {
+    const { driver } = await makeDriver();
+
+    driver.state.showingSessionPicker = true;
+    driver.state.editor.onEscape?.();
+
+    expect(driver.state.showingSessionPicker).toBe(false);
   });
 
   it('dispatches the next queued message after the active turn ends', async () => {


### PR DESCRIPTION
## 背景

BYF 的取消机制是三层模型：对话框层用 Esc（面板自行处理）、操作层用 Ctrl-C（`cancelInFlight`）、进程层用两次 Ctrl-C。但存在一处不一致：流式生成/压缩时 Esc 和 Ctrl-C 都能取消；`/login` 每个对话框步骤按 Esc 都能中止登录；唯独目录获取的 spinner 间隙 Esc 无效——只清 pendingExit，不中止 fetch。用户在慢 fetch 时按 Esc（本能反应）会感觉"卡死"，这正是 #264 修复场景的交互延续。

## 改动

`apps/cli/src/tui/byf-tui.ts` 的 `editor.onEscape` 顶部新增 cancelInFlight 分支（与 `onCtrlC` 结构逐字一致）：

- 已注册取消句柄时：调用一次、清空句柄、清除 pendingExit，**不**继续落到其他分支（不双重触发 stream 取消）
- 未注册时：原有行为完全不变（清 pendingExit、关 session picker、取消 streaming/compacting）
- 面板挂载时 editor 无焦点（`mountEditorReplacement`），对话框的 Esc 行为不受影响

## 测试

3 个新测试（byf-tui-message-flow.test.ts）：Esc 取消恰一次且不 fall-through（streaming 同时激活时不取消 stream）、首次 Esc 后句柄清空（第二次 Esc 走原 streaming 分支）、Esc 仍清 pendingExit、仍关 session picker。69 pass；lint/fmt/typecheck 通过。

changeset：`@byfriends/cli` patch。