### PR TITLE
fix: DeepSeek Responses 流式 reasoning 文本丢失(reasoning_text.delta 事件)

### DIFF
--- a/.changeset/deepseek-responses-streaming-reasoning.md
+++ b/.changeset/deepseek-responses-streaming-reasoning.md
@@ -1,0 +1,6 @@
+---
+'@byfriends/kosong': patch
+'@byfriends/cli': patch
+---
+
+修复 DeepSeek Responses 流式路径下 reasoning 文本丢失:补 `response.reasoning_text.delta` 事件处理(此前落在默认分支被静默忽略),流式 reasoning 文本现可正常到达。

--- a/docs/research/INDEX.md
+++ b/docs/research/INDEX.md
@@ -26,9 +26,9 @@
 
 ### deepseek
 
-| Topic      | Major | Version | Verdict                                                                                                                                  | File                                                 | Status   |
-| ---------- | ----- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | -------- |
-| api-format | 4     | 4       | 两条 API 各遵循对应 OpenAI 标准(reasoning/cache 字段不同);byf 两路径均兼容;唯一缺口:Responses reasoning 文本在 content 而 byf 读 summary | [deepseek-api-format-4.md](deepseek-api-format-4.md) | verified |
+| Topic      | Major | Version | Verdict                                                                                                                           | File                                                 | Status   |
+| ---------- | ----- | ------- | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | -------- |
+| api-format | 4     | 4       | 两条 API 各遵循对应 OpenAI 标准(reasoning/cache 字段不同);byf 两路径均兼容;非流式/流式 reasoning 文本缺口均已修复;未验证:回传形态 | [deepseek-api-format-4.md](deepseek-api-format-4.md) | verified |
 
 ### Spikes (verification records, not versioned topics)
 

--- a/docs/research/deepseek-api-format-4.md
+++ b/docs/research/deepseek-api-format-4.md
@@ -61,3 +61,12 @@ byf 对 DeepSeek 两条路径的**缓存与 reasoning 格式均已正确处理**
 **实测验证（2026-08-13）**
 
 - 4 组合真实调用（deepseek-v4-flash / v4-pro × Chat Completions / Responses），返回 JSON 与上述文档逐字段一致；Responses reasoning 文本位于 `output[].content[]`（`reasoning_text`）而非 `summary` 为本记录新增发现，文档未明示此层级。
+
+## Correction (2026-08-13)
+
+**非流式与流式 reasoning 文本缺口均已修复，原 Verdict「唯一缺口」过时。**
+
+- **非流式**：`openai-responses.ts` reasoning 解析在 summary 无文本时 fallback 到 content 的 `reasoning_text` 项（summary 优先、不重复 yield）。
+- **流式**：DeepSeek Responses 用 `response.reasoning_text.delta` 事件流式传输 reasoning（文本在 `delta` 字段，官方文档逐字确认），byf 原只处理 `reasoning_summary_text.delta` 导致该事件落 default 被静默丢弃。已补 `response.reasoning_text.delta` case，并**用真实 API 流式实测验证**（2026-08-13，deepseek-v4-flash 生产 `OpenAIResponsesChatProvider`：reasoning 逐 token 流式到达、think parts 有文本、`inputCacheRead=256` 缓存命中）。
+- `output_item.done` 的 reasoning item 里 content 是累计全文，delta 已流式传输，故不重复读（done 分支保持空 think 结束标记，与 OpenAI 形态一致）。
+- **仍未验证**：出站回传方向——byf 多轮回传把 ThinkPart 序列化为 `{type:'reasoning', summary:[summary_text]}`（OpenAI 形态），DeepSeek Responses 输入侧接受 summary 还是 content 形态未经实测。若用户走 DeepSeek Responses 多轮工具调用，建议实测确认回传格式后再定论。

--- a/packages/kosong/src/providers/openai-responses.ts
+++ b/packages/kosong/src/providers/openai-responses.ts
@@ -747,6 +747,13 @@ export class OpenAIResponsesStreamedMessage extends BaseStreamedMessage {
             yield { type: 'think', think: '' };
             break;
           case 'response.reasoning_summary_text.delta':
+          case 'response.reasoning_text.delta':
+            // 两者都是 Responses API 标准流式事件(OpenAI OpenAPI spec 均定义):
+            // summary_text.delta 是 OpenAI 摘要形态,reasoning_text.delta 是明文
+            // reasoning 形态(DeepSeek 用后者)。文本都在 `delta` 字段;同一 reasoning
+            // item 若两事件并发,think 流会同时含摘要与全文(内容变多,不崩溃)。
+            // output_item.done 的 reasoning item 里 content 是累计全文,delta 已流式
+            // 传输过,故不重复读(见 streaming 测试)。
             yield { type: 'think', think: requireStringField(chunk, 'delta', type) };
             break;
           case 'response.completed':

--- a/packages/kosong/test/openai-responses.test.ts
+++ b/packages/kosong/test/openai-responses.test.ts
@@ -1496,6 +1496,79 @@ describe('OpenAIResponsesChatProvider', () => {
       ]);
     });
 
