### PR TITLE
fix: DeepSeek Responses reasoning 文本 fallback 到 content (reasoning_text)

### DIFF
--- a/.changeset/deepseek-responses-reasoning-content.md
+++ b/.changeset/deepseek-responses-reasoning-content.md
@@ -1,0 +1,6 @@
+---
+'@byfriends/kosong': patch
+'@byfriends/cli': patch
+---
+
+修复 DeepSeek Responses 路径下 reasoning 文本被漏读:reasoning 解析在 summary 为空时回退到 content 的 reasoning_text 项(不影响 OpenAI 形态)。

--- a/docs/research/INDEX.md
+++ b/docs/research/INDEX.md
@@ -26,8 +26,8 @@
 
 ### deepseek
 
-| Topic      | Major | Version | Verdict                                                                                                                              | File                                         | Status   |
-| ---------- | ----- | ------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------- | -------- |
+| Topic      | Major | Version | Verdict                                                                                                                                  | File                                                 | Status   |
+| ---------- | ----- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | -------- |
 | api-format | 4     | 4       | 两条 API 各遵循对应 OpenAI 标准(reasoning/cache 字段不同);byf 两路径均兼容;唯一缺口:Responses reasoning 文本在 content 而 byf 读 summary | [deepseek-api-format-4.md](deepseek-api-format-4.md) | verified |
 
 ### Spikes (verification records, not versioned topics)
@@ -49,4 +49,4 @@
 | compile-native-addons              | bun@1        | [bun-compile-native-addons-1.md](bun-compile-native-addons-1.md)                           |
 | test-migration-from-vitest         | bun@1        | [bun-test-migration-from-vitest-1.md](bun-test-migration-from-vitest-1.md)                 |
 | weakmap-memoization                | typescript@6 | [typescript-weakmap-memoization-6.md](typescript-weakmap-memoization-6.md)                 |
-| api-format                          | deepseek@4   | [deepseek-api-format-4.md](deepseek-api-format-4.md)                                       |
+| api-format                         | deepseek@4   | [deepseek-api-format-4.md](deepseek-api-format-4.md)                                       |

--- a/docs/research/deepseek-api-format-4.md
+++ b/docs/research/deepseek-api-format-4.md
@@ -1,6 +1,6 @@
 # deepseek: API 格式契约（Chat Completions vs Responses）
 
-> **Stack**: deepseek@4  | **Major**: 4  | **Verified**: 2026-08-13  | **Status**: verified
+> **Stack**: deepseek@4 | **Major**: 4 | **Verified**: 2026-08-13 | **Status**: verified
 
 ## TL;DR
 
@@ -18,16 +18,16 @@ DeepSeek v4（v4-flash / v4-pro）在 Chat Completions 与 Responses 两条 API 
 
 ## Findings
 
-| 维度 | Chat Completions (`/chat/completions`) | Responses (`/responses`) |
-|---|---|---|
-| **reasoning 输出** | `message.reasoning_content`（字符串，与 `content` 同级） | `output[]` 里 `{type:"reasoning", content:[{type:"reasoning_text", text}], summary:[]}` 对象 |
-| **cache usage 字段** | 顶层 `prompt_cache_hit_tokens` + `prompt_cache_miss_tokens`；**同时**带嵌套 `prompt_tokens_details.cached_tokens`（= hit 值） | 仅嵌套 `input_tokens_details.cached_tokens`；**无**顶层 hit/miss |
-| **token 字段名** | `prompt_tokens` / `completion_tokens` | `input_tokens` / `output_tokens` |
-| **reasoning 计费** | `completion_tokens_details.reasoning_tokens` | `output_tokens_details.reasoning_tokens` |
-| **thinking 开启** | 顶层 `reasoning_effort:"high"` + `extra_body.thinking:{type:"enabled"}`（展开进 body） | 顶层 `reasoning:{effort:"high", summary:"auto"}` 被接受 |
-| **工具定义格式** | 嵌套 `{type:"function", function:{name, parameters}}` | 扁平 `{type:"function", name, description, parameters}`（用 completions 格式会 400 `missing field name`） |
-| **prompt_cache_key 字段** | 文档未提；body 可带但不被消费（缓存全自动） | 响应**含** `prompt_cache_key:null` 字段（请求未带时为 null），说明 API 认识该字段 |
-| **缓存命中实测** | cold：hit=0, miss=377（首请求） | 部分命中：`cached_tokens=256`（input=377） |
+| 维度                      | Chat Completions (`/chat/completions`)                                                                                        | Responses (`/responses`)                                                                                  |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **reasoning 输出**        | `message.reasoning_content`（字符串，与 `content` 同级）                                                                      | `output[]` 里 `{type:"reasoning", content:[{type:"reasoning_text", text}], summary:[]}` 对象              |
+| **cache usage 字段**      | 顶层 `prompt_cache_hit_tokens` + `prompt_cache_miss_tokens`；**同时**带嵌套 `prompt_tokens_details.cached_tokens`（= hit 值） | 仅嵌套 `input_tokens_details.cached_tokens`；**无**顶层 hit/miss                                          |
+| **token 字段名**          | `prompt_tokens` / `completion_tokens`                                                                                         | `input_tokens` / `output_tokens`                                                                          |
+| **reasoning 计费**        | `completion_tokens_details.reasoning_tokens`                                                                                  | `output_tokens_details.reasoning_tokens`                                                                  |
+| **thinking 开启**         | 顶层 `reasoning_effort:"high"` + `extra_body.thinking:{type:"enabled"}`（展开进 body）                                        | 顶层 `reasoning:{effort:"high", summary:"auto"}` 被接受                                                   |
+| **工具定义格式**          | 嵌套 `{type:"function", function:{name, parameters}}`                                                                         | 扁平 `{type:"function", name, description, parameters}`（用 completions 格式会 400 `missing field name`） |
+| **prompt_cache_key 字段** | 文档未提；body 可带但不被消费（缓存全自动）                                                                                   | 响应**含** `prompt_cache_key:null` 字段（请求未带时为 null），说明 API 认识该字段                         |
+| **缓存命中实测**          | cold：hit=0, miss=377（首请求）                                                                                               | 部分命中：`cached_tokens=256`（input=377）                                                                |
 
 **两条路径的 reasoning 形态不可互换**：Completions 永远用 `reasoning_content` 字符串；Responses 永远用 `reasoning` 对象（且文本在 `content[].text`，`summary` 为空数组）。
 
