### PR TITLE
docs(agent-core): 公开 API JSDoc 与模块顶部注释译为中文

### DIFF
--- a/packages/agent-core/src/agent/context/index.ts
+++ b/packages/agent-core/src/agent/context/index.ts
@@ -164,51 +164,44 @@ export class ContextMemory {
   }
 
   /**
-   * Media-degraded projection of the current messages: all but the most
-   * recent {@link MEDIA_DEGRADE_KEEP_RECENT} media parts are replaced by
-   * text markers. Used for the one-shot resend after the provider rejects
-   * the request body as too large (HTTP 413 body-size). Read-side only —
-   * the underlying history is left untouched.
+   * 当前消息的 media-degraded 投影:除最近
+   * {@link MEDIA_DEGRADE_KEEP_RECENT} 个媒体 part 外的全部被替换为文本标记。
+   * 用于 provider 以请求体过大(HTTP 413 体积)拒绝后的一次性重发。
+   * 纯读侧——底层历史原封不动。
    *
-   * Accepts the same optional ephemeral injections as {@link getMessages}
-   * so the degraded projection includes the same per-request dynamic
-   * content (timestamp, permission mode) as the normal projection.
+   * 接受与 {@link getMessages} 相同的可选 ephemeral 注入,使降级投影包含
+   * 与常规投影相同的每请求动态内容(时间戳、权限模式)。
    */
   getMediaDegradedMessages(ephemeral?: readonly EphemeralInjection[]): Message[] {
     return degradeOlderMediaParts(this.getMessages(ephemeral), MEDIA_DEGRADE_KEEP_RECENT);
   }
 
   /**
-   * Media-stripped projection: ALL media parts replaced by text markers.
-   * Used for the one-shot resend after the provider rejects an image's
-   * format/data (the poisoned image could be anywhere, so only a full
-   * strip guarantees a clean request). Read-side only.
+   * media-stripped 投影:所有媒体 part 被替换为文本标记。
+   * 用于 provider 拒绝图片格式 / 数据后的一次性重发(坏图可能位于任意位置,
+   * 只有整体剥离才能保证请求干净)。纯读侧。
    */
   getMediaStrippedMessages(ephemeral?: readonly EphemeralInjection[]): Message[] {
     return degradeOlderMediaParts(this.getMessages(ephemeral), 0, MEDIA_STRIPPED_PLACEHOLDERS);
   }
 
   /**
-   * Project history into provider-ready messages, optionally with
-   * ephemeral injections (e.g. timestamp, permission mode) appended
-   * at the `'before_user'` position.
+   * 把历史投影为 provider 就绪的消息,可选地在 `'before_user'` 位置
+   * 追加 ephemeral 注入(如时间戳、权限模式)。
    */
   getMessages(ephemeral?: readonly EphemeralInjection[]): Message[] {
     return project(this.history, ephemeral);
   }
 
   /**
-   * Provider-ready snapshot of the conversation history safe to feed into a
-   * detached, read-only LLM call (e.g. a `/btw` side query).
+   * 可安全喂给独立只读 LLM 调用(如 `/btw` 侧查询)的会话历史
+   * provider 就绪快照。
    *
-   * Unlike {@link getMessages}, this trims the trailing assistant message
-   * (and anything after it) when the main turn is mid-tool-call. A message
-   * sequence containing a `tool_call` without its paired `tool_result` is
-   * illegal and would be rejected by providers, so the snapshot rolls back
-   * to the last fully-complete step boundary. Ephemeral injections are
-   * excluded — a side query appends its own user message and the
-   * `before_user`-positioned injections would otherwise land between the
-   * main history and that question.
+   * 与 {@link getMessages} 不同,当主 turn 处于工具调用中间时,它会截掉
+   * 尾部 assistant 消息(及其后的任何内容)。含 `tool_call` 而无配对的
+   * `tool_result` 的消息序列是非法的,会被 provider 拒绝,因此快照回滚到
+   * 最后一个完整 step 边界。ephemeral 注入被排除——侧查询会追加自己的
+   * user 消息,否则 `before_user` 位置的注入会落在主历史与该问题之间。
    */
   getStableSnapshot(): Message[] {
     const messages = this.getMessages();

--- a/packages/agent-core/src/agent/context/notification-xml.ts
+++ b/packages/agent-core/src/agent/context/notification-xml.ts
@@ -1,20 +1,19 @@
 /**
- * Notification XML rendering — produces the chat-history injection text
- * shared between the live ContextMemory and the projector.
+ * 通知 XML 渲染——生成 live ContextMemory 与 projector 共享的
+ * 会话历史注入文本。
  *
- * Output shape:
+ * 输出形态:
  *   <notification id="..." category="..." type="..." source_kind="..." source_id="...">
  *   Title: ...
  *   Severity: ...
  *   <body>
- *   <task-notification>   (only when source_kind === 'background_task' and tail_output is non-empty)
- *   <truncated tail>
+ *   <task-notification>   (仅当 source_kind === 'background_task' 且 tail_output 非空)
+ *   <截断的尾部>
  *   </task-notification>
  *   </notification>
  *
- * The opening-tag names (`<notification ` / `<task-notification>`) are
- * load-bearing for the projector's `mergeAdjacentUserMessages` detector
- * — rename requires updating the detector too.
+ * 开标签名(`<notification ` / `<task-notification>`)对 projector 的
+ * `mergeAdjacentUserMessages` 检测器负有承重作用——改名必须同步更新检测器。
  */
 
 export function renderNotificationXml(data: Record<string, unknown>): string {

--- a/packages/agent-core/src/agent/context/observation-masking.ts
+++ b/packages/agent-core/src/agent/context/observation-masking.ts
@@ -4,13 +4,13 @@ import { estimateTokensForMessages } from '../../utils/tokens';
 import type { ContextMessage } from './types';
 
 export interface MaskingConfig {
-  /** Effective capacity ratio (default 0.6 = 60% of advertised capacity) */
+  /** 有效容量比例(默认 0.6 = 通告容量的 60%) */
   effectiveCapacityRatio: number;
-  /** Low priority masking threshold (default 0.60) */
+  /** 低优先级遮蔽阈值(默认 0.60) */
   lowPriorityThreshold: number;
-  /** Medium priority masking threshold (default 0.80) */
+  /** 中优先级遮蔽阈值(默认 0.80) */
   mediumPriorityThreshold: number;
-  /** High priority threshold — unmaskable, goes straight to compaction */
+  /** 高优先级阈值——不可遮蔽,直接进入压缩 */
   highPriorityThreshold: number;
 }
 
@@ -21,7 +21,7 @@ export const DEFAULT_MASKING_CONFIG: MaskingConfig = {
   highPriorityThreshold: 0.85,
 };
 
-/** Tool priority */
+/** 工具优先级 */
 export type ToolPriority = 'high' | 'medium' | 'low';
 
 export function getToolPriority(toolName: string): ToolPriority {
@@ -143,8 +143,8 @@ function maskToolResult(
 }
 
 /**
- * Apply observation masking to tool result messages in history.
- * Returns a new history array (does not mutate the original) and masking result.
+ * 对历史中的工具结果消息应用 observation masking。
+ * 返回新的历史数组(不修改原数组)与遮蔽结果。
  */
 export function applyObservationMasking(
   history: readonly ContextMessage[],

--- a/packages/agent-core/src/agent/context/projector.ts
+++ b/packages/agent-core/src/agent/context/projector.ts
@@ -196,9 +196,8 @@ function cloneMessage(message: Message): Message {
 // ---------------------------------------------------------------------------
 
 /**
- * How many of the most recent media parts survive the media-degraded
- * projection. The tail images are what the model is actively working from
- * (the screenshot it just took); everything older is replaced by a marker.
+ * media-degraded 投影中保留的最近媒体 part 数量。尾部图像是模型正在实际
+ * 使用的(它刚截的屏);更旧的都被替换为标记。
  */
 export const MEDIA_DEGRADE_KEEP_RECENT = 2;
 
@@ -212,10 +211,9 @@ const MEDIA_DEGRADED_PLACEHOLDERS = {
 } as const;
 
 /**
- * Markers for the media-stripped resend after the provider rejected an
- * image's FORMAT (not its size): the image marker points the model at
- * re-reading the file, whose refusal carries per-OS conversion instructions;
- * audio/video are collateral of the full strip and say so.
+ * 提供方因图片**格式**(而非大小)拒绝后的 media-stripped 重发标记:
+ * 图片标记引导模型重新读取文件,其拒绝信息携带各 OS 的转换指引;
+ * 音频 / 视频是整体剥离的连带品,标记中如实说明。
  */
 export const MEDIA_STRIPPED_PLACEHOLDERS = {
   image_url:
@@ -233,17 +231,14 @@ function isDegradableMediaPart(
 }
 
 /**
- * Replace all but the `keepRecent` most recent media parts with deterministic
- * text markers. This is the media-degraded projection used to resend a request
- * the provider rejected as too large (HTTP 413 on accumulated base64 media)
- * and — with `keepRecent = 0` and `MEDIA_STRIPPED_PLACEHOLDERS` — the resend
- * after an image-format rejection, where the poisoned image could be anywhere
- * and only a full strip guarantees a clean request. A purely read-side
- * transform — the underlying history is left untouched — that trades pixels
- * for deliverability while the surrounding text (including ReadMediaFile's
- * `<image path="...">` wrapper) survives, so the model can re-read any file
- * it still needs. Untouched messages are returned by reference, and when
- * nothing needs degrading the input array itself is returned.
+ * 把除 `keepRecent` 个最近媒体 part 之外的全部替换为确定性文本标记。
+ * 这是 media-degraded 投影:用于重发被提供方判为过大的请求(累积 base64
+ * 媒体导致 HTTP 413);配合 `keepRecent = 0` 与 `MEDIA_STRIPPED_PLACEHOLDERS`
+ * 则是图片格式被拒后的重发——此时坏图可能位于任意位置,只有整体剥离才能
+ * 保证请求干净。这是纯读侧变换——底层历史原封不动——以像素换可达性,
+ * 同时周围文本(含 ReadMediaFile 的 `<image path="...">` 包装)保留,
+ * 使模型可重新读取它仍需要的任何文件。未触碰的消息按引用返回;无需降级
+ * 时直接返回输入数组本身。
  */
 export function degradeOlderMediaParts(
   messages: readonly Message[],

--- a/packages/agent-core/src/agent/context/types.ts
+++ b/packages/agent-core/src/agent/context/types.ts
@@ -48,7 +48,7 @@ export interface HookResultOrigin {
   readonly blocked?: boolean;
 }
 
-/** Origin for a session-cron fire injected via steer (PRD-0023 R3). */
+/** 经 steer 注入的会话内 cron 触发来源(PRD-0023 R3)。 */
 export interface CronJobOrigin {
   readonly kind: 'cron_job';
   readonly jobId: string;
@@ -58,7 +58,7 @@ export interface CronJobOrigin {
   readonly stale: boolean;
 }
 
-/** Origin for an explicit missed-cron banner (reserved; coalesce covers most cases). */
+/** 显式错过-cron 横幅的来源(保留;coalesce 覆盖大多数情况)。 */
 export interface CronMissedOrigin {
   readonly kind: 'cron_missed';
   readonly count: number;

--- a/packages/agent-core/src/agent/context/wire-fold.ts
+++ b/packages/agent-core/src/agent/context/wire-fold.ts
@@ -1,20 +1,16 @@
 /**
- * Wire-fold logic, extracted from `ContextMemory.appendLoopEvent`.
+ * Wire-fold 逻辑,自 `ContextMemory.appendLoopEvent` 抽取。
  *
- * This module folds a stream of `LoopRecordedEvent`s and explicit
- * `context.append_message` records into a `ContextMessage[]` timeline. It is
- * the single source of truth for how wire records reconstruct the
- * conversation history — consumed by both the live agent (via
- * `ContextMemory`) and external readers (e.g. apps/vis), eliminating the
- * duplicate fold logic that previously drifted between them.
+ * 本模块把一串 `LoopRecordedEvent` 与显式 `context.append_message` 记录折叠为
+ * `ContextMessage[]` 时间线。它是 wire 记录如何重建会话历史的唯一事实源——
+ * 同时被 live agent(经 `ContextMemory`)与外部读者(如 apps/vis)消费,
+ * 消除了此前在两者间漂移的重复 fold 逻辑。
  *
- * Pure-function contract (PRD-0027 Phase 5): no disk I/O, record logging,
- * event emission, injection hooks, or caller-supplied effect ports inside
- * this module. Each fold function mutates `state` in place and **returns the
- * messages committed to the timeline** (including any deferred messages
- * flushed when a tool exchange closes) — callers run their own side effects
- * (background delivery, replay builder, token snapshots, output offloading)
- * against the returned messages in the service layer.
+ * 纯函数契约(PRD-0027 Phase 5):本模块内无磁盘 I/O、记录日志、事件发出、
+ * 注入钩子或调用方提供的 effect 端口。每个 fold 函数原地变更 `state`,
+ * 并**返回提交到时间线的消息**(含工具交换关闭时刷出的延迟消息)——调用方在
+ * service 层针对返回的消息运行自己的副作用(后台投递、replay builder、
+ * token 快照、输出 offload)。
  */
 
 import { createToolMessage, type ContentPart } from '@byfriends/kosong';
@@ -29,13 +25,11 @@ const TOOL_EMPTY_ERROR_STATUS =
 const TOOL_OUTPUT_EMPTY_TEXT = 'Tool output is empty.';
 
 /**
- * Apply agent-core's output-normalisation to a tool result before it enters
- * the history: empty/error outputs get an explicit `<system>` marker so the
- * model can distinguish "tool ran, produced nothing" from "tool failed".
+ * 在工具结果进入历史前应用 agent-core 的输出归一化:空 / 错误输出会被加上
+ * 显式 `<system>` 标记,使模型能区分「工具运行了但没有产出」与「工具失败」。
  *
- * Exported so vis (and any external reader) can replicate the exact same
- * transformation the live agent applies — previously vis showed the raw
- * output and silently diverged on empty / error tool results.
+ * 导出供 vis(及任何外部读者)复现 live agent 施加的完全相同变换——
+ * 此前 vis 显示原始输出,在空 / 错误工具结果上会静默偏离。
  */
 export function toolResultOutputForModel(result: ExecutableToolResult): string | ContentPart[] {
   const output = result.output;
@@ -67,27 +61,23 @@ function isEmptyOutputText(output: string): boolean {
 }
 
 /**
- * Mutable fold state. The live `ContextMemory` and vis each hold one instance
- * and feed records through {@link foldLoopEvent} / {@link foldAppendMessage}.
- * The live agent shares its instance with the `context` wire model
- * (`WireService.mountModel`), so the fold functions double as the model's
- * `apply` implementations.
+ * 可变 fold 状态。live `ContextMemory` 与 vis 各持一个实例,经
+ * {@link foldLoopEvent} / {@link foldAppendMessage} 喂入记录。live agent 将其
+ * 实例与 `context` wire model 共享(`WireService.mountModel`),因此 fold 函数
+ * 同时充当 model 的 `apply` 实现。
  */
 export interface WireFoldState {
   history: ContextMessage[];
-  /** step.uuid → the assistant ContextMessage currently being filled in. */
+  /** step.uuid → 正在填充中的 assistant ContextMessage。 */
   openSteps: Map<string, ContextMessage>;
-  /** tool-call ids whose result hasn't arrived yet. Non-empty means we're
-   *  inside a tool exchange and explicit `appendMessage`s must be deferred
-   *  until the exchange closes (otherwise user/background messages would be
-   *  interleaved into the assistant's tool-call run, confusing the model). */
+  /** 结果尚未到达的 tool-call id。非空表示正处于工具交换中,显式
+   *  `appendMessage` 必须延迟到交换关闭(否则 user / background 消息会插入
+   *  assistant 的工具调用运行中,使模型困惑)。 */
   pendingToolResultIds: Set<string>;
-  /** tool-call id → {name, args}; consulted by observation masking / pruning
-   *  and by the service layer's output-offload decision (Agent-tool subagent
-   *  summaries are never offloaded). */
+  /** tool-call id → {name, args};observation masking / pruning 及 service 层的
+   *  输出 offload 决策会查阅(Agent 工具的子 agent 摘要永不 offload)。 */
   toolCallInfo: Map<string, { name: string; args: unknown }>;
-  /** Messages queued during an open tool exchange; flushed when the last
-   *  pending tool result lands and the exchange closes. */
+  /** 工具交换打开期间排队的消息;最后一个待决工具结果落地、交换关闭时刷出。 */
   deferredMessages: ContextMessage[];
 }
 
@@ -102,10 +92,8 @@ export function createWireFoldState(): WireFoldState {
 }
 
 /**
- * Push a message into state, honouring the tool-exchange deferral rule:
- * if a tool exchange is open (some tool call still awaiting its result),
- * queue the message; it flushes when the exchange closes. Returns the
- * messages committed to history (empty when deferred).
+ * 把消息推入 state,遵循工具交换延迟规则:若交换打开(仍有工具调用等待结果),
+ * 则排队消息;交换关闭时刷出。返回提交到历史的消息(延迟时为空)。
  */
 export function foldAppendMessage(state: WireFoldState, message: ContextMessage): ContextMessage[] {
   if (state.pendingToolResultIds.size > 0) {
@@ -117,11 +105,9 @@ export function foldAppendMessage(state: WireFoldState, message: ContextMessage)
 }
 
 /**
- * Fold one loop event into state. Pure and synchronous: no side effects, no
- * async (tool outputs enter the timeline in full; output offloading is a
- * service-layer effect after dispatch, see PRD-0027 R3). Returns the messages
- * committed to history (may include deferred messages flushed when a tool
- * exchange closes).
+ * 把一个 loop 事件折叠进 state。纯且同步:无副作用、无 async(工具输出完整进入
+ * 时间线;输出 offload 是 dispatch 之后的 service 层 effect,见 PRD-0027 R3)。
+ * 返回提交到历史的消息(可能包含工具交换关闭时刷出的延迟消息)。
  */
 export function foldLoopEvent(state: WireFoldState, event: LoopRecordedEvent): ContextMessage[] {
   switch (event.type) {
@@ -181,11 +167,9 @@ export function foldLoopEvent(state: WireFoldState, event: LoopRecordedEvent): C
 }
 
 /**
- * Reset fold state to empty in place (e.g. on `context.clear`). Mutates the
- * existing arrays/maps rather than replacing them, so callers whose state is
- * a view onto their own fields (like `ContextMemory.foldState()`) see the
- * reset. Callers that hold display metadata should clear their own
- * structures in parallel.
+ * 原地把 fold 状态重置为空(例如 `context.clear` 时)。变更既有数组 / 映射而非
+ * 替换它们,使 state 是其自身字段视图的调用方(如 `ContextMemory.foldState()`)
+ * 能看到重置。持有展示元数据的调用方应并行清空自己的结构。
  */
 export function resetWireFoldState(state: WireFoldState): void {
   state.history.length = 0;
@@ -196,13 +180,11 @@ export function resetWireFoldState(state: WireFoldState): void {
 }
 
 /**
- * Apply a compaction summary in place: replace the first `compactedCount`
- * messages with a single summary assistant message and keep the uncompacted
- * tail (`history.slice(compactedCount)`). Clears open steps and flushes any
- * deferred messages once the tool-exchange gate allows.
+ * 原地应用压缩摘要:把前 `compactedCount` 条消息替换为一条 summary assistant
+ * 消息,保留未压缩的尾部(`history.slice(compactedCount)`)。清空打开的 step,
+ * 并在工具交换闸门允许时刷出任何延迟消息。
  *
- * Shared by `ContextMemory` and external readers (vis) so partial-compaction
- * tails cannot drift again.
+ * 由 `ContextMemory` 与外部读者(vis)共享,使部分压缩尾部不再漂移。
  */
 export function foldApplyCompaction(
   state: WireFoldState,
@@ -228,9 +210,8 @@ function commitMessage(state: WireFoldState, message: ContextMessage): void {
 }
 
 /**
- * Flush any deferred messages when no tool exchange is open. Public so that
- * out-of-band state changes (e.g. `applyCompaction` rebuilding the history)
- * can re-check the deferral rule without going through `foldLoopEvent`.
+ * 在无工具交换打开时刷出任何延迟消息。公开使带外状态变更(例如 `applyCompaction`
+ * 重建历史)无需经过 `foldLoopEvent` 即可重新检查延迟规则。
  */
 export function flushDeferred(state: WireFoldState): ContextMessage[] {
   return flushDeferredIfToolExchangeClosed(state);
@@ -250,10 +231,9 @@ function flushDeferredIfToolExchangeClosed(state: WireFoldState): ContextMessage
 }
 
 /**
- * Find the history indices of tool messages whose content starts with the
- * `[ToolName:` masked prefix (observation masking leaves this signature).
- * Pure helper shared by the `context.pruning` apply and the service layer's
- * prune-counting (PRD-0027 Phase 5).
+ * 查找内容以 `[ToolName:` 掩码前缀开头的工具消息的历史索引(observation
+ * masking 会留下此签名)。纯辅助函数,由 `context.pruning` 的 apply 与 service
+ * 层的修剪计数共享(PRD-0027 Phase 5)。
  */
 export function findMaskedToolResultIndices(state: WireFoldState): number[] {
   const indices: number[] = [];

--- a/packages/agent-core/src/agent/cron/manager.ts
+++ b/packages/agent-core/src/agent/cron/manager.ts
@@ -1,40 +1,32 @@
 /**
- * CronManager — Agent-facing facade for the cron scheduler.
+ * CronManager — 面向 Agent 的 cron 调度门面(facade)。
  *
- * This layer sits between the raw `CronScheduler` (which knows nothing
- * about agents) and the rest of the agent runtime (Agent / turn /
- * telemetry / tool surface). Its job is small but important:
+ * 本层位于原始 `CronScheduler`(它完全不了解 agent)与 agent 运行时其余部分
+ * (Agent / turn / 遥测 / 工具面)之间。职责小而关键:
  *
- *   - own the `SessionCronStore` for this session;
- *   - hand `() => store.list()` to the scheduler so add / delete are
- *     picked up automatically every tick;
- *   - gate fires on `agent.turn.hasActiveTurn` rather than maintaining a
- *     duplicate idle flag — the turn machinery already knows;
- *   - translate a fired `CronTask` into a `steer(...)` call carrying a
- *     `CronJobOrigin`, plus the `cron_fired` telemetry event;
- *   - mirror every store mutation to `<sessionDir>/cron/<id>.json`
- *     (via {@link addTask} / {@link removeTasks}) so that `byf resume`
- *     can call {@link loadFromDisk} to rehydrate previously-scheduled
- *     tasks. When no `sessionDir` is supplied (subagents, tests,
- *     ephemeral sessions) the manager stays purely in-memory.
- *   - provide a `handleMissed(...)` entry point that future boot-time
- *     missed-task notification will call. Today the scheduler's
- *     `coalescedCount` semantics handle missed fires inline, so this
- *     entry point is not wired by the framework — it stays exposed so
- *     adding a banner later does not require API churn here.
+ *   - 持有本会话的 `SessionCronStore`;
+ *   - 把 `() => store.list()` 交给调度器,使每次 tick 自动感知增删;
+ *   - 用 `agent.turn.hasActiveTurn` 门控触发,而非维护重复的空闲标志——
+ *     turn 机制本身已经知道是否空闲;
+ *   - 把一次触发的 `CronTask` 翻译为携带 `CronJobOrigin` 的 `steer(...)` 调用,
+ *     并发出 `cron_fired` 遥测事件;
+ *   - 把每次 store 变更镜像到 `<sessionDir>/cron/<id>.json`
+ *     (经 {@link addTask} / {@link removeTasks}),使 `byf resume` 可调用
+ *     {@link loadFromDisk} 重新水合此前已排定的任务。未提供 `sessionDir` 时
+ *     (subagent、测试、临时会话)管理器保持纯内存运行。
+ *   - 提供 `handleMissed(...)` 入口,供未来的启动期错过任务通知调用。目前调度器的
+ *     `coalescedCount` 语义已内联处理错过触发,因此框架不会调用此入口——它保持
+ *     暴露,以便日后增加横幅提示时无需改动本文件 API。
  *
- * The manager does NOT read `Date.now()` directly anywhere; every
- * wall-clock read goes through `this.clocks.wallNow()`. The
- * `no-date-now.test.ts` guard does not list this file (it covers the
- * scheduler / jitter layer), but the same discipline is intentional so
- * bench / test clock injection holds end-to-end.
+ * 管理器任何地方都不会直接读 `Date.now()`;所有墙钟读取都经由
+ * `this.clocks.wallNow()`。`no-date-now.test.ts` 守卫未列出本文件(它覆盖
+ * 调度器 / 抖动层),但同样的纪律在此有意为之,使 bench / 测试时钟注入
+ * 端到端生效。
  *
- * Note on `recurring` semantics: the canonical task representation uses
- * `recurring: boolean | undefined` where `undefined` means recurring
- * (cron tasks default to repeating). One-shot is the explicit
- * `recurring === false` opt-out. Every check in this file uses
- * `task.recurring !== false` to keep that default behaviour even when
- * the field is omitted by the caller.
+ * 关于 `recurring` 语义的说明:规范的任务表示使用
+ * `recurring: boolean | undefined`,`undefined` 表示循环(cron 任务默认重复)。
+ * 一次性任务通过显式 `recurring === false` 退出。本文件中的每次检查都用
+ * `task.recurring !== false`,使调用方省略该字段时仍保持默认行为。
  */
 import type { ContentPart } from '@byfriends/kosong';
 
@@ -69,54 +61,52 @@ import type { Agent } from '../index';
 const STALE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
 
 /**
- * Point-in-time view of a scheduled cron task, exposed over RPC so host
- * applications (e.g. the `byf -p` flow deciding whether pending work
- * remains before exit) can enumerate scheduled tasks without going
- * through the model-facing CronList tool.
+ * 已排定 cron 任务在某一时刻的快照,经 RPC 暴露,使宿主应用
+ * (例如 `byf -p` 流程在退出前判断是否仍有待办工作)无需经由面向模型的
+ * CronList 工具即可枚举已排定任务。
  */
 export interface CronTaskSnapshot {
   readonly id: string;
   readonly cron: string;
   /**
-   * Human-readable schedule derived from {@link cron}. Falls back to the
-   * raw expression when parsing fails (malformed store injects / tests).
+   * 由 {@link cron} 推导的人类可读调度描述。解析失败时回退到原始表达式
+   * (store 注入的畸形数据 / 测试场景)。
    */
   readonly humanSchedule: string;
-  /** Full prompt string; hosts (e.g. `/cron` list) may truncate for display. */
+  /** 完整提示词字符串;宿主(如 `/cron` 列表)可按需截断显示。 */
   readonly prompt: string;
   readonly recurring: boolean;
   readonly createdAt: number;
   readonly lastFiredAt: number | undefined;
-  /** Post-jitter next fire (epoch ms), or null when no future fire exists. */
+  /** 抖动后的下一次触发时间(epoch 毫秒);不存在未来触发时为 null。 */
   readonly nextFireAt: number | null;
 }
 
 export interface CronManagerOptions {
   /**
-   * Override for tests / bench. Defaults to
-   * `resolveClockSources(process.env.BYF_CRON_CLOCK)` so production
-   * picks up `BYF_CRON_CLOCK=file:...` automatically.
-   * When unset, falls through to {@link SYSTEM_CLOCKS}.
+   * 测试 / bench 用覆盖。默认取
+   * `resolveClockSources(process.env.BYF_CRON_CLOCK)`,使生产环境自动
+   * 读取 `BYF_CRON_CLOCK=file:...`。未设置时回退到 {@link SYSTEM_CLOCKS}。
    */
   readonly clocks?: ClockSources;
 
   /**
-   * Override scheduler poll interval. Defaults handled by the scheduler
-   * (1000ms unless `BYF_CRON_MANUAL_TICK=1`, which forces `null` here
-   * so the auto-tick `setInterval` is never installed). `null` or `0`
-   * means "no automatic timer — caller drives `tick()` manually".
+   * 覆盖调度器轮询间隔。默认值由调度器处理
+   * (1000ms;除非 `BYF_CRON_MANUAL_TICK=1`,此时此处强制为 `null`,
+   * 使自动 tick 的 `setInterval` 永不安装)。`null` 或 `0`
+   * 表示「无自动定时器——由调用方手动驱动 `tick()`」。
    */
   readonly pollIntervalMs?: number | null;
 }
 
 export class CronManager {
-  /** In-memory task store. Empty at construction; populated by
-   * {@link addTask} (and {@link loadFromDisk} on resume). */
+  /** 内存任务 store。构造时为空;由 {@link addTask}(及 resume 时的
+   * {@link loadFromDisk})填充。 */
   readonly store: SessionCronStore;
 
   /**
-   * Clock source used for the stale judgment. Also passed to the
-   * scheduler so the entire stack shares one notion of "now".
+   * 用于过期(stale)判断的时钟源。同样传给调度器,
+   * 使整个调用栈共享同一个「当前时间」概念。
    */
   readonly clocks: ClockSources;
 
@@ -191,18 +181,15 @@ export class CronManager {
   }
 
   /**
-   * Add a fresh task to the in-memory store and, when persistence is
-   * attached, mirror the new record to `<sessionDir>/cron/<id>.json`.
+   * 向内存 store 添加一个新任务;启用持久化时,将新记录镜像到
+   * `<sessionDir>/cron/<id>.json`。
    *
-   * The store call is synchronous (CronCreate needs the id for its
-   * response); the on-disk write is fire-and-forget so a slow disk
-   * never blocks the tool's reply. Per-id queueing serializes
-   * concurrent writes on the same id (e.g. add → stale auto-expire) so
-   * the rm cannot race the rename.
+   * store 调用是同步的(CronCreate 的响应需要 id);落盘写入为
+   * fire-and-forget,慢磁盘不会阻塞工具的回复。按 id 排队可串行化
+   * 同一 id 上的并发写入(例如 add → 过期自动清理),避免 rm 与 rename 竞争。
    *
-   * Persistence failures are logged via `agent.log.warn` and swallowed
-   * — a flaky disk drops cross-resume durability but must not crash
-   * the agent loop.
+   * 持久化失败经 `agent.log.warn` 记录并吞掉——磁盘抖动会丢失跨 resume
+   * 的持久性,但不能使 agent 循环崩溃。
    */
   addTask(init: SessionCronTaskInit): CronTask {
     const task = this.store.add(init, this.clocks.wallNow());
@@ -211,16 +198,13 @@ export class CronManager {
   }
 
   /**
-   * Remove a batch of tasks from the in-memory store and mirror each
-   * deletion to disk (when persistence is attached). Returns the
-   * subset of ids that were actually present, matching
-   * `SessionCronStore.remove`'s contract — callers (CronDelete /
-   * scheduler one-shot cleanup / stale auto-expire) read this to
-   * decide whether to emit telemetry.
+   * 从内存 store 移除一批任务,并(启用持久化时)把每次删除镜像到磁盘。
+   * 返回实际存在的 id 子集,与 `SessionCronStore.remove` 的契约一致——
+   * 调用方(CronDelete / 调度器一次性清理 / 过期自动清理)据此决定
+   * 是否发遥测。
    *
-   * Persistence failures are logged and swallowed; cross-resume the
-   * worst case is a ghost entry that gets dropped on the next
-   * `list()` shape-guard pass.
+   * 持久化失败被记录并吞掉;跨 resume 的最坏情况是残留一个幽灵条目,
+   * 会在下一次 `list()` 的形状守卫中被丢弃。
    */
   removeTasks(ids: readonly string[]): readonly string[] {
     const removed = this.store.remove(ids);
@@ -252,14 +236,12 @@ export class CronManager {
   }
 
   /**
-   * Rehydrate the in-memory store from `<sessionDir>/cron/` after
-   * `byf resume`. No-op when persistence is not attached. Idempotent:
-   * clears the in-memory map and re-inserts every record on disk.
+   * `byf resume` 后从 `<sessionDir>/cron/` 重新水合内存 store。
+   * 未启用持久化时为空操作。幂等:清空内存映射并重新插入磁盘上的每条记录。
    *
-   * Tasks are inserted via {@link SessionCronStore.adopt} so the
-   * original `id` and `createdAt` survive — `createdAt` is the
-   * scheduler's recurring baseline and the 7-day stale judgment's
-   * input, so a regenerated value would corrupt both.
+   * 任务经 {@link SessionCronStore.adopt} 插入,使原始 `id` 与 `createdAt`
+   * 得以保留——`createdAt` 是调度器的循环基线和 7 天过期判断的输入,
+   * 重新生成的值会同时破坏两者。
    */
   async loadFromDisk(): Promise<void> {
     if (this.persistStore === undefined) return;
@@ -296,13 +278,11 @@ export class CronManager {
   }
 
   /**
-   * Wait for every pending persistence write / remove scheduled via
-   * {@link addTask} / {@link removeTasks} to settle. Called from
-   * {@link stop} for graceful session shutdown and exposed publicly so
-   * tests can synchronise on disk-visible state without polling.
+   * 等待经 {@link addTask} / {@link removeTasks} 排入的所有待写 / 待删
+   * 持久化操作完成。{@link stop} 在优雅关停会话时调用它;它公开暴露,
+   * 使测试无需轮询即可同步到磁盘可见状态。
    *
-   * Errors are already swallowed by `persistEnqueue`, so this never
-   * rejects.
+   * 错误已被 `persistEnqueue` 吞掉,因此该方法永不 reject。
    */
   async flushPersist(): Promise<void> {
     // Snapshot the chain promises rather than the map itself — the
@@ -313,9 +293,8 @@ export class CronManager {
   }
 
   /**
-   * Begin the scheduler's auto-tick loop and bind the SIGUSR1 manual-tick
-   * hook (P1.8). Idempotent: a second call is a no-op so the boot
-   * sequence and tests can opt into "ensure started" without bookkeeping.
+   * 启动调度器的自动 tick 循环,并绑定 SIGUSR1 手动 tick 钩子(P1.8)。
+   * 幂等:重复调用为空操作,启动序列与测试无需记账即可「确保已启动」。
    */
   start(): void {
     if (this.started) return;
@@ -325,16 +304,13 @@ export class CronManager {
   }
 
   /**
-   * Stop the scheduler, drain pending persistence writes, clear
-   * in-flight bookkeeping, and unbind the SIGUSR1 handler. Idempotent
-   * and signal-handler-safe — multiple vitest files exercising the
-   * manager must not leave a SIGUSR1 listener dangling on the shared
-   * process.
+   * 停止调度器,排空待写持久化,清理进行中的记账,并解绑 SIGUSR1 处理器。
+   * 幂等且信号处理器安全——多个运行管理器的 vitest 文件不得在共享进程上
+   * 留下悬空的 SIGUSR1 监听器。
    *
-   * Draining persistence on shutdown matters for production: a session
-   * `close()` immediately after a CronCreate would otherwise tear the
-   * process down before the JSON file lands on disk, and the task
-   * would be missing from the resume's `loadFromDisk()`.
+   * 关停时排空持久化对生产环境很重要:否则 CronCreate 之后紧接着的会话
+   * `close()` 会在 JSON 文件落盘前拆掉进程,任务将缺失于 resume 的
+   * `loadFromDisk()`。
    */
   async stop(): Promise<void> {
     this.unbindSigusr1();
@@ -343,34 +319,31 @@ export class CronManager {
     this.started = false;
   }
 
-  /** Drive one scheduler tick synchronously. Used by tests + P1.8 SIGUSR1. */
+  /** 同步驱动一次调度器 tick。供测试与 P1.8 SIGUSR1 使用。 */
   tick(): void {
     this.scheduler.tick();
   }
 
   /**
-   * Earliest theoretical (post-jitter) next-fire across all tasks, or
-   * null if there are no tasks / none have a future fire. Used by the
-   * `/cron` slash command and external monitoring.
+   * 所有任务中最早的(抖动后)理论下一次触发时间;没有任务或均无未来触发
+   * 时为 null。供 `/cron` 斜杠命令与外部监控使用。
    */
   getNextFireTime(): number | null {
     return this.scheduler.getNextFireTime();
   }
 
   /**
-   * Per-task post-jitter next-fire. Forwards to the scheduler so
-   * CronList renders the same instant the scheduler will fire — even
-   * when an already-past ideal still has a pending jittered delivery
-   * in the current period.
+   * 单个任务抖动后的下一次触发时间。转发给调度器,使 CronList 渲染出
+   * 调度器实际触发的同一时刻——即使理想时刻已过、当期仍有待投递的
+   * 抖动交付。
    */
   getNextFireForTask(taskId: string): number | null {
     return this.scheduler.getNextFireForTask(taskId);
   }
 
   /**
-   * Enumerate every scheduled task with its post-jitter next fire time.
-   * Unlike the CronList tool (which renders for the model), this returns
-   * structured data for host applications polling for pending work.
+   * 枚举每个已排定任务及其抖动后的下一次触发时间。与面向模型的 CronList
+   * 工具不同,此方法为轮询待办工作的宿主应用返回结构化数据。
    */
   listTaskSnapshots(): readonly CronTaskSnapshot[] {
     return this.store.list().map((task) => {
@@ -394,9 +367,9 @@ export class CronManager {
   }
 
   /**
-   * Host-path delete (PRD-0024 / ADR-0030). Not a tool — no permission ask.
-   * Returns whether a task was actually removed. Invalid ids are treated as
-   * not found (`deleted: false`) so hosts can present a uniform error.
+   * 宿主路径删除(PRD-0024 / ADR-0030)。不是工具——不询问权限。
+   * 返回任务是否真的被移除。无效 id 按「未找到」处理(`deleted: false`),
+   * 使宿主可以呈现统一的错误。
    */
   deleteCronTask(id: string): { deleted: boolean } {
     if (!/^[0-9a-f]{8}$/.test(id)) {
@@ -411,17 +384,15 @@ export class CronManager {
   }
 
   /**
-   * Stale judgment.
+   * 过期(stale)判断。
    *
-   *   - `BYF_CRON_NO_STALE=1` short-circuits to false (bench).
-   *   - One-shot tasks (`recurring === false`) are never stale — they
-   *     fire at most once by construction; flagging them stale would be
-   *     a noisy false positive on every backlog wakeup.
-   *   - Otherwise: `wallNow() - createdAt >= 7 days`.
+   *   - `BYF_CRON_NO_STALE=1` 直接短路为 false(bench)。
+   *   - 一次性任务(`recurring === false`)永不过期——它们构造上最多触发一次;
+   *     标记其过期会在每次积压唤醒时产生嘈杂的误报。
+   *   - 其他情况:`wallNow() - createdAt >= 7 天`。
    *
-   * `Number.isFinite` guards against the wall clock being broken (e.g.
-   * a mis-set bench env that returns `NaN`); a non-finite age is
-   * treated as "we don't know, don't claim stale".
+   * `Number.isFinite` 防御墙钟损坏(例如错误设置的 bench 环境返回 `NaN`);
+   * 非有限年龄按「不知道,不声称过期」处理。
    */
   isStale(task: CronTask): boolean {
     if (process.env['BYF_CRON_NO_STALE'] === '1') return false;
@@ -489,23 +460,17 @@ export class CronManager {
   }
 
   /**
-   * Reserved hook for an explicit "you missed N fires while offline"
-   * banner. Today the scheduler's `coalescedCount` semantics already
-   * communicate missed fires inside the `cron_job` envelope (and
-   * recurring tasks past 7 days arrive with `stale: true`), so the
-   * resume path does NOT invoke this from the framework. The method
-   * stays exposed because adding a separate user-facing banner later
-   * — e.g. for one-shots whose fire times all landed during a long
-   * outage — should not require an API change here.
+   * 显式「离线期间错过了 N 次触发」横幅的保留钩子。目前调度器的
+   * `coalescedCount` 语义已在 `cron_job` 信封内传达错过触发(超过 7 天的
+   * 循环任务会以 `stale: true` 到达),因此 resume 路径不会从框架调用此方法。
+   * 它保持暴露,因为日后增加独立的用户可见横幅——例如为触发时间全部落在
+   * 长时间中断内的一次性任务——不应要求此处改 API。
    *
-   * The `renderMissedNotification` callback is supplied by the caller
-   * (rather than imported here) so this module stays free of UI / copy
-   * coupling; the same manager works for tests that want to inject a
-   * trivial renderer.
+   * `renderMissedNotification` 回调由调用方提供(而非在此导入),
+   * 使本模块不耦合 UI / 文案;同一个管理器也能服务于想注入简单渲染器的测试。
    *
-   * `count: 0` is a no-op — the scheduler-side missed-task detector
-   * filters empties before calling us, but defending here keeps the
-   * contract simple ("safe to call with anything, no-op when empty").
+   * `count: 0` 为空操作——调度器侧的错过任务检测器在调用我们之前已过滤
+   * 空集,但在此防御可使契约保持简单(「任何输入都可安全调用,空时无操作」)。
    */
   handleMissed(
     tasks: readonly CronTask[],
@@ -522,12 +487,10 @@ export class CronManager {
   }
 
   /**
-   * Emit `cron_scheduled` for a freshly-added task. Called by
-   * `CronCreate` after a successful `store.add(...)`. Kept as an
-   * explicit method so the tool layer never reaches into
-   * `manager.agent.telemetry` — preserves the "tools see the manager,
-   * the manager sees the agent" layering and matches the symmetric
-   * `emitDeleted` used by `CronDelete` (P1.6).
+   * 为新添加的任务发出 `cron_scheduled`。由 `CronCreate` 在成功
+   * `store.add(...)` 后调用。作为显式方法保留,使工具层永远不直接触碰
+   * `manager.agent.telemetry`——保持「工具只见管理器、管理器只见 agent」
+   * 的分层,并与 `CronDelete` 使用的对称 `emitDeleted` 一致(P1.6)。
    */
   emitScheduled(task: CronTask): void {
     this.agent.telemetry.track(CRON_SCHEDULED, {
@@ -536,9 +499,8 @@ export class CronManager {
   }
 
   /**
-   * Emit `cron_deleted` for a removed task. Wired up here so P1.6 can
-   * land without touching this file again. `task_id` matches the field
-   * naming used elsewhere in the telemetry surface (snake_case).
+   * 为已移除的任务发出 `cron_deleted`。在此接线,使 P1.6 无需再次改动本文件。
+   * `task_id` 与遥测面其他位置的字段命名一致(snake_case)。
    */
   emitDeleted(taskId: string): void {
     this.agent.telemetry.track(CRON_DELETED, { task_id: taskId });

--- a/packages/agent-core/src/agent/hooks/runner.ts
+++ b/packages/agent-core/src/agent/hooks/runner.ts
@@ -8,28 +8,24 @@ export interface RunHookOptions {
   readonly cwd?: string;
   readonly signal?: AbortSignal;
   /**
-   * Execution backend used to spawn the hook command. Defaults to the local
-   * {@link Kaos} environment via {@link createKaosHookExec}; production wiring
-   * (HookEngine → Session) injects the runtime's active Kaos so hook execution
-   * follows the user's working directory, including under future SSHKaos
-   * (ADR 0006).
+   * 用于拉起 hook 命令的执行后端。默认经 {@link createKaosHookExec} 使用本地
+   * {@link Kaos} 环境;生产接线(HookEngine → Session)注入运行时的活跃 Kaos,
+   * 使 hook 执行跟随用户的工作目录,包括未来 SSHKaos 场景(ADR 0006)。
    */
   readonly exec?: HookExec;
 }
 
 /**
- * Execution backend used by {@link runHook}.
+ * {@link runHook} 使用的执行后端。
  *
- * Hooks run in the user's project working directory, which is the exact path
- * that becomes remote once `SSHKaos` (per ADR 0006) lands. Routing the spawn
- * through `Kaos.execWithEnv()` keeps hook execution on the correct side of the
- * local/remote boundary instead of always spawning on the BYF host.
+ * hook 在用户的项目工作目录中运行,而该目录正是 `SSHKaos`(ADR 0006)落地后
+ * 变为远程的路径。经 `Kaos.execWithEnv()` 路由 spawn,使 hook 执行保持在
+ * 本地 / 远程边界的正确一侧,而不是总在 BYF 宿主上拉起。
  */
 export interface HookExec {
   /**
-   * Spawn a shell-interpreted command with an optional working directory and
-   * environment, returning the running process. Mirrors `Kaos.execWithEnv` so
-   * the local implementation can delegate directly.
+   * 以可选工作目录与环境拉起一条由 shell 解释的命令,返回运行中的进程。
+   * 镜像 `Kaos.execWithEnv`,使本地实现可直接委托。
    */
   exec(
     command: string,
@@ -38,23 +34,22 @@ export interface HookExec {
 }
 
 /**
- * Build a {@link HookExec} backed by the active {@link Kaos} environment.
+ * 构建由活跃 {@link Kaos} 环境支撑的 {@link HookExec}。
  *
- * `Kaos.execWithEnv` spawns without shell interpretation and at the Kaos
- * instance's own cwd (the BYF host process dir, shared across sessions), so a
- * hook command needs two adaptations before it reaches `execWithEnv`:
+ * `Kaos.execWithEnv` 不经 shell 解释,且在 Kaos 实例自身的 cwd( BYF 宿主
+ * 进程目录,跨会话共享)中拉起,因此 hook 命令在到达 `execWithEnv` 前需要
+ * 两处适配:
  *
- * 1. **Shell interpretation** — hook commands are free-form shell strings
- *    (pipes, variables, `&&`, scripts). Wrap them as `["<shell>", "-c", cmd]`
- *    using the same cross-platform shell probe the Bash tool uses.
- * 2. **Working directory** — the Kaos instance is shared, so we cannot chdir
- *    it per hook. Switch directory inside the shell via
- *    `cd '<cwd>' && <command>` (POSIX single-quote escaping), mirroring the
- *    Bash tool's approach. When no cwd is given the shell's inherited cwd
- *    (the Kaos cwd) is used, preserving the previous fallthrough behavior.
+ * 1. **Shell 解释** — hook 命令是自由格式的 shell 字符串(管道、变量、
+ *    `&&`、脚本)。按 Bash 工具使用的同一跨平台 shell 探测,包装为
+ *    `["<shell>", "-c", cmd]`。
+ * 2. **工作目录** — Kaos 实例是共享的,无法为每个 hook 切换其目录。在
+ *    shell 内部经 `cd '<cwd>' && <command>` 切换(POSIX 单引号转义),
+ *    镜像 Bash 工具的做法。未给出 cwd 时使用 shell 继承的 cwd(Kaos cwd),
+ *    保留此前的回退行为。
  *
- * This keeps hook execution on the correct side of the local/remote boundary
- * (ADR 0006): once `SSHKaos` lands, the shell + cd run remotely.
+ * 这使 hook 执行保持在本地 / 远程边界的正确一侧(ADR 0006):
+ * `SSHKaos` 落地后,shell 与 cd 都在远程运行。
  */
 export function createKaosHookExec(kaos: Kaos, shellPath: string): HookExec {
   return {

--- a/packages/agent-core/src/agent/injection/goal.ts
+++ b/packages/agent-core/src/agent/injection/goal.ts
@@ -7,17 +7,17 @@ const PAUSED_HEADER = 'The goal is paused; do not take goal-directed action unti
 const COMPLETE_HEADER = 'The goal has been completed; finish any in-flight work cleanly.';
 
 /**
- * Ephemeral injector for goal mode state (PRD-0019 R6 / ADR-0022).
+ * goal 模式状态的 ephemeral 注入器(PRD-0019 R6 / ADR-0022)。
  *
- * Renders a `before_user` reminder reflecting the current goal tier:
- * - active: full reminder with objective + budget guidance + completion instruction.
- * - blocked: light reminder naming the blocked reason.
- * - paused: guard reminder (no goal-directed action).
- * - complete (transient): completion-tier reminder.
- * - no goal: empty.
+ * 渲染反映当前 goal 层级的 `before_user` 提醒:
+ * - active:完整提醒,含目标 + 预算指引 + 完成指令。
+ * - blocked:指明阻塞原因的轻量提醒。
+ * - paused:守卫提醒(不做目标导向行动)。
+ * - complete(瞬时):完成层级提醒。
+ * - 无 goal:为空。
  *
- * Ephemeral: not stored in history, regenerated each step, does not pollute the
- * cached prefix. Persistence/replay comes from the goal.* records, not from here.
+ * Ephemeral:不存入历史,每步重新生成,不污染缓存前缀。持久化 / replay
+ * 来自 goal.* 记录,而非此处。
  */
 export class GoalInjector extends DynamicInjector {
   protected override readonly injectionVariant = 'goal';

--- a/packages/agent-core/src/agent/injection/permission-mode.ts
+++ b/packages/agent-core/src/agent/injection/permission-mode.ts
@@ -7,16 +7,13 @@ const AUTO_MODE_REMINDER = [
 ].join('\n');
 
 /**
- * Ephemeral injector for permission mode state.
+ * 权限模式状态的 ephemeral 注入器。
  *
- * Emits the current permission mode as an ephemeral injection placed at
- * the `'before_user'` position. Unlike the previous persistent approach
- * (which recorded transition events into history), the ephemeral approach
- * always reflects the current state — surviving compaction and avoiding
- * history pollution.
+ * 把当前权限模式作为置于 `'before_user'` 位置的 ephemeral 注入发出。与旧的
+ * 持久化做法(把转换事件记录进历史)不同,ephemeral 做法始终反映当前状态——
+ * 扛住压缩,避免历史污染。
  *
- * Only auto mode produces an injection; in all other modes the absence
- * of a reminder signals that normal approval prompts apply.
+ * 只有 auto 模式产生注入;其他模式下提醒的缺席即表示常规审批提示适用。
  */
 export class PermissionModeInjector extends DynamicInjector {
   protected override readonly injectionVariant = 'permission_mode';

--- a/packages/agent-core/src/agent/injection/timestamp.ts
+++ b/packages/agent-core/src/agent/injection/timestamp.ts
@@ -1,12 +1,11 @@
 import { DynamicInjector } from './injector';
 
 /**
- * Ephemeral injector that provides the current timestamp at request time.
+ * 在请求时提供当前时间戳的 ephemeral 注入器。
  *
- * The timestamp is rendered fresh on every step (not frozen) and placed
- * at the `'before_user'` position so it never breaks the cached prefix.
- * This aligns with the prompt-cache best practice of keeping per-request
- * dynamic content out of the cacheable system-prompt blocks.
+ * 时间戳在每一步都重新渲染(不冻结),置于 `'before_user'` 位置,
+ * 因此永不破坏缓存前缀。这符合提示缓存的最佳实践:把每请求的动态内容
+ * 移出可缓存的 system-prompt 块。
  */
 export class TimestampInjector extends DynamicInjector {
   protected override readonly injectionVariant = 'timestamp';

--- a/packages/agent-core/src/agent/permission/action-label.ts
+++ b/packages/agent-core/src/agent/permission/action-label.ts
@@ -1,23 +1,19 @@
 /**
- * describeApprovalAction — coarse action label for approve_for_session.
+ * describeApprovalAction — approve_for_session 的粗粒度动作标签。
  *
- * The label is the key used by `auto_approve_actions` set (session-level
- * approve-for-session cache). It must be **coarse** enough that the user
- * pressing "approve for session" on one request also unlocks *semantically
- * equivalent* future requests — otherwise approve-for-session degrades
- * into approve-once.
+ * 该标签是 `auto_approve_actions` 集合(会话级 approve-for-session 缓存)
+ * 使用的键。它必须**足够粗**,使用户在一次请求上按「批准本会话」也能解锁
+ * *语义等价*的未来请求——否则 approve-for-session 会退化为 approve-once。
  *
- * Derivation priority:
- *   1. `ApprovalDisplay.kind` mapping (the display already carries the
- *      semantic classification the UI renders):
+ * 推导优先级:
+ *   1. `ApprovalDisplay.kind` 映射(display 已携带 UI 渲染的语义分类):
  *        command    → "run command"
  *        diff       → "edit file"
  *        file_write → "write file"
  *        task_stop  → "stop background task"
- *        generic    → tool-name fallback
- *   2. Hard-coded toolName → action map for tools that emit `generic`
- *      display.
- *   3. Last resort: `call <toolName>`.
+ *        generic    → 工具名回退
+ *   2. 硬编码 toolName → 动作映射,服务于发出 `generic` display 的工具。
+ *   3. 最后手段:`call <toolName>`。
  */
 
 import type { ToolInputDisplay } from '../../tools/display/schemas';
@@ -49,16 +45,14 @@ const ACTION_TO_PATTERN: Readonly<Record<string, string | null>> = {
 };
 
 /**
- * Prefix for CronCreate action labels that embed the full create payload.
- * Session approval must be payload-scoped: approving one schedule must not
- * unlock arbitrary later CronCreate calls (PRD-0023 #244).
+ * CronCreate 动作标签的前缀,标签内嵌完整 create 负载。会话批准必须是
+ * 负载作用域的:批准一个调度不得解锁日后任意的 CronCreate 调用(PRD-0023 #244)。
  */
 export const CRON_CREATE_ACTION_PREFIX = 'call CronCreate ';
 
 /**
- * Stable action label for CronCreate that includes cron/prompt/recurring.
- * Same payload → same label (so re-approve-for-session keeps working);
- * different payload → different label.
+ * CronCreate 的稳定动作标签,包含 cron/prompt/recurring。
+ * 相同负载 → 相同标签(重新批准本会话继续有效);不同负载 → 不同标签。
  */
 export function describeCronCreateApprovalAction(args: unknown): string {
   return `${CRON_CREATE_ACTION_PREFIX}${serializeCronCreatePayload(args)}`;
@@ -155,16 +149,15 @@ export function describeApprovalAction(
 }
 
 /**
- * Inverse mapping from an approve_for_session action label to the
- * permission-rule pattern that should gate future same-action calls.
+ * approve_for_session 动作标签到权限规则模式的逆向映射,该规则将门控未来的
+ * 同类动作调用。
  *
- * When no entry matches, fall back to the concrete tool name. A `null`
- * table entry means the action should be cached by action label only,
- * without creating a broad PermissionRule.
+ * 无条目匹配时回退到具体工具名。`null` 表项表示该动作只按动作标签缓存,
+ * 不创建宽泛的 PermissionRule。
  *
- * Payload-scoped CronCreate actions also skip creating a rule: a bare
- * `CronCreate` pattern would match every future create (matchesRule name-only).
- * Same-payload re-approval is handled by `sessionApprovedActions` alone.
+ * 负载作用域的 CronCreate 动作同样跳过规则创建:裸的 `CronCreate` 模式会匹配
+ * 每次未来的 create(matchesRule 仅按名称匹配)。同负载的重新批准仅由
+ * `sessionApprovedActions` 处理。
  */
 export function actionToRulePattern(action: string, fallbackToolName: string): string | undefined {
   if (action.startsWith(CRON_CREATE_ACTION_PREFIX)) {

--- a/packages/agent-core/src/agent/permission/matches-rule.ts
+++ b/packages/agent-core/src/agent/permission/matches-rule.ts
@@ -1,12 +1,11 @@
 /**
- * matchesRule — pure function that decides whether a PermissionRule
- * applies to a given tool call.
+ * matchesRule — 判定 PermissionRule 是否适用于给定工具调用的纯函数。
  *
- * Contract:
- *   - No side effects, no `this`, no IO, no exceptions.
- *   - Deterministic: same `(rule, toolName, args)` → same result.
- *   - Returns boolean only; decision semantics (deny/ask/allow) are a
- *     caller concern (see `check-rules.ts`).
+ * 契约:
+ *   - 无副作用、无 `this`、无 IO、无异常。
+ *   - 确定性:相同 `(rule, toolName, args)` → 相同结果。
+ *   - 只返回布尔值;决策语义(deny/ask/allow)是调用方的事
+ *     (见 `check-rules.ts`)。
  */
 
 import picomatch from 'picomatch';
@@ -64,16 +63,15 @@ function extractArgField(toolName: string, args: unknown): ArgField | undefined 
 }
 
 /**
- * Decide whether a single rule matches a specific tool call.
+ * 判定单条规则是否匹配特定的工具调用。
  *
- * Algorithm:
- *   1. Parse `rule.pattern` into `{toolName, argPattern?}`.
- *   2. If parsed toolName is `*`, skip name check; otherwise compare with
- *      glob semantics so `mcp__github__*` matches `mcp__github__list`.
- *   3. If the rule has no argPattern, name match → rule fires.
- *   4. Otherwise extract the tool-specific field value and match against
- *      the glob. Handle the leading `!` negation prefix by flipping the
- *      final boolean.
+ * 算法:
+ *   1. 把 `rule.pattern` 解析为 `{toolName, argPattern?}`。
+ *   2. 若解析出的 toolName 为 `*`,跳过名称检查;否则按 glob 语义比较,
+ *      使 `mcp__github__*` 能匹配 `mcp__github__list`。
+ *   3. 若规则无 argPattern,名称匹配 → 规则生效。
+ *   4. 否则提取工具特定字段值,与 glob 匹配。对前导 `!` 取反前缀,
+ *      通过翻转最终布尔值处理。
  */
 export function matchesRule(
   rule: PermissionRule,

--- a/packages/agent-core/src/agent/permission/parse-pattern.ts
+++ b/packages/agent-core/src/agent/permission/parse-pattern.ts
@@ -1,12 +1,12 @@
 /**
- * DSL parser for PermissionRule `pattern` strings.
+ * PermissionRule `pattern` 字符串的 DSL 解析器。
  *
- * Grammar:
+ * 文法:
  *   pattern    := toolName ( "(" argPattern ")" )?
- *   toolName   := identifier characters (e.g. `Bash`, `mcp__github__*`)
- *   argPattern := any string (may start with `!` for negation)
+ *   toolName   := 标识符字符(例如 `Bash`、`mcp__github__*`)
+ *   argPattern := 任意字符串(可以 `!` 开头表示取反)
  *
- * Examples:
+ * 示例:
  *   "Write"            → { toolName: "Write" }
  *   "Read(/etc/**)"    → { toolName: "Read", argPattern: "/etc/**" }
  *   "Bash(!rm *)"      → { toolName: "Bash", argPattern: "!rm *" }
@@ -19,9 +19,8 @@ export interface ParsedPattern {
 }
 
 /**
- * Parse a DSL pattern. Throws on malformed input (missing closing paren,
- * empty tool name). The parser is the single source of truth for DSL
- * syntax and is exercised by table-driven tests.
+ * 解析 DSL pattern。输入畸形时抛出(缺少闭合括号、工具名为空)。该解析器是
+ * DSL 语法的唯一事实源,由表驱动测试覆盖。
  */
 export function parsePattern(pattern: string): ParsedPattern {
   const trimmed = pattern.trim();

--- a/packages/agent-core/src/agent/permission/path-glob-match.ts
+++ b/packages/agent-core/src/agent/permission/path-glob-match.ts
@@ -18,8 +18,8 @@ interface PathMatchSemantics {
 }
 
 /**
- * Match ordinary string fields, like command text or search patterns.
- * `*` and `**` work as wildcards, but the value is not treated as a file path.
+ * 匹配普通字符串字段,如命令文本或搜索模式。
+ * `*` 与 `**` 可作通配符,但值不会被当作文件路径处理。
  */
 export function globMatch(value: string, pattern: string, options?: { nocase?: boolean }): boolean {
   if (picomatch.isMatch(value, pattern, options)) return true;
@@ -35,9 +35,9 @@ function stripLeadingDotSlash(value: string): string {
 }
 
 /**
- * Match file path fields, like Read/Write/Edit `path`.
- * Also compares normalized forms, so `./a`, `dir/../a`, and Windows
- * separator or case variants can match the same rule.
+ * 匹配文件路径字段,如 Read/Write/Edit 的 `path`。
+ * 同时比较归一化形式,使 `./a`、`dir/../a` 以及 Windows 分隔符或
+ * 大小写变体能匹配同一条规则。
  */
 export function pathGlobMatch(
   value: string,

--- a/packages/agent-core/src/agent/permission/types.ts
+++ b/packages/agent-core/src/agent/permission/types.ts
@@ -3,27 +3,24 @@ import type { ToolInputDisplay } from '../../tools/display';
 export type PermissionRuleDecision = 'allow' | 'deny' | 'ask';
 
 /**
- * Rule provenance. `session-runtime` is the value used by the runtime
- * "approve for session" path; `turn-override`, `project`, and `user`
- * are reserved for static-loaded rules surfaced by external callers.
+ * 规则来源。`session-runtime` 是运行时「批准本会话」路径使用的值;
+ * `turn-override`、`project`、`user` 预留给由外部调用方呈现的静态加载规则。
  */
 export type PermissionRuleScope = 'turn-override' | 'session-runtime' | 'project' | 'user';
 
 /**
- * Top-level user-facing permission posture. Controls how non-deny rules
- * are treated when the closure is constructed. Independent of rule
- * merging: deny rules always fire regardless of mode.
+ * 面向用户的顶层权限姿态。控制构建闭包时如何处理非 deny 规则。
+ * 独立于规则合并:deny 规则无论何种模式都生效。
  *
- *   - `manual` — rule set drives decision; unmatched tool calls ask
- *   - `yolo`   — only deny rules can block; everything else allows
- *   - `auto`   — caller may bypass rule checks entirely
+ *   - `manual` — 规则集驱动决策;未匹配的工具调用会询问
+ *   - `yolo`   — 仅 deny 规则可阻止;其余全部放行
+ *   - `auto`   — 调用方可完全绕过规则检查
  */
 export type PermissionMode = 'manual' | 'yolo' | 'auto';
 
 /**
- * A single permission rule. `pattern` is the DSL form (`Read(/etc/**)`,
- * `Bash(rm *)`, or bare `Write`). See `parse-pattern.ts` for the parser
- * and `matches-rule.ts` for the matcher.
+ * 单条权限规则。`pattern` 为 DSL 形式(`Read(/etc/**)`、`Bash(rm *)`
+ * 或裸 `Write`)。解析器见 `parse-pattern.ts`,匹配器见 `matches-rule.ts`。
  */
 export interface PermissionRule {
   readonly decision: PermissionRuleDecision;

--- a/packages/agent-core/src/agent/records/types.ts
+++ b/packages/agent-core/src/agent/records/types.ts
@@ -117,16 +117,16 @@ export type AgentRecordOf<K extends keyof AgentRecordEvents> = Extract<
 >;
 
 /**
- * Records whose `type` is `Prefix.*` (e.g. `context`, `turn`).
- * Used by subsystem `restoreRecord` handlers so their switches can be
- * exhaustively checked over the routed subset only.
+ * `type` 为 `Prefix.*`(如 `context`、`turn`)的记录。
+ * 子系统 `restoreRecord` 处理器使用它,使其 switch 只需对被路由的子集
+ * 做穷尽检查。
  */
 export type AgentRecordsOfPrefix<Prefix extends string> = Extract<
   AgentRecord,
   { readonly type: `${Prefix}.${string}` }
 >;
 
-/** Type guard: narrow `AgentRecord` to the prefix subset routed to one handler. */
+/** 类型守卫:把 `AgentRecord` 收窄为路由到某一处理器的前缀子集。 */
 export function isAgentRecordOfPrefix<Prefix extends string>(
   record: AgentRecord,
   prefix: Prefix,

--- a/packages/agent-core/src/agent/turn/canonical-args.ts
+++ b/packages/agent-core/src/agent/turn/canonical-args.ts
@@ -1,6 +1,6 @@
 /**
- * JSON canonicalization used by tool-call telemetry and dedup.
- * Recursively sorts object keys so semantically-equal args produce identical keys.
+ * 工具调用遥测与去重使用的 JSON 规范化。
+ * 递归排序对象键,使语义相等的参数产生相同键。
  */
 export function canonicalTelemetryArgs(args: unknown): string {
   const json = JSON.stringify(sortJsonValue(args));

--- a/packages/agent-core/src/agent/turn/kosong-llm.ts
+++ b/packages/agent-core/src/agent/turn/kosong-llm.ts
@@ -1,18 +1,15 @@
 /**
- * Kosong-backed implementation of the loop `LLM` interface.
+ * loop `LLM` 接口的 Kosong 支撑实现。
  *
- * Bridges the new `loop/llm.ts` contract onto
- * the kosong `generate()` streaming API:
+ * 把新的 `loop/llm.ts` 契约桥接到 kosong 的 `generate()` 流式 API:
  *
- *   - kosong's per-part `onMessagePart` is forwarded to loop per-delta
- *     callbacks (`onTextDelta`, `onThinkDelta`, `onToolCallDelta`).
- *   - loop per-block callbacks (`onTextPart`, `onThinkPart`) only fire
- *     after the kosong stream drains, iterating over the merged
- *     `result.message.content`. Completed
- *     blocks land on the WAL seam, raw deltas never do.
- *   - kosong's finish reasons are preserved as provider diagnostics. The loop
- *     derives loop control from the normalized response shape, not from the
- *     provider's finish-reason spelling.
+ *   - kosong 的逐 part `onMessagePart` 转发为 loop 的逐 delta 回调
+ *     (`onTextDelta`、`onThinkDelta`、`onToolCallDelta`)。
+ *   - loop 的逐块回调(`onTextPart`、`onThinkPart`)只在 kosong 流排空后触发,
+ *     遍历合并后的 `result.message.content`。完成的块落在 WAL 接缝上,
+ *     原始 delta 永不落盘。
+ *   - kosong 的 finish reason 作为 provider 诊断保留。loop 从归一化的响应
+ *     形态推导循环控制,而非 provider 对 finish reason 的拼写。
  */
 
 import {
@@ -48,14 +45,13 @@ export interface KosongLLMConfig {
   readonly systemPrompt: string;
   readonly capability?: ModelCapability;
   /**
-   * Optional override for the kosong `generate()` entry point. Lets the
-   * agent host (and its test harness) inject a scripted generator without
-   * having to substitute the entire LLM implementation.
+   * kosong `generate()` 入口的可选覆盖。使 agent 宿主(及其测试装置)注入
+   * 脚本化生成器,而无需替换整个 LLM 实现。
    */
   readonly generate?: GenerateFn;
   /**
-   * Completion budget config resolved from agent/provider settings. The
-   * final cap is computed per request from the current messages and tools.
+   * 由 agent / provider 设置解析出的完成预算配置。最终上限在每次请求时
+   * 根据当前消息与工具计算。
    */
   readonly completionBudgetConfig?: CompletionBudgetConfig;
 }
@@ -164,10 +160,10 @@ function generateOptions(
 }
 
 /**
- * Get the cache capability from a provider.
+ * 获取 provider 的缓存能力。
  *
- * Safely handles providers that don't implement getCapability or don't have cache.
- * Returns a default capability with 'none' strategy for non-caching providers.
+ * 安全处理未实现 getCapability 或没有缓存的 provider。
+ * 对非缓存 provider 返回带 `'none'` 策略的默认能力。
  */
 export function getProviderCacheCapability(provider: ChatProvider): ProviderCacheCapability {
   if (typeof provider.getCapability !== 'function') {

--- a/packages/agent-core/src/agent/turn/tool-dedup.ts
+++ b/packages/agent-core/src/agent/turn/tool-dedup.ts
@@ -74,15 +74,13 @@ function appendReminder(result: ExecutableToolResult, reminderText: string): Exe
 const DEDUP_PLACEHOLDER_RESULT: ExecutableToolResult = { output: '' };
 
 /**
- * Detects and suppresses repetitive tool calls within a single turn.
+ * 检测并抑制单个 turn 内重复的工具调用。
  *
- * Two behaviours are layered:
- * - Same-step dedup: a duplicate `(toolName, args)` issued in the same LLM step
- *   reuses the original call's result instead of executing the tool twice.
- * - Cross-step dedup: when the exact same call is repeated consecutively
- *   across steps, the result returned to the model is suffixed with a system
- *   reminder at specific streak thresholds (3, 5, and 8) to nudge the model
- *   to try a different approach.
+ * 两层行为叠加:
+ * - 同 step 去重:同一 LLM step 内发出的重复 `(toolName, args)` 复用原调用
+ *   的结果,而不是执行两次工具。
+ * - 跨 step 去重:同一调用连续跨 step 重复时,返回给模型的结果会在特定
+ *   连续阈值(3、5、8)处追加系统提醒,引导模型尝试不同方法。
  */
 export class ToolCallDeduplicator {
   private stepDeferreds = new Map<string, Deferred<ExecutableToolResult>>();
@@ -127,14 +125,12 @@ export class ToolCallDeduplicator {
   }
 
   /**
-   * Called from `prepareToolExecution`. If this `(toolName, args)` was already
-   * seen in the current step, returns a placeholder result so the loop can
-   * skip executing the tool again; the real result is patched in during
-   * `finalizeResult`. Returns `null` for the first occurrence so the normal
-   * execution path proceeds.
+   * 从 `prepareToolExecution` 调用。若此 `(toolName, args)` 在当前 step 中
+   * 已出现过,返回占位结果,使 loop 跳过再次执行工具;真实结果在
+   * `finalizeResult` 期间补入。首次出现返回 `null`,走正常执行路径。
    *
-   * This method is intentionally synchronous to avoid deadlocking the prepare
-   * loop on a deferred that only resolves in the finalize phase.
+   * 此方法刻意保持同步,避免 prepare 循环在仅于 finalize 阶段 resolve 的
+   * deferred 上死锁。
    */
   checkSameStep(toolCallId: string, toolName: string, args: unknown): ExecutableToolResult | null {
     const key = makeKey(toolName, args);
@@ -153,12 +149,10 @@ export class ToolCallDeduplicator {
   }
 
   /**
-   * Called from `finalizeToolResult`, in provider order. For first-occurrence
-   * calls, projects the consecutive streak ending at this call and, if the
-   * threshold is reached, appends the system reminder, then resolves the
-   * deferred so subsequent same-step dups can fetch the real result. For
-   * synthetic duplicates, awaits the original's deferred and returns its
-   * value, discarding the placeholder.
+   * 从 `finalizeToolResult` 调用,按 provider 顺序。对首次出现的调用,
+   * 计算止于此调用的连续重复次数,达到阈值时追加系统提醒,然后 resolve
+   * deferred,使后续同 step 重复调用可取到真实结果。对合成重复调用,
+   * 等待原调用的 deferred 并返回其值,丢弃占位结果。
    */
   async finalizeResult(
     toolCallId: string,

--- a/packages/agent-core/src/config/login-provider-registry.ts
+++ b/packages/agent-core/src/config/login-provider-registry.ts
@@ -1,19 +1,18 @@
 /**
- * loginProviderRegistry — single source of truth for /login provider type choices.
+ * loginProviderRegistry — /login 提供方类型选项的唯一事实源。
  *
- * Only includes types whose base-URL propagation is end-to-end functional.
- * `google-genai` / `vertexai` are deliberately omitted (ADR 0016): their runtime
- * providers do not consume a user-supplied baseUrl.
+ * 只包含 base-URL 传播端到端可用的类型。`google-genai` / `vertexai`
+ * 刻意省略(ADR 0016):其运行时提供方不消费用户提供的 baseUrl。
  *
- * The `API_TYPE_OPTIONS` in login-flow.ts and `DEFAULT_BASE_URL` lookup are
- * both derived from this registry.
+ * login-flow.ts 中的 `API_TYPE_OPTIONS` 与 `DEFAULT_BASE_URL` 查找
+ * 均派生自本注册表。
  */
 
-/** Static entry for one login-capable provider type. */
+/** 单个可登录提供方类型的静态条目。 */
 export interface LoginProviderRegistryEntry {
-  /** Human-readable label shown in the choice picker. */
+  /** 选择器中展示的人类可读标签。 */
   readonly label: string;
-  /** Official default base URL (used when user leaves the input empty). */
+  /** 官方默认 base URL(用户留空输入时使用)。 */
   readonly defaultBaseUrl: string;
 }
 
@@ -34,7 +33,7 @@ export const loginProviderRegistry = {
 
 export type LoginProviderType = keyof typeof loginProviderRegistry;
 
-/** Choices array derived from registry keys — safe to pass to ChoicePicker. */
+/** 由注册表键派生的选项数组——可安全传给 ChoicePicker。 */
 export function getLoginProviderOptions(): ReadonlyArray<{
   value: LoginProviderType;
   label: string;

--- a/packages/agent-core/src/config/resolve.ts
+++ b/packages/agent-core/src/config/resolve.ts
@@ -1,7 +1,7 @@
 const TRUE_BOOLEAN_ENV_VALUES = new Set(['1', 'true', 'yes', 'on']);
 const FALSE_BOOLEAN_ENV_VALUES = new Set(['0', 'false', 'no', 'off']);
 
-/** Default print-mode background wait ceiling (seconds). ADR-0029 / PRD-0023. */
+/** 打印模式后台等待上限默认值(秒)。ADR-0029 / PRD-0023。 */
 export const DEFAULT_PRINT_WAIT_CEILING_S = 3600;
 
 export const PRINT_WAIT_CEILING_ENV_KEY = 'BYF_PRINT_WAIT_CEILING_S';
@@ -15,8 +15,8 @@ export interface ResolveConfigValueInput<T> {
 }
 
 /**
- * Precedence: env (parsed) → configValue → defaultValue.
- * Matches docs: environment variables override `config.toml`.
+ * 优先级:env(解析后)→ configValue → defaultValue。
+ * 与文档一致:环境变量覆盖 `config.toml`。
  */
 export function resolveConfigValue<T>(input: ResolveConfigValueInput<T>): T {
   return input.parseEnv(input.env?.[input.envKey]) ?? input.configValue ?? input.defaultValue;
@@ -31,9 +31,8 @@ export function parseBooleanEnv(value: string | undefined): boolean | undefined 
 }
 
 /**
- * Parse a positive integer env value. Empty, non-numeric, non-finite, or
- * non-positive values return `undefined` so resolution can fall through
- * (never returns `NaN`, which would break `??` chains).
+ * 解析正整数环境变量值。空、非数字、非有限或非正值返回 `undefined`,
+ * 使解析可以回退(绝不返回 `NaN`,那会破坏 `??` 链)。
  */
 export function parsePositiveIntEnv(value: string | undefined): number | undefined {
   if (value === undefined) return undefined;
@@ -45,9 +44,9 @@ export function parsePositiveIntEnv(value: string | undefined): number | undefin
 }
 
 /**
- * Resolve print-mode background wait ceiling in seconds.
- * Precedence: `BYF_PRINT_WAIT_CEILING_S` → `background.printWaitCeilingS` → 3600.
- * Always returns a finite positive integer (never NaN).
+ * 解析打印模式后台等待上限(秒)。
+ * 优先级:`BYF_PRINT_WAIT_CEILING_S` → `background.printWaitCeilingS` → 3600。
+ * 始终返回有限的正整数(绝不返回 NaN)。
  */
 export function resolvePrintWaitCeilingS(input: {
   readonly env?: Readonly<Record<string, string | undefined>>;

--- a/packages/agent-core/src/errors/classes.ts
+++ b/packages/agent-core/src/errors/classes.ts
@@ -1,17 +1,17 @@
 import type { ByfErrorCode } from './codes';
 
 export interface ByfErrorOptions {
-  /** JSON-serializable structured details. */
+  /** 可 JSON 序列化的结构化细节。 */
   readonly details?: Record<string, unknown>;
-  /** Original error or value. Local-only; never serialized to the wire. */
+  /** 原始错误或值。仅本地;绝不序列化到 wire 上。 */
   readonly cause?: unknown;
 }
 
 /**
- * The single Byf error class.
+ * 唯一的 Byf 错误类。
  *
- * Discrimination is always by `code`. Cross-process consumers receive
- * `ByfErrorPayload` and must branch on `code` rather than class identity.
+ * 判别始终依据 `code`。跨进程消费者收到 `ByfErrorPayload`,
+ * 必须按 `code` 分支而非类身份。
  */
 export class ByfError extends Error {
   readonly code: ByfErrorCode;

--- a/packages/agent-core/src/errors/codes.ts
+++ b/packages/agent-core/src/errors/codes.ts
@@ -1,12 +1,12 @@
 /**
- * Error codes for Byf Core's public error protocol.
+ * Byf Core 公共错误协议的错误码。
  *
- * `ErrorCodes` is the source of truth for every code Byf Core may emit.
- * Downstream consumers (SDK, RPC clients, telemetry, agent-facing docs)
- * should depend on these string values rather than on class identity.
+ * `ErrorCodes` 是 Byf Core 可能发出的每个码的唯一事实源。下游消费者
+ * (SDK、RPC 客户端、遥测、面向 agent 的文档)应依赖这些字符串值,
+ * 而非类身份。
  *
- * Codes follow `domain.reason`. Adding a code is a minor change; renaming
- * or removing one is a major change.
+ * 码遵循 `domain.reason` 形式。新增一个码是 minor 变更;重命名或移除
+ * 一个是 major 变更。
  */
 export const ErrorCodes = {
   CONFIG_INVALID: 'config.invalid',

--- a/packages/agent-core/src/errors/serialize.ts
+++ b/packages/agent-core/src/errors/serialize.ts
@@ -9,14 +9,13 @@ import { ByfError } from './classes';
 import { ErrorCodes, BYF_ERROR_INFO, type ByfErrorCode } from './codes';
 
 /**
- * Wire-safe payload of a Byf error.
+ * Byf 错误的 wire 安全负载。
  *
- * The structure passed across process / language boundaries (RPC, events,
- * telemetry, SDK wrappers). Class identity does not survive the boundary;
- * downstream code must branch on `code` rather than `instanceof`.
+ * 这是跨进程 / 跨语言边界(RPC、事件、遥测、SDK 包装)传递的结构。类身份
+ * 无法跨过边界;下游代码必须按 `code` 分支而非 `instanceof`。
  *
- * `details` is JSON-serialized. `cause` is intentionally absent -- it is
- * local-only diagnostic state and must not cross the boundary.
+ * `details` 被 JSON 序列化。`cause` 刻意缺席——它是仅本地的诊断状态,
+ * 不得跨边界。
  */
 export interface ByfErrorPayload {
   readonly code: ByfErrorCode;
@@ -26,16 +25,15 @@ export interface ByfErrorPayload {
   readonly retryable: boolean;
 }
 
-/** Type guard for ByfError. */
+/** ByfError 的类型守卫。 */
 export function isByfError(error: unknown): error is ByfError {
   return error instanceof ByfError;
 }
 
 /**
- * Build a ByfErrorPayload directly from a code + message (no Error instance
- * needed). Use this for synthetic error events that are signaled, not thrown
- * -- e.g. "turn busy" or "compaction failed". `retryable` is filled from
- * BYF_ERROR_INFO so callers cannot drift out of sync with the registry.
+ * 直接由 code + message 构建 ByfErrorPayload(无需 Error 实例)。用于以信号
+ * 而非抛出的方式表达的错误事件——例如「turn 忙碌」或「压缩失败」。
+ * `retryable` 从 BYF_ERROR_INFO 填充,使调用方不会与注册表脱节。
  */
 export function makeErrorPayload(
   code: ByfErrorCode,
@@ -52,17 +50,16 @@ export function makeErrorPayload(
 }
 
 /**
- * Normalize any value into a ByfErrorPayload.
+ * 把任意值归一化为 ByfErrorPayload。
  *
- * Recognized errors:
- * - `ByfError`: passthrough.
- * - `APIStatusError`: 429 -> rate_limit, 401 -> auth_error, otherwise -> api_error.
- * - `APIConnectionError` / `APITimeoutError`: connection_error.
- * - `ChatProviderError`: api_error.
- * - Heuristic "Model not set" / "Provider not set" messages: model.not_configured.
+ * 可识别的错误:
+ * - `ByfError`:直接透传。
+ * - `APIStatusError`:429 → rate_limit,401 → auth_error,其余 → api_error。
+ * - `APIConnectionError` / `APITimeoutError`:connection_error。
+ * - `ChatProviderError`:api_error。
+ * - 启发式匹配「Model not set」/「Provider not set」消息:model.not_configured。
  *
- * Anything else collapses to `internal`. We never echo `cause` or stack on
- * the wire.
+ * 其余一切归并为 `internal`。我们绝不在 wire 上回显 `cause` 或堆栈。
  */
 export function toByfErrorPayload(error: unknown): ByfErrorPayload {
   if (isByfError(error)) {
@@ -138,9 +135,8 @@ export function toByfErrorPayload(error: unknown): ByfErrorPayload {
 }
 
 /**
- * Rehydrate a ByfErrorPayload into a ByfError. Used by SDK boundary code
- * receiving errors over RPC to re-surface them with a real class so
- * in-process consumers can still use `instanceof`.
+ * 把 ByfErrorPayload 重新水合为 ByfError。SDK 边界代码经 RPC 收到错误后用它
+ * 以真实类重新呈现,使进程内消费者仍可使用 `instanceof`。
  */
 export function fromByfErrorPayload(payload: ByfErrorPayload): ByfError {
   return new ByfError(payload.code, payload.message, {

--- a/packages/agent-core/src/logging/logger.ts
+++ b/packages/agent-core/src/logging/logger.ts
@@ -397,20 +397,19 @@ function mergeCtx(
 }
 
 /**
- * Root logger. Import and use directly for events that don't belong to any
- * session (CLI startup, harness construction, etc.):
+ * 根日志器。对不属于任何会话的事件(CLI 启动、harness 构造等)直接导入使用:
  *
  *   import { log } from 'byf-sdk';
  *   log.info('byf starting', { version });
  *
- * For events scoped to a session or agent, use the parent's `log` field:
+ * 对限定于会话或 agent 的事件,使用父级的 `log` 字段:
  *
  *   session.log.error('mcp initial load failed', error);
  *   agent.log.error('turn failed', { turnId, error });
  *
- * Late-binding: methods look up the current `RootLogger` on every call, so
- * importing `log` at module load (before `ByfHarness` configures the root)
- * is safe — calls during the pre-configure window are silent noops.
+ * 晚绑定:方法在每次调用时查找当前 `RootLogger`,因此在模块加载时
+ * (`ByfHarness` 配置根日志器之前)导入 `log` 是安全的——配置前窗口内的
+ * 调用是静默空操作。
  */
 export const log: Logger = new LoggerImpl({});
 

--- a/packages/agent-core/src/logging/resolve-config.ts
+++ b/packages/agent-core/src/logging/resolve-config.ts
@@ -13,11 +13,10 @@ export interface ResolveLoggingInput {
 }
 
 /**
- * Build the runtime `LoggingConfig` from env vars + defaults.
+ * 由环境变量 + 默认值构建运行时 `LoggingConfig`。
  *
- * v1 deliberately does not read `config.toml [logging]` — the schema is in
- * flux and reading it adds a startup-time failure surface. Users who need to
- * override the defaults set env vars:
+ * v1 刻意不读取 `config.toml [logging]`——schema 仍在变动,读取它会增加
+ * 启动期失败面。需要覆盖默认值的用户设置环境变量:
  *
  *   BYF_LOG_LEVEL=debug
  *   BYF_LOG_GLOBAL_MAX_BYTES=... BYF_LOG_GLOBAL_FILES=...

--- a/packages/agent-core/src/logging/types.ts
+++ b/packages/agent-core/src/logging/types.ts
@@ -3,16 +3,14 @@ export type LogLevel = 'off' | 'error' | 'warn' | 'info' | 'debug';
 export type LogContext = Record<string, unknown>;
 
 /**
- * Second argument to `log.error / warn / info / debug`.
+ * `log.error / warn / info / debug` 的第二个参数。
  *
- * Three usage shapes, detected at runtime:
- *   - `Error`     → stack is extracted onto the entry
- *   - `LogContext` (object) → merged into entry context; if it contains
- *                              `{ error: Error }`, that field is pulled out
- *                              and its stack extracted (bunyan-style)
- *   - `unknown`   → typically a `catch` binding; treated as an Error if
- *                   it's an Error instance, otherwise stringified into a
- *                   `reason` field
+ * 三种用法形态,运行时检测:
+ *   - `Error`     → 堆栈被提取到条目上
+ *   - `LogContext`(对象) → 合并进条目上下文;若含 `{ error: Error }`,
+ *                          该字段会被取出并提取其堆栈(bunyan 风格)
+ *   - `unknown`   → 通常是 `catch` 绑定;是 Error 实例则按 Error 处理,
+ *                   否则字符串化为 `reason` 字段
  */
 export type LogPayload = unknown;
 
@@ -22,14 +20,14 @@ export interface Logger {
   info(message: string, payload?: LogPayload): void;
   debug(message: string, payload?: LogPayload): void;
   /**
-   * Returns a new logger that adds `ctx` to every entry it emits. The bound
-   * context wins over per-call payload context, so callers can't accidentally
-   * overwrite ownership fields like `sessionId` / `agentId`:
+   * 返回一个新 logger,为其发出的每条条目添加 `ctx`。绑定上下文优先于
+   * 每次调用的负载上下文,使调用方不会意外覆盖 `sessionId` / `agentId`
+   * 等归属字段:
    *
    *   finalCtx = { ...payloadCtx, ...boundCtx }
    *
-   * Children chain — `parent.createChild({a: 1}).createChild({b: 2})` binds
-   * both.
+   * 子级可链式继承——`parent.createChild({a: 1}).createChild({b: 2})`
+   * 同时绑定两者。
    */
   createChild(ctx: LogContext): Logger;
 }
@@ -67,11 +65,11 @@ export interface SessionAttachInput {
 export interface RootLogger {
   configure(config: LoggingConfig): Promise<void>;
   attachSession(input: SessionAttachInput): SessionLogHandle;
-  /** False if any sink could not flush its pending batch. */
+  /** 任一 sink 未能刷出待处理批次时为 false。 */
   flush(): Promise<boolean>;
-  /** False if the global sink could not flush; true when there is no global sink. */
+  /** 全局 sink 未能刷出时为 false;无全局 sink 时为 true。 */
   flushGlobal(): Promise<boolean>;
-  /** False if the session sink could not flush; true when there is no active sink. */
+  /** 会话 sink 未能刷出时为 false;无活跃 sink 时为 true。 */
   flushSession(sessionId: string): Promise<boolean>;
   flushSync(): void;
   isConfigured(): boolean;

--- a/packages/agent-core/src/loop/errors.ts
+++ b/packages/agent-core/src/loop/errors.ts
@@ -1,5 +1,5 @@
 /**
- * Loop-local error helpers.
+ * Loop 局部的错误辅助工具。
  */
 
 import { isAbortError } from '@byfriends/kosong';

--- a/packages/agent-core/src/prompt-plan/builder.ts
+++ b/packages/agent-core/src/prompt-plan/builder.ts
@@ -117,34 +117,30 @@ function findImplicitBoundaries(prompt: string): number[] {
 }
 
 /**
- * Diagnostics for the system prompt's cache-boundary structure.
+ * 系统提示词缓存边界结构的诊断。
  *
- * `buildPromptPlan` splits the prompt on {@link IMPLICIT_BOUNDARY_HEADERS}.
- * ADR 0013 requires all three headers to be present and ordered so the
- * 4-block cache architecture (base / project / workingEnvironment /
- * sessionContext) stays intact — a missing header silently degrades
- * caching (e.g. OpenAI's `prompt_cache_key` stops being stable across
- * sessions). These issues are otherwise invisible, since
- * {@link findImplicitBoundaries} skips missing headers without error.
+ * `buildPromptPlan` 按 {@link IMPLICIT_BOUNDARY_HEADERS} 切分提示词。
+ * ADR 0013 要求三个标题全部存在且有序,4 块缓存架构
+ * (base / project / workingEnvironment / sessionContext)才能保持完整——
+ * 缺少标题会静默劣化缓存(例如 OpenAI 的 `prompt_cache_key` 跨会话不再稳定)。
+ * 这些问题是隐形的,因为 {@link findImplicitBoundaries} 会无错跳过缺失标题。
  */
 export interface BoundaryDiagnostics {
-  /** Boundary headers expected but absent from the prompt. */
+  /** 期望出现但提示词中缺失的边界标题。 */
   readonly missingHeaders: readonly string[];
-  /** Boundary headers found in a position inconsistent with their declared order. */
+  /** 出现位置与声明顺序不一致的边界标题。 */
   readonly outOfOrderHeaders: readonly string[];
 }
 
 /**
- * Detect cache-boundary structural issues in a rendered system prompt.
+ * 检测渲染后的系统提示词中的缓存边界结构问题。
  *
- * Pure, side-effect free. Returns empty arrays when the prompt contains
- * all expected boundary headers in their declared order. Consumers (e.g.
- * the turn layer) may log the result; {@link buildPromptPlan} itself
- * never throws on these issues, so this function is the only way to
- * observe silent cache degradation.
+ * 纯函数,无副作用。提示词按声明顺序包含全部期望标题时返回空数组。
+ * 消费者(如 turn 层)可记录结果;{@link buildPromptPlan} 自身对这些
+ * 问题绝不抛出,因此本函数是观察静默缓存劣化的唯一途径。
  *
- * @param prompt - The fully rendered system prompt to inspect
- * @returns Diagnostics describing missing or out-of-order boundary headers
+ * @param prompt - 待检查的完整渲染系统提示词
+ * @returns 描述缺失或乱序边界标题的诊断
  */
 export function detectBoundaryDiagnostics(prompt: string): BoundaryDiagnostics {
   const missingHeaders: string[] = [];
@@ -267,14 +263,14 @@ function hasImplicitBoundaries(prompt: string): boolean {
 }
 
 /**
- * Build a prompt plan from a rendered system prompt and provider cache capability.
+ * 由渲染后的系统提示词与 provider 缓存能力构建提示计划。
  *
- * This function parses cache boundary markers from the system prompt and creates
- * a structured plan with named blocks, each with an appropriate cache scope.
+ * 本函数解析系统提示词中的缓存边界标记,创建带命名块的结构化计划,
+ * 每个块带有合适的缓存作用域。
  *
- * @param renderedSystemPrompt - The fully rendered system prompt (may contain `__CACHE_BOUNDARY__` markers)
- * @param providerCacheCapability - The provider's cache capability (for scope filtering)
- * @returns A prompt plan with cacheable blocks
+ * @param renderedSystemPrompt - 完整渲染的系统提示词(可能含 `__CACHE_BOUNDARY__` 标记)
+ * @param providerCacheCapability - provider 的缓存能力(用于作用域过滤)
+ * @returns 带可缓存块的提示计划
  *
  * @example
  * ```ts

--- a/packages/agent-core/src/rpc/core-api.ts
+++ b/packages/agent-core/src/rpc/core-api.ts
@@ -72,12 +72,12 @@ export interface ExportSessionPayload {
   readonly sessionId: string;
   readonly outputPath?: string;
   /**
-   * When true, the active global diagnostic log (`$BYF_HOME/logs/byf.log`)
-   * is copied into the zip at `logs/global/byf.log`. Off by default to
-   * avoid bundling events from concurrent sessions / other projects.
+   * 为 true 时,活跃的全局诊断日志(`$BYF_HOME/logs/byf.log`)会被复制进
+   * zip 的 `logs/global/byf.log`。默认关闭,避免打包并发会话 / 其他项目
+   * 的事件。
    */
   readonly includeGlobalLog?: boolean;
-  /** Host version to record in the export manifest. */
+  /** 记录到导出 manifest 的宿主版本。 */
   readonly version: string;
 }
 
@@ -92,9 +92,9 @@ export interface ExportSessionManifest {
   readonly sessionLastActivity?: string;
   readonly title?: string;
   readonly workspaceDir?: string;
-  /** zip-relative path to the session diagnostic log when present. */
+  /** 会话诊断日志存在时的 zip 相对路径。 */
   readonly sessionLogPath?: string;
-  /** zip-relative path to the bundled global diagnostic log (only when --include-global-log). */
+  /** 打包的全局诊断日志的 zip 相对路径(仅当 --include-global-log 时)。 */
   readonly globalLogPath?: string;
 }
 
@@ -179,7 +179,7 @@ export interface SetActiveToolsPayload {
 }
 export interface StopBackgroundPayload {
   readonly taskId: string;
-  /** Free-form human-readable reason persisted with the task record. */
+  /** 随任务记录持久化的自由格式人类可读原因。 */
   readonly reason?: string;
 }
 export interface GetBackgroundOutputPayload {
@@ -191,12 +191,11 @@ export interface GetBackgroundOutputPathPayload {
 }
 export interface GetBackgroundPayload {
   /**
-   * When omitted, returns all tasks (including terminal/lost). Pass
-   * `true` to filter down to active-only — useful for model-facing
-   * surfaces. UI/TUI consumers should leave it undefined.
+   * 省略时返回所有任务(含 terminal/lost)。传 `true` 过滤为仅活跃任务——
+   * 对面向模型的表面有用。UI/TUI 消费者应保持 undefined。
    */
   readonly activeOnly?: boolean;
-  /** Caps the number of tasks returned. When omitted, returns all matching tasks. */
+  /** 限制返回的任务数。省略时返回全部匹配任务。 */
   readonly limit?: number;
 }
 export interface SkillSummary {
@@ -261,7 +260,7 @@ export interface GetCronTasksResult {
   readonly tasks: readonly CronTaskSnapshot[];
 }
 
-/** Host-path cron delete (PRD-0024 / ADR-0030). Not a tool permission surface. */
+/** 宿主路径 cron 删除(PRD-0024 / ADR-0030)。不是工具权限表面。 */
 export interface DeleteCronTaskPayload {
   readonly id: string;
 }

--- a/packages/agent-core/src/rpc/core-impl.ts
+++ b/packages/agent-core/src/rpc/core-impl.ts
@@ -114,29 +114,26 @@ export interface ByfCoreOptions {
 }
 
 /**
- * Narrow handle returned by {@link createByfCore}.
+ * {@link createByfCore} 返回的窄句柄。
  *
- * SDK consumers only need the RPC channel (a `PromisableMethods<CoreAPI>`
- * that can be fed to `createRPC`) plus the two resolved paths. Exposing the
- * full `ByfCore` concrete class would leak the engine's 40+ internal members
- * (sessions map, sdk Promise, providerManager, sessionStore, telemetry, …)
- * through the SDK type surface and break the ADR 0006 isolation seam.
- * See ADR 0006 (Monorepo Layered Architecture).
+ * SDK 消费者只需要 RPC 通道(一个可喂给 `createRPC` 的
+ * `PromisableMethods<CoreAPI>`)加两个解析后的路径。暴露完整的 `ByfCore`
+ * 具体类会把引擎的 40+ 内部成员(sessions 映射、sdk Promise、
+ * providerManager、sessionStore、telemetry …)泄漏进 SDK 类型表面,
+ * 破坏 ADR 0006 的隔离接缝。见 ADR 0006(Monorepo 分层架构)。
  */
 export interface CoreEngineHandle {
-  /** CoreRPC-ready core: pass to the first slot of `createRPC<CoreAPI, SDKAPI>()`. */
+  /** CoreRPC 就绪的 core:传给 `createRPC<CoreAPI, SDKAPI>()` 的第一个槽位。 */
   readonly core: PromisableMethods<CoreAPI>;
   readonly homeDir: string;
   readonly configPath: string;
 }
 
 /**
- * Construct a {@link ByfCore} engine and return a narrow {@link CoreEngineHandle}.
+ * 构造 {@link ByfCore} 引擎,返回窄 {@link CoreEngineHandle}。
  *
- * This is the supported way for the SDK layer to bootstrap the engine. The
- * concrete `ByfCore` class is intentionally not re-exported from the package
- * public surface (see `rpc/index.ts`); callers program against the
- * {@link CoreAPI} contract via this factory.
+ * 这是 SDK 层引导引擎的受支持方式。具体 `ByfCore` 类刻意不重导出到包公开
+ * 面(见 `rpc/index.ts`);调用方经本工厂面向 {@link CoreAPI} 契约编程。
  */
 export function createByfCore(
   rpcClient: CoreRPCClient,

--- a/packages/agent-core/src/rpc/events.ts
+++ b/packages/agent-core/src/rpc/events.ts
@@ -16,25 +16,25 @@ export interface UsageStatus {
   readonly byModel?: Record<string, TokenUsage>;
   readonly currentTurn?: TokenUsage;
   readonly total?: TokenUsage;
-  /** Cache hit rate across all recorded usage (0–1), undefined when no data. */
+  /** 全部已记录用量的缓存命中率(0–1);无数据时为 undefined。 */
   readonly cacheHitRate?: CacheHitRate;
   /**
-   * Estimated input-token distribution across six categories, computed on
-   * demand by the Agent (it owns config/tools/context). `undefined` when the
-   * caller has not requested it. See {@link InputTokenBreakdown}.
+   * 六个类别的估算输入 token 分布,由 Agent 按需计算(它拥有
+   * config/tools/context)。调用方未请求时为 `undefined`。
+   * 见 {@link InputTokenBreakdown}。
    */
   readonly inputBreakdown?: InputTokenBreakdown;
   /**
-   * Break-side attribution (PRD-0029 R3): the most recent static-prefix change
-   * detected this session. `undefined` when no churn has occurred. `turnsAgo` is
-   * `undefined` for churns replayed from the journal (turn id not persisted).
+   * 破坏侧归因(PRD-0029 R3):本会话检测到的最远一次静态前缀变化。
+   * 未发生 churn 时为 `undefined`。从 journal 重放的 churn 其 `turnsAgo`
+   * 为 `undefined`(turn id 未持久化)。
    */
   readonly lastCacheChurn?: {
     readonly blockName: string;
     readonly cacheScope: CacheScope;
     readonly turnsAgo?: number;
   };
-  /** Total `context.cache_churn` events this session (PRD-0029 R3). `undefined` when zero. */
+  /** 本会话 `context.cache_churn` 事件总数(PRD-0029 R3)。为零时为 `undefined`。 */
   readonly cacheChurnCount?: number;
 }
 
@@ -319,7 +319,7 @@ export interface GoalUpdatedEvent {
   readonly change?: GoalChange;
 }
 
-/** Fired when a session-scoped cron task delivers its prompt (PRD-0023 R3.3). */
+/** 会话内 cron 任务投递其提示词时触发(PRD-0023 R3.3)。 */
 export interface CronFiredEvent {
   readonly type: 'cron.fired';
   readonly origin: {

--- a/packages/agent-core/src/session/git-context.ts
+++ b/packages/agent-core/src/session/git-context.ts
@@ -1,11 +1,9 @@
 /**
- * Git repository context for explore subagents.
+ * 供 explore subagent 使用的 Git 仓库上下文。
  *
- * `collectGitContext` produces a `<git-context>` block that is prepended to a
- * fresh explore subagent's prompt so it can orient itself in the repository
- * before searching. Every git command is individually guarded — a single
- * failure never aborts the whole collection — and remote URLs are sanitized
- * so internal infrastructure is not surfaced to the model.
+ * `collectGitContext` 生成一个 `<git-context>` 块,前置到全新 explore subagent
+ * 的提示词中,使其在搜索前能在仓库中定位自己。每条 git 命令都单独防护——
+ * 单次失败不会中止整个收集——远程 URL 会被清洗,内部基础设施不会暴露给模型。
  */
 
 import type { Readable } from 'node:stream';
@@ -28,10 +26,10 @@ const ALLOWED_HOSTS = [
 ] as const;
 
 /**
- * Collect git context for the explore agent.
+ * 为 explore agent 收集 git 上下文。
  *
- * Returns a formatted `<git-context>` block, or an empty string if the
- * directory is not a git repository or no useful information was collected.
+ * 返回格式化后的 `<git-context>` 块;目录不是 git 仓库或未收集到有用信息时
+ * 返回空字符串。
  */
 export async function collectGitContext(kaos: Kaos, cwd: string): Promise<string> {
   // Quick check: is this a git repo?
@@ -91,8 +89,8 @@ export async function collectGitContext(kaos: Kaos, cwd: string): Promise<string
 }
 
 /**
- * Return the remote URL if it points to a well-known public host, stripping
- * credentials from HTTPS URLs. Returns `null` for unrecognized hosts.
+ * 若远程 URL 指向知名公共主机则返回之,并从 HTTPS URL 中剥离凭据。
+ * 无法识别的主机返回 `null`。
  */
 export function sanitizeRemoteUrl(remoteUrl: string): string | null {
   // SSH format: git@host:owner/repo.git — no credentials possible.
@@ -116,9 +114,9 @@ export function sanitizeRemoteUrl(remoteUrl: string): string | null {
 }
 
 /**
- * Extract the project path from a git remote URL — `owner/repo`, or the full
- * `group/subgroup/repo` for nested namespaces (e.g. GitLab subgroups).
- * Supports scp-like SSH (`git@host:path`) and URL forms (`https://`, `ssh://`).
+ * 从 git 远程 URL 提取项目路径——`owner/repo`,嵌套命名空间(如 GitLab 子组)
+ * 则为完整的 `group/subgroup/repo`。支持 scp 风格 SSH(`git@host:path`)
+ * 与 URL 形式(`https://`、`ssh://`)。
  */
 export function parseProjectName(remoteUrl: string): string | null {
   // scp-like SSH (`git@host:owner/.../repo.git`) is not a valid URL — match it

--- a/packages/agent-core/src/tools/builtin/goal/outcome-prompts.ts
+++ b/packages/agent-core/src/tools/builtin/goal/outcome-prompts.ts
@@ -1,30 +1,28 @@
 /**
- * Pure functions that render goal lifecycle transitions into user-facing
- * prose (PRD-0019 R14). They run from the `goal.updated` event snapshot in
- * both live and replay paths, so any change here automatically stays
- * consistent across both rendering modes.
+ * 把 goal 生命周期转换渲染为用户可见文案的纯函数(PRD-0019 R14)。
+ * 它们在 live 与 replay 两条路径中都基于 `goal.updated` 事件快照运行,
+ * 因此这里的任何改动都会自动保持两种渲染模式一致。
  *
- * Kept dependency-free on purpose: the CLI (#205) imports these so the
- * wording is shared instead of duplicated.
+ * 刻意保持零依赖:CLI(#205)导入这些函数,使措辞共享而非重复。
  */
 
 import type { GoalSnapshot } from '../../../agent/goal/types';
 
-/** Render the completion summary line for a finished goal. */
+/** 渲染已完成 goal 的完成摘要行。 */
 export function renderCompletionSummary(snapshot: GoalSnapshot, reason?: string): string {
   const usageLine = formatUsage(snapshot);
   const tail = reason && reason.trim().length > 0 ? ` — ${reason.trim()}` : '';
   return `Goal complete: ${snapshot.objective}${tail}\n${usageLine}`;
 }
 
-/** Render the blocked-reason line for a goal that hit a blocker. */
+/** 渲染遇到阻塞器的 goal 的阻塞原因行。 */
 export function renderBlockedReason(snapshot: GoalSnapshot): string {
   const usageLine = formatUsage(snapshot);
   const reason = snapshot.blockedReason ?? 'unknown blocker';
   return `Goal blocked: ${snapshot.objective} — ${reason}\n${usageLine}`;
 }
 
-/** Render a single-line snapshot for `/goal status`. */
+/** 渲染 `/goal status` 的单行快照。 */
 export function renderStatusLine(snapshot: GoalSnapshot): string {
   const budgetLine = formatBudgetRemaining(snapshot);
   const parts = [

--- a/packages/agent-core/src/tools/support/file-type.ts
+++ b/packages/agent-core/src/tools/support/file-type.ts
@@ -1,5 +1,5 @@
 /**
- * file-type — magic-byte + extension detection. No npm dependency.
+ * file-type — magic-byte + 扩展名检测。无 npm 依赖。
  */
 
 export const MEDIA_SNIFF_BYTES = 512;
@@ -238,13 +238,11 @@ export interface ImageDimensions {
 }
 
 /**
- * Best-effort pixel-dimension reader for common raster formats.
+ * 常见栅格格式像素尺寸的尽力读取器。
  *
- * Inspects only the fixed region near the start of the file where each
- * format records its dimensions (the IHDR/DIB header, the RIFF chunk
- * after the `WEBP` tag, or the first JPEG SOFn segment). Returns `null`
- * for formats whose dimensions are not locatable from that region, or
- * when the supplied buffer is too short to cover it.
+ * 只检查文件起始附近各格式记录尺寸的固定区域(IHDR/DIB 头部、
+ * `WEBP` 标签后的 RIFF chunk,或首个 JPEG SOFn 段)。对无法从该区域
+ * 定位尺寸的格式,或提供的缓冲区过短不足以覆盖时,返回 `null`。
  */
 export function sniffImageDimensions(data: Buffer | Uint8Array): ImageDimensions | null {
   const buf = toBuffer(data);

--- a/packages/agent-core/src/tools/support/image-compress.ts
+++ b/packages/agent-core/src/tools/support/image-compress.ts
@@ -1,20 +1,16 @@
 /**
- * image-compress — downscale + re-encode large images so they fit the
- * model's token / context budget.
+ * image-compress — 缩小 + 重编码大图,使其适配模型的 token / 上下文预算。
  *
- * ReadMediaFileTool sends images as base64 data URLs. A full-resolution
- * screenshot easily blows the context budget, so before base64-encoding we
- * run this pipeline: cap the longest edge, then walk a JPEG quality ladder
- * until the result fits a byte budget.
+ * ReadMediaFileTool 以 base64 data URL 发送图片。全分辨率截图很容易撑爆
+ * 上下文预算,因此在 base64 编码前运行本管线:限制最长边,然后沿 JPEG
+ * 质量阶梯下降,直到结果落入字节预算。
  *
- * Scope (see ADR / issue #233): Jimp's default plugins decode PNG/JPEG/GIF/
- * BMP/TIFF but NOT WebP, and re-encoding GIF drops animation. WebP and GIF
- * therefore pass through unchanged (they are already small / efficient).
- * BMP is rejected by the format gate (not in MODEL_ACCEPTED_IMAGE_MIMES)
- * before compression runs, so it is intentionally not in the compressible
- * set. Effective compression targets PNG and JPEG. This is the BYF-
- * appropriate subset — no area-average resizing, no full-format-policy
- * machinery.
+ * 范围(见 ADR / issue #233):Jimp 默认插件可解码 PNG/JPEG/GIF/BMP/TIFF,
+ * 但**不**支持 WebP,且重编码 GIF 会丢失动画。因此 WebP 与 GIF 原样透传
+ * (它们本就小 / 高效)。BMP 在压缩运行前就被格式闸门拒绝(不在
+ * MODEL_ACCEPTED_IMAGE_MIMES 中),因此刻意不在可压缩集合内。实际压缩目标
+ * 是 PNG 与 JPEG。这是 BYF 适当的子集——无面积平均缩放,无完整格式策略
+ * 机制。
  */
 
 import { Jimp } from 'jimp';
@@ -26,27 +22,25 @@ type DecodedImage = Awaited<ReturnType<typeof Jimp.read>>;
 
 // ── Tunables ─────────────────────────────────────────────────────────
 
-/** Longest edge a decoded image is allowed to keep, in pixels. */
+/** 解码后图像允许保留的最长边,单位像素。 */
 export const MAX_IMAGE_EDGE_PX = 2000;
-/** Soft byte budget; images already under this (and within the edge) pass through. */
+/** 软字节预算;已低于此值(且在边限内)的图像直接透传。 */
 export const IMAGE_BYTE_BUDGET = Math.floor(3.75 * 1024 * 1024);
-/** Guard against decompression bombs: refuse to decode above this many pixels. */
+/** 防解压炸弹:像素数超过此值则拒绝解码。 */
 export const MAX_DECODE_PIXELS = 100_000_000;
-/** Guard against decompression bombs: refuse to even attempt decode above this many bytes. */
+/** 防解压炸弹:字节数超过此值则拒绝尝试解码。 */
 export const MAX_DECODE_BYTES = 64 * 1024 * 1024;
 
 /**
- * Byte budget for the ReadMediaFile entry point — the raw file size above
- * which reading is refused before any decode/compress attempt. Kept smaller
- * than {@link IMAGE_BYTE_BUDGET} (the post-compress target) so a single
- * huge file does not consume memory.
+ * ReadMediaFile 入口的字节预算——原始文件大小超过此值,在任何解码 / 压缩
+ * 尝试前即拒绝读取。保持小于 {@link IMAGE_BYTE_BUDGET}(压缩后目标),
+ * 使单个超大文件不会消耗内存。
  */
 export const READ_IMAGE_BYTE_BUDGET = 100 * 1024 * 1024;
 
 /**
- * Parse a positive integer from an environment variable. Returns `undefined`
- * when the variable is absent, empty, or not a positive integer — the caller
- * falls back to config or built-in defaults.
+ * 从环境变量解析正整数。变量缺失、为空或不是正整数时返回 `undefined`——
+ * 调用方回退到配置或内置默认值。
  */
 export function positiveIntFromEnv(
   env: Readonly<Record<string, string | undefined>>,
@@ -60,8 +54,8 @@ export function positiveIntFromEnv(
 }
 
 /**
- * Read the max image edge override from `BYF_IMAGE_MAX_EDGE_PX`.
- * Operator-level (process-wide); per-owner config is layered underneath.
+ * 从 `BYF_IMAGE_MAX_EDGE_PX` 读取最大图像边限覆盖。
+ * 操作员级(进程范围);按 owner 的配置叠加在其下。
  */
 export function maxImageEdgeFromEnv(
   env: Readonly<Record<string, string | undefined>>,
@@ -70,7 +64,7 @@ export function maxImageEdgeFromEnv(
 }
 
 /**
- * Read the read-entry byte budget override from `BYF_IMAGE_READ_BYTE_BUDGET`.
+ * 从 `BYF_IMAGE_READ_BYTE_BUDGET` 读取读入口字节预算覆盖。
  */
 export function readImageByteBudgetFromEnv(
   env: Readonly<Record<string, string | undefined>>,
@@ -85,11 +79,11 @@ const JPEG_QUALITY_LADDER: readonly number[] = [80, 60, 40, 20];
 
 export interface CompressInput {
   readonly data: Buffer;
-  /** The sniffed/accepted MIME from detectFileType. */
+  /** detectFileType 嗅探 / 接受的 MIME。 */
   readonly mimeType: string;
-  /** Default {@link MAX_IMAGE_EDGE_PX}. */
+  /** 默认 {@link MAX_IMAGE_EDGE_PX}。 */
   readonly maxEdgePx?: number;
-  /** Default {@link IMAGE_BYTE_BUDGET}; images already under this pass through fast. */
+  /** 默认 {@link IMAGE_BYTE_BUDGET};已低于此值的图像快速透传。 */
   readonly byteBudget?: number;
 }
 
@@ -180,15 +174,14 @@ async function reencode(
 // ── Public API ───────────────────────────────────────────────────────
 
 /**
- * Compress an image for model consumption.
+ * 为模型消费压缩图像。
  *
- * - WebP / GIF / unsupported MIME → passthrough (returns the original data).
- * - Already within edge + byte budget → passthrough.
- * - Otherwise: decode (with bomb guards), downscale to `maxEdgePx`, re-encode
- *   walking a JPEG quality ladder.
+ * - WebP / GIF / 不支持的 MIME → 透传(返回原始数据)。
+ * - 已在边限 + 字节预算内 → 透传。
+ * - 否则:解码(带防炸弹守卫),缩小到 `maxEdgePx`,沿 JPEG 质量阶梯重编码。
  *
- * Never throws: on any decode/encode error returns outcome `error` with the
- * original data, so the caller can fall back to sending the original.
+ * 绝不抛出:任何解码 / 编码错误都返回携带原始数据的 `error` 结果,
+ * 使调用方可回退为发送原图。
  */
 export async function compressImageForModel(input: CompressInput): Promise<CompressResult> {
   const { data, mimeType } = input;

--- a/packages/agent-core/src/tools/support/image-limits.ts
+++ b/packages/agent-core/src/tools/support/image-limits.ts
@@ -1,16 +1,16 @@
 /**
- * Per-owner image ingestion budget (longest edge, read-entry byte budget).
+ * 按 owner 的图片摄入预算(最长边、读入口字节预算)。
  *
- * One instance per owner (Agent / standalone core). Nothing is stored in
- * module state, so two cores in one process each compress with their own
- * `[image]` settings and a reload of one never restamps the other.
+ * 每个 owner(Agent / 独立 core)一个实例。模块状态中不存任何内容,
+ * 因此一个进程内的两个 core 各按自己的 `[image]` 设置压缩,
+ * 重载其一不会重新盖印另一个。
  *
- * Resolution priority: **env > owning config > built-in default**. The env
- * override is operator-level (process-wide, e.g. `BYF_IMAGE_MAX_EDGE_PX`);
- * the config layer is per-owner (from `[image]` in config.toml).
+ * 解析优先级:**env > 所属配置 > 内置默认**。env 覆盖是操作员级
+ * (进程范围,如 `BYF_IMAGE_MAX_EDGE_PX`);配置层按 owner
+ * (来自 config.toml 的 `[image]`)。
  *
- * Shared by all image ingestion entry points — `ReadMediaFile`, CLI paste,
- * MCP image output — so "the tool compressed but paste didn't" cannot happen.
+ * 所有图片摄入入口共用——`ReadMediaFile`、CLI 粘贴、MCP 图片输出——
+ * 因此不会出现「工具压缩了但粘贴没压缩」。
  */
 
 import {
@@ -35,12 +35,12 @@ export class ImageLimits {
     this.config = config;
   }
 
-  /** Longest edge (px) a decoded image is allowed to keep. */
+  /** 解码后图像允许保留的最长边(像素)。 */
   maxEdgePx(): number {
     return maxImageEdgeFromEnv(this.env) ?? this.config?.maxEdgePx ?? MAX_IMAGE_EDGE_PX;
   }
 
-  /** Raw file byte budget for the read entry point (before decode/compress). */
+  /** 读入口(解码 / 压缩前)的原始文件字节预算。 */
   readByteBudget(): number {
     return (
       readImageByteBudgetFromEnv(this.env) ?? this.config?.readByteBudget ?? READ_IMAGE_BYTE_BUDGET


### PR DESCRIPTION
## 背景

仓库语言规范（`docs/agents/language.md`，Branch 1 已明确）要求：**公开 API 的 JSDoc 与文件/模块顶部注释按简体中文撰写**；内部实现行内注释、非导出符号与 `@internal` 标注的注释沿用代码（英文）约定。agent-core 的公开面注释此前大部分为英文，本 PR 将其统一为中文。

cache-impact: none

## 改动内容

- **公开面清单**：以 `packages/agent-core/src/index.ts` 的 re-export 链为公开面（106 个模块文件），对其中的**文件/模块顶部说明性注释**与 **`export` 符号上的 JSDoc** 译为简体中文（约 30 个文件、140+ 个注释块）。
- **范围纪律**：
  - 已译：公开 API JSDoc（函数/类/接口/类型/常量）+ 模块顶部注释 + 公开接口字段注释
  - 保留英文：函数体内部行内注释、非导出/私有符号注释、`@internal` 标注、代码标识符与技术术语（如 `WireFoldState`、`coalescedCount`）
  - 已跳过：wire v2 重构（PRD-0027/ADR-0032）期间已用中文书写的注释
- **代表性文件**：`cron/manager.ts`、`context/wire-fold.ts`、`errors/serialize.ts`、`prompt-plan/builder.ts`、`tools/support/image-compress.ts`、`rpc/core-api.ts`、`session/git-context.ts` 等。

## 验收

- **零代码变更**：`git diff` 逐行校验——全部变更行均为注释（0 处非注释变更）
- `bun run --filter '@byfriends/agent-core' typecheck` 通过
- `bun run lint` 0 错误；`bun run fmt:check` 通过
- 测试：2564 pass / 11 fail，**失败集与 dev 基线完全一致**（rg 下载等环境相关 + 已知单进程测试间干扰，ADR 0028/#215，与本次改动无关；v1.1 迁移测试单独跑通过）

## Changeset

**无需 changeset**：注释在编译时被剥离、不进入发布产物，属于纯文档性改动（`gen-changesets` skill 规则 #6）。