+    it('streams reasoning text from response.reasoning_text.delta (DeepSeek shape)', async () => {
+      // DeepSeek Responses streams reasoning via `response.reasoning_text.delta`
+      // (text in `delta`), NOT `response.reasoning_summary_text.delta`. The
+      // output_item.done reasoning item carries the accumulated full text in
+      // `content` (which must NOT be re-emitted — it would duplicate the
+      // already-streamed deltas; the done marker stays an empty think).
+      const events = [
+        {
+          type: 'response.output_item.added',
+          item: { id: 'rs_1', type: 'reasoning' },
+          output_index: 0,
+        },
+        {
+          type: 'response.reasoning_text.delta',
+          item_id: 'rs_1',
+          output_index: 0,
+          content_index: 0,
+          delta: 'Thinking about ',
+        },
+        {
+          type: 'response.reasoning_text.delta',
+          item_id: 'rs_1',
+          output_index: 0,
+          content_index: 0,
+          delta: 'the weather...',
+        },
+        {
+          type: 'response.output_item.done',
+          item: {
+            id: 'rs_1',
+            type: 'reasoning',
+            summary: [],
+            content: [{ type: 'reasoning_text', text: 'Thinking about the weather...' }],
+          },
+          output_index: 0,
+        },
+        { type: 'response.output_text.delta', delta: 'The answer is 42.' },
+        {
+          type: 'response.completed',
+          response: {
+            id: 'resp_ds_stream',
+            usage: {
+              input_tokens: 377,
+              input_tokens_details: { cached_tokens: 256 },
+              output_tokens: 68,
+              output_tokens_details: { reasoning_tokens: 22 },
+              total_tokens: 445,
+            },
+          },
+        },
+      ];
+
+      const stream = new OpenAIResponsesStreamedMessage(makeAsyncIterable(events), true);
+
+      const parts: StreamedMessagePart[] = [];
+      for await (const part of stream) {
+        parts.push(part);
+      }
+
+      expect(parts).toEqual([
+        { type: 'think', think: 'Thinking about ' },
+        { type: 'think', think: 'the weather...' },
+        { type: 'think', think: '' },
+        { type: 'text', text: 'The answer is 42.' },
+      ]);
+      expect(stream.usage).toEqual({
+        inputOther: 121,
+        output: 68,
+        inputCacheRead: 256,
+        inputCacheCreation: 0,
+      });
+    });
+
     it('stream.id is response.id, not output item id (tool call)', async () => {
       // Regression: previously `output_item.added` / `output_item.done`
       // overwrote `_id` with the item id (or undefined for tool-call items


### PR DESCRIPTION
## Problem

review 发现上一轮修复(PR #276,非流式 content fallback)**在生产中不可达**:`openai-responses.ts` 硬编码 `_stream = true`(生产永远走流式),而流式 switch 只处理 OpenAI 的 `reasoning_summary_text.delta`;DeepSeek 用 `response.reasoning_text.delta`(官方文档逐字确认,文本在 `delta` 字段)流式传输 reasoning → 该事件落 default 被静默丢弃 → **DeepSeek Responses 生产路径 reasoning 文本全部丢失**。

## What changed

- `openai-responses.ts`:新增 `response.reasoning_text.delta` case(与 `reasoning_summary_text.delta` 合并为 fall-through,文本同在 `delta` 字段)。`output_item.done` 的 reasoning item 里 content 是累计全文,delta 已流式传输故不重复读(done 保持空 think 结束标记,与 OpenAI 形态一致)。
- 测试:流式 DeepSeek 事件序列(reasoning_text.delta ×2 + done(content 全文) + output_text + completed)→ 断言 think 文本到达、done 不重复 yield、usage 缓存解析正确(inputCacheRead=256)。修复前 RED(+0 think)、修复后 GREEN。
- 生产验证:真实 key 流式实测(deepseek-v4-flash,生产 `OpenAIResponsesChatProvider`)reasoning 逐 token 到达、`inputCacheRead=256` 缓存命中——不再重蹈"测试可达、生产不可达"。
- research 文档追加 Correction(2026-08-13)+ INDEX verdict 同步。
- changeset(patch,kosong+cli)。

## Review 说明

三视角 review 一致 Approve,无必修项。两个非阻塞建议已顺手处理:注释修正(该事件实为 OpenAI Responses 标准事件,非 DeepSeek 独有;OpenAI 可能 summary/content 双事件并发,think 流含两者)+ 两 case 合并。

**已知未验证(建议 follow-up)**:出站回传形态——byf 多轮回传把 ThinkPart 序列化为 summary 形态,DeepSeek Responses 输入侧接受 summary 还是 content 形态未经实测(多轮工具调用场景)。research 文档已如实标注。

## Verification

lint/fmt:check/sherif/typecheck/build 全绿;kosong 全量 1109 pass(1 skip = opt-in 探针)。

cache-impact: low