@@ -52,10 +52,12 @@ byf 对 DeepSeek 两条路径的**缓存与 reasoning 格式均已正确处理**
 ## Sources
 
 **Tier 1（maintainer-authored, required）**
+
 - [DeepSeek 官方 API reference: Chat Completions (create-chat-completion)](https://api-docs.deepseek.com/zh-cn/api/create-chat-completion) — usage 字段定义（`prompt_tokens` = `prompt_cache_hit_tokens` + `prompt_cache_miss_tokens`）、顶层 hit/miss 字段
 - [DeepSeek 官方 API reference: Responses (create-response)](https://api-docs.deepseek.com/zh-cn/api/create-response) — usage 嵌套 `input_tokens_details.cached_tokens`、`input_tokens`/`output_tokens` 字段
 - [DeepSeek 官方指南: 上下文硬盘缓存 (kv_cache)](https://api-docs.deepseek.com/zh-cn/guides/kv_cache) — "对所有用户默认开启，用户无需修改代码即可享用"、完整前缀匹配、尽力而为；未提 `prompt_cache_key`
 - [DeepSeek 官方指南: 思考模式 (thinking_mode)](https://api-docs.deepseek.com/zh-cn/guides/thinking_mode) — `reasoning_content` 与 content 同级、多轮有工具调用必须完整回传 reasoning_content、`reasoning_effort` + `extra_body.thinking`
 
 **实测验证（2026-08-13）**
+
 - 4 组合真实调用（deepseek-v4-flash / v4-pro × Chat Completions / Responses），返回 JSON 与上述文档逐字段一致；Responses reasoning 文本位于 `output[].content[]`（`reasoning_text`）而非 `summary` 为本记录新增发现，文档未明示此层级。

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -83,6 +83,12 @@ type ResponseOutputItemView =
       type: 'reasoning';
       encryptedContent?: string;
       summary: RawObject[];
+      /**
+       * Reasoning content items. OpenAI 标准把 reasoning 明文摘要放 {@link summary};
+       * 部分兼容端(如 DeepSeek Responses)把 reasoning 文本放在 content 的
+       * `reasoning_text` 项、summary 为空。解析时 summary 优先,content 作 fallback。
+       */
+      content?: RawObject[];
     }
   | {
       type: 'other';
@@ -174,6 +180,7 @@ function readResponseOutputItem(value: unknown, context: string): ResponseOutput
       type,
       encryptedContent: readStringField(item, 'encrypted_content'),
       summary: readObjectArrayField(item, 'summary') ?? [],
+      content: readObjectArrayField(item, 'content'),
     };
   }
 
@@ -532,9 +539,23 @@ export class OpenAIResponsesStreamedMessage extends BaseStreamedMessage {
           arguments: outputItem.arguments ?? null,
         } satisfies ToolCall;
       } else if (outputItem.type === 'reasoning') {
+        // OpenAI 标准:reasoning 明文摘要走 summary(summary_text)。部分兼容端
+        // (如 DeepSeek Responses)把 reasoning 文本放在 content 的 reasoning_text 项、
+        // summary 为空 → summary 无文本时 fallback 到 content,避免漏读。
+        const thinkTexts: string[] = [];
         for (const summary of outputItem.summary) {
           const text = readStringField(summary, 'text');
-          if (text === undefined) continue;
+          if (text !== undefined) thinkTexts.push(text);
+        }
+        if (thinkTexts.length === 0 && outputItem.content !== undefined) {
+          for (const contentItem of outputItem.content) {
+            if (readStringField(contentItem, 'type') === 'reasoning_text') {
+              const text = readStringField(contentItem, 'text');
+              if (text !== undefined) thinkTexts.push(text);
+            }
+          }
+        }
+        for (const text of thinkTexts) {
           const thinkPart: StreamedMessagePart = {
             type: 'think',
             think: text,

--- a/packages/kosong/test/openai-responses.test.ts
+++ b/packages/kosong/test/openai-responses.test.ts
@@ -1081,6 +1081,90 @@ describe('OpenAIResponsesChatProvider', () => {
 
       expect(parts).toEqual([{ type: 'think', think: 'Thinking...' }]);
     });
+
+    it('non-stream reasoning with text in content (reasoning_text) and empty summary yields ThinkPart (DeepSeek shape)', async () => {
+      // DeepSeek Responses puts reasoning text in `output[].content[]` as
+      // `{type:"reasoning_text", text}` and leaves `summary` empty. The parser
+      // must fall back to content so reasoning is not lost.
+      const provider = createProvider();
+      (provider as any)._stream = false;
+      ((provider as any)._client.responses as unknown as Record<string, unknown>)['create'] = vi
+        .fn()
+        .mockResolvedValue({
+          id: 'resp_deepseek',
+          output: [
+            {
+              type: 'reasoning',
+              summary: [],
+              content: [
+                { type: 'reasoning_text', text: 'I should call get_weather for Shanghai.' },
+              ],
+            },
+            {
+              type: 'function_call',
+              id: 'fc_1',
+              call_id: 'call_1',
+              name: 'get_weather',
+              arguments: '{"city":"Shanghai"}',
+            },
+          ],
+          usage: {
+            input_tokens: 377,
+            input_tokens_details: { cached_tokens: 256 },
+            output_tokens: 68,
+            output_tokens_details: { reasoning_tokens: 22 },
+            total_tokens: 445,
+          },
+        });
+
+      const stream = await provider.generate(
+        '',
+        [],
+        [{ role: 'user', content: [{ type: 'text', text: 'weather?' }], toolCalls: [] }],
+      );
+      const parts: StreamedMessagePart[] = [];
+      for await (const p of stream) parts.push(p);
+
+      expect(parts).toEqual([
+        { type: 'think', think: 'I should call get_weather for Shanghai.' },
+        {
+          type: 'function',
+          id: 'call_1',
+          name: 'get_weather',
+          arguments: '{"city":"Shanghai"}',
+        },
+      ]);
+    });
+
+    it('non-stream reasoning prefers summary when both summary and content are present (no duplication)', async () => {
+      // OpenAI shape: summary carries the text. content may also carry reasoning
+      // items (e.g. encrypted_content); summary must win to avoid duplicates.
+      const provider = createProvider();
+      (provider as any)._stream = false;
+      ((provider as any)._client.responses as unknown as Record<string, unknown>)['create'] = vi
+        .fn()
+        .mockResolvedValue({
+          id: 'resp_both',
+          output: [
+            {
+              type: 'reasoning',
+              summary: [{ type: 'summary_text', text: 'summary wins' }],
+              content: [{ type: 'reasoning_text', text: 'content fallback should NOT be used' }],
+            },
+          ],
+          usage: { input_tokens: 1, output_tokens: 1, total_tokens: 2 },
+        });
+
+      const stream = await provider.generate(
+        '',
+        [],
+        [{ role: 'user', content: [{ type: 'text', text: 'Hi' }], toolCalls: [] }],
+      );
+      const parts: StreamedMessagePart[] = [];
+      for await (const p of stream) parts.push(p);
+
+      expect(parts).toEqual([{ type: 'think', think: 'summary wins' }]);
+    });
   });
 
   describe('provider property accessors', () => {


### PR DESCRIPTION
## Problem

实测发现(见 `docs/research/deepseek-api-format-4.md`,4 组合真实调用):DeepSeek Responses API 把 reasoning 文本放在 `output[].content[]`(`type:"reasoning_text"`)、`summary` 为空;而 byf responses 路径只遍历 `outputItem.summary` → **reasoning 文本被漏读**。不影响缓存命中(看 usage)、不影响工具调用(`function_call` 独立解析),仅影响 reasoning 文本展示与多轮回传。

## What changed

- `openai-responses.ts`:reasoning 解析时 **summary 优先,summary 无文本时 fallback 到 content 的 `reasoning_text` 项**;类型定义 + `readResponseOutputItem` 同步加 `content?: RawObject[]`。OpenAI 形态(summary 有文本)行为不变,不重复 yield。
- 测试:加 2 个非流式用例——DeepSeek 形态(content/empty summary)+ summary 与 content 并存时 summary 优先不重复。
- `chore(fmt)`:顺带规范 research 文档表格格式,修复 dev CI fmt:check(research 文档直推时未跑全量 oxfmt)。

## Verification

`lint`/`fmt:check`/`sherif`/`typecheck`/`build` 全绿;kosong 全量 1108 pass。新增 2 用例覆盖 DeepSeek 形态与 summary 优先。

cache-impact: low
