### PR TITLE
docs(cli): 源文件模块头注释与公开 JSDoc 译为中文

### DIFF
--- a/apps/cli/src/built-in-catalog.ts
+++ b/apps/cli/src/built-in-catalog.ts
@@ -1,7 +1,7 @@
-// Filled by build define (`__BYF_CODE_BUILT_IN_CATALOG__`) in JS release builds.
-// Compile release path injects via `globalThis.__BYF_COMPILE_CATALOG__` before
-// main loads (see scripts/compile/build.mjs) — catalog is too large for
-// `bun build --define` CLI args (ARG_MAX).
+// 由 JS 发布构建中的 build define(`__BYF_CODE_BUILT_IN_CATALOG__`)填充。
+// compile 发布路径在 main 加载前经 `globalThis.__BYF_COMPILE_CATALOG__`
+// 注入(见 scripts/compile/build.mjs)——目录太大,不适合放进
+// `bun build --define` CLI 参数(ARG_MAX)。
 declare const __BYF_CODE_BUILT_IN_CATALOG__: string | undefined;
 
 const COMPILE_CATALOG_KEY = '__BYF_COMPILE_CATALOG__';

--- a/apps/cli/src/cli/goal-prompt.ts
+++ b/apps/cli/src/cli/goal-prompt.ts
@@ -3,12 +3,11 @@ import type { GoalSnapshot } from '@byfriends/sdk';
 import { parseGoalCommand } from '#/tui/commands/index';
 
 /**
- * Headless goal-mode support for the `byf -p "/goal <objective>"` prompt path.
+ * `byf -p "/goal <objective>"` 提示路径的 headless goal 模式支持。
  *
- * The goal driver keeps the prompt's turn-run alive across continuation turns
- * until the goal reaches a terminal state, so the existing prompt-turn waiter
- * already blocks until then. This module adds the create-on-entry parsing, a
- * machine-readable summary, and the terminal-status → exit-code mapping.
+ * goal 驱动使提示词的 turn 运行跨续行保持存活,直到 goal 达到终态,
+ * 因此既有的提示 turn 等待器已阻塞到那时。本模块补充进入时的 create
+ * 解析、机器可读摘要,以及终态 → 退出码的映射。
  */
 
 export interface HeadlessGoalCreate {
@@ -17,11 +16,10 @@ export interface HeadlessGoalCreate {
 }
 
 /**
- * Exit codes by final goal status. The lifecycle has only one success outcome
- * (`complete` → 0) and two resumable stopped states: `blocked` (the system
- * stopped pursuing — the model's UpdateGoal, a budget, or an error) and `paused`
- * (a turn abort / SIGINT). Both are non-zero — the goal did not complete. An absent goal
- * (should not happen on the create path) maps to success.
+ * 按最终 goal 状态的退出码。生命周期只有一个成功结果(`complete` → 0)
+ * 与两个可恢复的停止态:`blocked`(系统停止追求——模型的 UpdateGoal、
+ * 预算或错误)与 `paused`(turn 中止 / SIGINT)。两者都非零——goal 未完成。
+ * 缺失 goal(create 路径上不应发生)映射为成功。
  */
 export const GOAL_EXIT_CODES = {
   complete: 0,
@@ -38,12 +36,10 @@ export function goalExitCode(status: string | undefined): number {
 const GOAL_PREFIX = /^\/goal(\s|$)/;
 
 /**
- * Parses a headless prompt into a goal-create request, or `undefined` when the
- * prompt is not a `/goal` create command (so the caller runs it as a normal
- * prompt). Non-create goal subcommands are not supported headless and fall
- * through to normal prompt handling. Malformed create commands throw instead of
- * falling through, so validation errors are reported before anything is sent to
- * the model.
+ * 把 headless 提示词解析为 goal-create 请求;提示词不是 `/goal` create
+ * 命令时返回 `undefined`(调用方按普通提示词运行)。非 create 的 goal
+ * 子命令在 headless 下不受支持,回退到普通提示词处理。畸形 create 命令
+ * 抛出而非回退,使校验错误在向模型发送任何内容前被报告。
  */
 export function parseHeadlessGoalCreate(prompt: string): HeadlessGoalCreate | undefined {
   const trimmed = prompt.trim();

--- a/apps/cli/src/cli/headless-exit.ts
+++ b/apps/cli/src/cli/headless-exit.ts
@@ -2,29 +2,25 @@ import type { Writable } from 'node:stream';
 
 import { HEADLESS_FORCE_EXIT_GRACE_MS, HEADLESS_STDIO_DRAIN_TIMEOUT_MS } from '#/constant/app';
 
-/** Minimal process surface needed to force a headless run to terminate. */
+/** 强制终止 headless 运行所需的最小进程表面。 */
 export interface ExitableProcess {
   exit(code?: number): void;
 }
 
 /**
- * Schedule a best-effort force-exit for a completed headless (`byf -p`) run.
+ * 为已完成的 headless(`byf -p`)运行安排尽力而为的强制退出。
  *
- * Print mode does not call `process.exit()`; it relies on the Node event loop
- * draining once the run is done. If a stray ref'd handle survives shutdown — a
- * lingering socket (e.g. a connection blackholed by a restrictive firewall, or
- * an HTTP/2 session kept alive by PING), an un-cleared timer, or a child whose
- * pipes stay open — the loop never empties and the process hangs until an
- * external timeout kills it.
+ * 打印模式不调用 `process.exit()`;它依赖 Node 事件循环在运行完成后排空。
+ * 若游离的 ref'd 句柄在关停后存活——一个残留 socket(例如被严格防火墙
+ * 黑洞掉的连接,或被 PING 保活的 HTTP/2 会话)、一个未清除的定时器,
+ * 或管道仍打开的 child——循环永不满空,进程挂起直到外部超时将其杀死。
  *
- * This arms an **unref'd** fallback timer: a healthy run drains and exits
- * naturally before it fires (so behaviour is unchanged), and the timer itself
- * never keeps the loop alive. It only force-exits a run whose loop is already
- * wedged. The exit code is read lazily at fire time so callers may set
- * `process.exitCode` after scheduling (e.g. a goal turn mapping its terminal
- * status to a non-zero code).
+ * 本函数武装一个 **unref'd** 回退定时器:健康运行会在它触发前自然排空并
+ * 退出(行为不变),定时器本身也永不使循环存活。它只强制退出循环已卡死的
+ * 运行。退出码在触发时惰性读取,使调用方可在调度后设置
+ * `process.exitCode`(例如 goal turn 把终态映射为非零码)。
  *
- * Returns the timer handle so callers/tests can `clearTimeout` it.
+ * 返回定时器句柄,供调用方 / 测试 `clearTimeout`。
  */
 export function scheduleHeadlessForceExit(
   proc: ExitableProcess,
@@ -55,12 +51,11 @@ function flushStream(stream: Writable): Promise<void> {
 }
 
 /**
- * Wait for buffered output on the given streams to flush, bounded by `timeoutMs`.
+ * 等待给定流上的缓冲输出刷出,以 `timeoutMs` 为上限。
  *
- * A slow or piped consumer that hasn't read all of stdout/stderr yet leaves the
- * pipe as a legitimate ref'd handle keeping the loop alive. Flushing before any
- * force-exit prevents truncating output from an otherwise-successful run. The
- * wait is bounded so a permanently-stuck consumer can't re-introduce the hang.
+ * 尚未读完全部 stdout/stderr 的慢速或管道消费者,会把管道作为合法 ref'd
+ * 句柄使循环保持存活。在任何强制退出前刷出,可避免截断本会成功的运行的
+ * 输出。等待有界,使永久卡住的消费者无法重新引入挂起。
  */
 export async function drainStdio(
   streams: readonly Writable[],
@@ -79,13 +74,11 @@ export async function drainStdio(
 }
 
 /**
- * Finalize a completed headless run: flush stdio, then arm the force-exit
- * backstop.
+ * 完成 headless 运行:刷出 stdio,然后武装强制退出兜底。
  *
- * Draining first means in-flight legitimate output is fully written before the
- * backstop can fire, and — since drained stdio no longer holds the loop — only a
- * genuinely leaked handle can keep it alive afterwards, which is exactly what
- * the backstop is for.
+ * 先排空意味着进行中的合法输出在兜底触发前已完整写出,并且——排空后的
+ * stdio 不再持有循环——之后只有真正泄漏的句柄才能使其存活,这正是兜底
+ * 的用途。
  */
 export async function finalizeHeadlessRun(
   proc: ExitableProcess,

--- a/apps/cli/src/cli/sub/export.ts
+++ b/apps/cli/src/cli/sub/export.ts
@@ -1,8 +1,8 @@
 /**
- * `byf export` sub-command.
+ * `byf export` 子命令。
  *
- * CLI glue only: session lookup, previous-session confirmation, and output.
- * The actual ZIP/manifest export is owned by the SDK.
+ * 仅 CLI 胶水:会话查找、上一会话确认与输出。实际的 ZIP / manifest 导出
+ * 由 SDK 拥有。
  */
 
 import { createInterface } from 'node:readline/promises';

--- a/apps/cli/src/cli/sub/vis.ts
+++ b/apps/cli/src/cli/sub/vis.ts
@@ -1,10 +1,9 @@
 /**
- * `byf vis` sub-command.
+ * `byf vis` 子命令。
  *
- * CLI glue: parse flags, start the vis HTTP server in-process, open a browser,
- * and keep the process alive until interrupted. Server start and browser open
- * are delegated through `VisDeps` so the logic is testable without a real
- * network or GUI.
+ * CLI 胶水:解析标志、进程内启动 vis HTTP 服务器、打开浏览器,并保持
+ * 进程存活直到被中断。服务器启动与浏览器打开经 `VisDeps` 委托,
+ * 使逻辑无需真实网络或 GUI 即可测试。
  */
 
 import { createRequire } from 'node:module';
@@ -37,8 +36,8 @@ export const DEFAULT_VIS_PORT = 3001;
 export const DEFAULT_VIS_HOST = '127.0.0.1';
 
 /**
- * Run `byf vis`. Starts the server, prints a banner, optionally opens a
- * browser, and blocks until SIGINT/SIGTERM.
+ * 运行 `byf vis`。启动服务器、打印横幅、可选打开浏览器,
+ * 并阻塞直到 SIGINT/SIGTERM。
  */
 export async function handleVis(
   deps: VisDeps,

--- a/apps/cli/src/cli/update/cdn.ts
+++ b/apps/cli/src/cli/update/cdn.ts
@@ -3,14 +3,13 @@ import { valid } from 'semver';
 import { BYF_RELEASES_LATEST_URL } from '#/constant/app';
 
 /**
- * Fetch the latest published BYF version from the GitHub Releases /latest API.
+ * 从 GitHub Releases /latest API 获取最新发布的 BYF 版本。
  *
- * **Throws** on any failure (network error, non-2xx, missing tag_name, invalid
- * semver). Callers must catch — `refreshUpdateCache` deliberately lets the
- * error propagate so the existing cache stays intact instead of being
- * overwritten with a null `latest` on a transient blip.
+ * 任何失败(网络错误、非 2xx、缺少 tag_name、无效 semver)都会**抛出**。
+ * 调用方必须捕获——`refreshUpdateCache` 刻意让错误传播,使既有缓存保持
+ * 完整,而非在瞬时抖动时被 null `latest` 覆盖。
  *
- * `fetchImpl` is injectable for tests; defaults to the global `fetch`.
+ * `fetchImpl` 可注入供测试;默认为全局 `fetch`。
  */
 export async function fetchLatestVersionFromGitHub(
   fetchImpl: typeof fetch = fetch,

--- a/apps/cli/src/cli/update/source.ts
+++ b/apps/cli/src/cli/update/source.ts
@@ -8,9 +8,9 @@ import { isNativePackagedBinary } from '#/native/standalone';
 import { NPM_PACKAGE_NAME, type InstallSource } from './types';
 
 /**
- * True when running as a packaged native binary.
- * Primary: Bun `bun build --compile` (Bun.main under `/$bunfs/`).
- * Also recognizes legacy Node SEA binaries if `node:sea` reports isSea().
+ * 以打包原生二进制运行时为 true。
+ * 主路径:Bun `bun build --compile`(Bun.main 位于 `/$bunfs/` 下)。
+ * 若 `node:sea` 报告 isSea(),也识别遗留 Node SEA 二进制。
  */
 export function detectNativeInstall(): boolean {
   return isNativePackagedBinary();
@@ -27,9 +27,8 @@ function normalizeForHeuristic(filePath: string): string {
 }
 
 /**
- * Heuristic classification by package root path segments. Returns the
- * matching `InstallSource` or `null` if no heuristic matches (caller should
- * fall through to npm-prefix comparison).
+ * 按包根路径段做启发式分类。返回匹配的 `InstallSource`;无启发式匹配时
+ * 返回 `null`(调用方应回退到 npm 前缀比较)。
  */
 export function classifyByPathHeuristic(packageRoot: string): InstallSource | null {
   const normalized = normalizeForHeuristic(packageRoot);
@@ -42,8 +41,8 @@ export function classifyByPathHeuristic(packageRoot: string): InstallSource | nu
 }
 
 /**
- * True when the binary/path lives under a package-manager `node_modules` tree
- * for `@byfriends/cli` (main package or platform optionalDep package).
+ * 二进制 / 路径位于 `@byfriends/cli` 的包管理器 `node_modules` 树
+ * (主包或平台 optionalDep 包)下时为 true。
  */
 export function isUnderCliNodeModules(filePath: string): boolean {
   return normalizeForHeuristic(filePath).includes(NODE_MODULES_CLI_SEGMENT);
@@ -62,8 +61,8 @@ function binFieldLooksLikeLegacyJs(bin: string | Record<string, string> | undefi
 }
 
 /**
- * Legacy npm-global JS layout: bin still points at the Node-interpreted
- * `dist/main.mjs` entry (pre-optionalDep packaging).
+ * 遗留 npm-global JS 布局:bin 仍指向 Node 解释执行的 `dist/main.mjs`
+ * 入口(optionalDep 打包之前)。
  */
 export function isLegacyJsGlobalLayout(packageRoot: string): boolean {
   const mainEntry = join(packageRoot, 'dist', 'main.mjs');
@@ -153,9 +152,9 @@ export function classifyInstallSource(
 }
 
 /**
- * When the process is a compile/SEA binary, decide whether it was launched
- * from an npm optionalDep layout (node_modules tree or launcher env) vs a
- * true GitHub Release / install.sh install.
+ * 当进程是 compile/SEA 二进制时,判定它来自 npm optionalDep 布局
+ * (node_modules 树或启动器 env)还是真正的 GitHub Release / install.sh
+ * 安装。
  */
 export function classifyNativeInstallSource(
   execPath: string,

--- a/apps/cli/src/cli/update/types.ts
+++ b/apps/cli/src/cli/update/types.ts
@@ -3,15 +3,14 @@ import { NPM_PACKAGE_NAME } from '#/constant/app';
 export { NPM_PACKAGE_NAME };
 
 /**
- * Where the running CLI was installed from. Drives update command + spawn.
+ * 运行中的 CLI 的安装来源。驱动 update 命令与 spawn。
  *
- * - `npm-global` / `pnpm-global` / `yarn-global` / `bun-global`: package-manager
- *   global install of the **new** optionalDep layout (launcher + platform binary).
- * - `npm-global-js`: legacy npm global where the bin still points at the old
- *   Node-interpreted `dist/main.mjs` layout — prompt reinstall, do not assume
- *   Node can keep upgrading in place.
- * - `native`: GitHub Release / `install.sh` compile binary (not under node_modules).
- * - `unsupported`: unknown layout; print a manual command only.
+ * - `npm-global` / `pnpm-global` / `yarn-global` / `bun-global`:包管理器
+ *   对**新** optionalDep 布局(启动器 + 平台二进制)的全局安装。
+ * - `npm-global-js`:遗留 npm 全局,bin 仍指向旧的 Node 解释执行
+ *   `dist/main.mjs` 布局——提示重装,不要假定 Node 能原地持续升级。
+ * - `native`:GitHub Release / `install.sh` compile 二进制(不在 node_modules 下)。
+ * - `unsupported`:未知布局;只打印手动命令。
  */
 export type InstallSource =
   | 'npm-global'

--- a/apps/cli/src/constant/app.ts
+++ b/apps/cli/src/constant/app.ts
@@ -3,14 +3,14 @@ import { ErrorCodes } from '@byfriends/sdk';
 export const PRODUCT_NAME = 'BYF';
 export const CLI_COMMAND_NAME = 'byf';
 
-// Used in HTTP User-Agent headers.
+// 用于 HTTP User-Agent 头。
 export const CLI_USER_AGENT_PRODUCT = 'byf-cli';
 export const CLI_UI_MODE = 'shell';
 
-// Published npm package name; this can differ from the executable command.
+// 发布的 npm 包名;它可能不同于可执行命令名。
 export const NPM_PACKAGE_NAME = '@byfriends/cli';
 
-// App-owned data paths. SDK/core runtime config is intentionally not routed here.
+// 应用自有数据路径。SDK/core 运行时配置刻意不路由到此。
 export const BYF_HOME_ENV = 'BYF_HOME';
 export const BYF_DATA_DIR_NAME = '.byf';
 export const BYF_LOG_DIR_NAME = 'logs';
@@ -39,11 +39,11 @@ export const BYF_RELEASES_INSTALL_PS1_URL = `${BYF_RELEASES_BASE}/latest/downloa
 export const NATIVE_INSTALL_COMMAND_UNIX = `curl -fsSL ${BYF_RELEASES_INSTALL_SH_URL} | bash`;
 export const NATIVE_INSTALL_COMMAND_WIN = `irm ${BYF_RELEASES_INSTALL_PS1_URL} | iex`;
 
-/** Grace period before force-exiting a completed headless (`byf -p`) run. */
+/** 强制退出已完成的 headless(`byf -p`)运行前的宽限期。 */
 export const HEADLESS_FORCE_EXIT_GRACE_MS = 2000;
 
-/** Max wait for stdout/stderr to drain before arming the headless force-exit. */
+/** 武装 headless 强制退出前,等待 stdout/stderr 排空的最长时间。 */
 export const HEADLESS_STDIO_DRAIN_TIMEOUT_MS = 10000;
 
-/** Bound for headless cleanup so a wedged shutdown cannot hang forever. */
+/** headless 清理上限,使卡死的关停不会永远挂起。 */
 export const PROMPT_CLEANUP_TIMEOUT_MS = 15_000;

--- a/apps/cli/src/constant/startup-error.ts
+++ b/apps/cli/src/constant/startup-error.ts
@@ -1,2 +1,2 @@
-// Pre-TUI startup errors render directly to stderr, before theme detection.
+// 前 TUI 启动错误在主题检测前直接渲染到 stderr。
 export const STARTUP_ERROR_COLOR = '#E85454';

--- a/apps/cli/src/constant/terminal.ts
+++ b/apps/cli/src/constant/terminal.ts
@@ -1,8 +1,8 @@
-// C0/control-sequence bytes used to build terminal protocol messages.
+// 用于构建终端协议消息的 C0 / 控制序列字节。
 export const ESC = '\u001B';
 export const BEL = '\u0007';
 export const ST = '\\';
 
-// ANSI cursor visibility toggles used by CLI prompts.
+// CLI 提示使用的 ANSI 光标可见性开关。
 export const HIDE_CURSOR = `${ESC}[?25l`;
 export const SHOW_CURSOR = `${ESC}[?25h`;

--- a/apps/cli/src/constant/update.ts
+++ b/apps/cli/src/constant/update.ts
@@ -1,5 +1,5 @@
-// Local palette for the pre-TUI update prompt. TUI colors still come
-// from `src/tui/theme`; do not use these in interactive TUI components.
+// 前 TUI 更新提示的本地调色板。TUI 颜色仍来自 `src/tui/theme`;
+// 不要在交互式 TUI 组件中使用这些。
 export const UPDATE_PROMPT_PRIMARY = '#1783ff';
 export const UPDATE_PROMPT_SUCCESS = '#16A34A';
 export const UPDATE_PROMPT_WARNING = '#CA8A04';

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,8 +1,8 @@
 /**
- * Byf Code entry point.
+ * Byf Code 入口点。
  *
- * Parses CLI arguments via Commander.js, validates options, runs the
- * outer update preflight, then delegates to the requested UI runner.
+ * 经 Commander.js 解析 CLI 参数、校验选项、运行外层 update 预检,
+ * 然后委托给请求的 UI 运行器。
  */
 
 import { flushDiagnosticLogs, log, resolveGlobalLogPath, resolveByfHome } from '@byfriends/sdk';

--- a/apps/cli/src/native/native-assets.ts
+++ b/apps/cli/src/native/native-assets.ts
@@ -111,8 +111,8 @@ function sanitizeSegment(value: string): string {
 }
 
 /**
- * Optional Node SEA asset source for legacy binaries only.
- * Official Bun `bun build --compile` embeds N-API modules directly — no SEA asset tree.
+ * 可选 Node SEA 资产源,仅用于遗留二进制。
+ * 官方 Bun `bun build --compile` 直接内嵌 N-API 模块——无 SEA 资产树。
  */
 export function getSeaAssetSource(): NativeAssetSource | null {
   const sea = loadSeaModule();
@@ -291,15 +291,14 @@ export interface CleanupResult {
 }
 
 /**
- * Remove stale native asset cache directories for the current (version, target).
+ * 移除当前 (version, target) 的过期原生资产缓存目录。
  *
- * Keeps:
- *   - the currentRoot (passed in by caller)
- *   - the most recently modified sibling (defensive: in case currentRoot calc changed)
+ * 保留:
+ *   - currentRoot(调用方传入)
+ *   - 最近修改的兄弟目录(防御性:以防 currentRoot 计算变化)
  *
- * Deletes all other sibling <manifest-hash> directories. Other versions and
- * other targets are never touched. Errors per-entry are collected and returned
- * (never throw — this is fire-and-forget background work).
+ * 删除所有其他兄弟 <manifest-hash> 目录。其他版本与其他 target 永不触碰。
+ * 逐条目收集并返回错误(绝不抛出——这是 fire-and-forget 后台工作)。
  */
 export function cleanupStaleNativeCache(options: CleanupOptions): CleanupResult {
   const { cacheBase, version, target, currentRoot } = options;
@@ -353,10 +352,10 @@ export function cleanupStaleNativeCache(options: CleanupOptions): CleanupResult 
 }
 
 /**
- * Convenience: discover currentRoot from embedded SEA manifest + run cleanup.
- * Safe to call without args from main.ts startup.
- * Returns null when not in SEA mode (including Bun compile standalone, which
- * does not materialize an extract-on-disk native asset cache).
+ * 便捷:从内嵌 SEA manifest 发现 currentRoot 并运行清理。
+ * 可从 main.ts 启动时无参调用。
+ * 非 SEA 模式时返回 null(包括 Bun compile standalone——它不物化
+ * 磁盘解压型原生资产缓存)。
  */
 export function cleanupStaleNativeCacheForCurrent(
   options: NativeAssetOptions = {},

--- a/apps/cli/src/native/standalone.ts
+++ b/apps/cli/src/native/standalone.ts
@@ -1,9 +1,9 @@
 /**
- * Detect packaged native binaries (Bun compile + legacy Node SEA).
+ * 检测打包的原生二进制(Bun compile + 遗留 Node SEA)。
  *
- * Bun 1.3.x does not expose `Bun.isStandaloneExecutable` (documented in newer
- * docs / research notes). Compiled executables report `Bun.main` under the
- * virtual `/$bunfs/` filesystem — that is the reliable 1.3.14 signal.
+ * Bun 1.3.x 不暴露 `Bun.isStandaloneExecutable`(更新文档 / 研究笔记中
+ * 有说明)。编译后的可执行文件在虚拟 `/$bunfs/` 文件系统下报告
+ * `Bun.main`——那是 1.3.14 的可靠信号。
  */
 
 import { createRequire } from 'node:module';
@@ -31,18 +31,18 @@ function loadSeaModule(): NodeSeaModule | null {
 }
 
 /**
- * Pure Bun-compile detection from a Bun-like shape.
- * Exported for unit tests — `globalThis.Bun` is non-configurable under Bun.
+ * 从 Bun 状形态做纯 Bun-compile 检测。
+ * 导出供单元测试——`globalThis.Bun` 在 Bun 下不可配置。
  */
 export function detectBunStandalone(bun: BunStandaloneGlobal | null | undefined): boolean {
   if (bun === undefined || bun === null) return false;
   if (bun.isStandaloneExecutable === true) return true;
   const main = typeof bun.main === 'string' ? bun.main : '';
-  // Bun 1.3.x: entry lives under the virtual standalone filesystem.
+  // Bun 1.3.x:入口位于虚拟 standalone 文件系统下。
   return main.startsWith('/$bunfs/') || main.includes('/$bunfs/');
 }
 
-/** True when this process is a Bun `bun build --compile` standalone executable. */
+/** 本进程是 Bun `bun build --compile` standalone 可执行文件时为 true。 */
 export function isBunStandaloneExecutable(): boolean {
   try {
     return detectBunStandalone((globalThis as { Bun?: BunStandaloneGlobal }).Bun);
@@ -52,8 +52,8 @@ export function isBunStandaloneExecutable(): boolean {
 }
 
 /**
- * True when running as a packaged native binary (Bun compile or Node SEA).
- * Prefer this for install-source / update paths.
+ * 以打包原生二进制(Bun compile 或 Node SEA)运行时为 true。
+ * 安装来源 / update 路径优先使用此判断。
  */
 export function isNativePackagedBinary(): boolean {
   if (isBunStandaloneExecutable()) return true;

--- a/apps/cli/src/tui/actions/cron.ts
+++ b/apps/cli/src/tui/actions/cron.ts
@@ -1,8 +1,8 @@
 /**
- * /cron command actions (PRD-0024).
+ * /cron 命令动作(PRD-0024)。
  *
- * List writes a transcript block; delete uses a status toast.
- * Host-path delete does not go through CronDelete tool permission (ADR-0030).
+ * 列表写入 transcript 块;删除使用状态 toast。
+ * 宿主路径删除不经 CronDelete 工具权限(ADR-0030)。
  */
 
 import type { CronTaskSnapshot, Session } from '@byfriends/sdk';
@@ -50,7 +50,7 @@ export async function handleCronCommand(
   }
 }
 
-/** Pure formatter for unit tests + live list. */
+/** 单元测试与实时列表的纯格式化器。 */
 export function formatCronList(tasks: readonly CronTaskSnapshot[]): string {
   if (tasks.length === 0) {
     return 'cron_jobs: 0\nNo cron jobs scheduled.';
@@ -80,7 +80,7 @@ export function truncatePrompt(prompt: string, max = PROMPT_PREVIEW_MAX): string
   return `${prompt.slice(0, max)}…`;
 }
 
-/** Local wall time with offset (CLI-side; avoids depending on agent-core). */
+/** 带偏移的本地墙钟时间(CLI 侧;避免依赖 agent-core)。 */
 export function formatLocalIsoWithOffset(ms: number): string {
   const d = new Date(ms);
   if (!Number.isFinite(ms) || Number.isNaN(d.getTime())) {

--- a/apps/cli/src/tui/actions/goal.ts
+++ b/apps/cli/src/tui/actions/goal.ts
@@ -1,10 +1,9 @@
 /**
- * /goal command action handler (PRD-0019 #204).
+ * /goal 命令动作处理器(PRD-0019 #204)。
  *
- * Pure dispatch from a parsed `GoalCommand` onto a Session. UI rendering
- * (footer badge / completion card / transcript marker) lives in #205 — this
- * module only mutates session state and emits the user-facing status line
- * that the transcript shares with the UI layer.
+ * 把解析后的 `GoalCommand` 纯分发到 Session。UI 渲染(页脚徽章 / 完成
+ * 卡片 / transcript 标记)位于 #205——本模块只变更会话状态,并发出
+ * transcript 与 UI 层共享的用户可见状态行。
  */
 
 import type { GoalSnapshot, Session } from '@byfriends/sdk';
@@ -34,10 +33,9 @@ export interface GoalActionCallbacks {
 }
 
 /**
- * Execute a parsed /goal command against the session. Returns a short status
- * string suitable for a transient toast; transcript persistence is the
- * caller's responsibility (via `appendTranscriptLine` for the `status` sub-
- * command, which writes a one-line snapshot per PRD R13).
+ * 对会话执行解析后的 /goal 命令。返回适合瞬时 toast 的短状态字符串;
+ * transcript 持久化是调用方的责任(经 `appendTranscriptLine` 处理
+ * `status` 子命令,按 PRD R13 写入单行快照)。
  */
 export async function handleGoalCommand(
   session: GoalSession,
@@ -99,7 +97,7 @@ export async function handleGoalCommand(
   }
 }
 
-/** Render a one-line summary of a snapshot for UI surfaces (footer badge). */
+/** 为 UI 表面(页脚徽章)渲染快照的单行摘要。 */
 export function summarizeGoalSnapshot(snapshot: GoalSnapshot | null): string | null {
   if (snapshot === null) return null;
   return renderStatusLine(snapshot);

--- a/apps/cli/src/tui/actions/replay-ops.ts
+++ b/apps/cli/src/tui/actions/replay-ops.ts
@@ -1,9 +1,8 @@
 /**
- * Session replay hydration.
+ * 会话 replay 水合。
  *
- * Core owns durable history as raw session records. The TUI projects those
- * records into the same transcript entries/components used by live events,
- * without mutating core session state or responding to replayed data.
+ * 核心以原始会话记录持有持久历史。TUI 把那些记录投影为 live 事件使用的
+ * 同一批 transcript 条目 / 组件,不修改核心会话状态,也不响应重放数据。
  */
 
 import type {
@@ -238,16 +237,14 @@ export function projectReplayRecords(
 }
 
 /**
- * Distills each non-main agent's resumed state into a `SubagentReplayBlockData`
- * keyed by its `parentToolCallId`. The child's own replay is projected to
- * recover its assistant text and its tool calls (paired with their results),
- * and its `profileName` and total usage are attached. The resulting map lets
- * `projectReplayRecords` attach child activity onto the matching main-agent
- * `Agent` tool-call card so a resumed `/agent` view shows the child's work.
+ * 把每个非主 agent 的恢复状态提炼为按 `parentToolCallId` 键控的
+ * `SubagentReplayBlockData`。子级的自身 replay 被投影,以恢复其 assistant
+ * 文本与工具调用(与结果配对),并附上 `profileName` 与总用量。所得映射使
+ * `projectReplayRecords` 能把子活动挂到匹配的主 agent `Agent` 工具调用
+ * 卡片上,使恢复后的 `/agent` 视图显示子级的工作。
  *
- * Children without a `parentToolCallId` (main agent, or sessions persisted
- * before the field existed) are skipped — their cards degrade to the existing
- * result-derived rendering.
+ * 无 `parentToolCallId` 的子级(主 agent,或字段存在前持久化的会话)被跳过
+ * ——其卡片退化为既有基于结果的渲染。
  */
 export function distillSubagents(
   agents: Readonly<Record<string, ResumedAgentState>>,
@@ -686,13 +683,12 @@ function isObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Inject projected flat entries into live state. Adjacent Agent tool_call
- * entries sharing `(turnId, step)` are grouped into an AgentGroupComponent so
- * replay matches live behavior. Other entries use the original append path.
+ * 把投影后的扁平条目注入 live 状态。共享 `(turnId, step)` 的相邻 Agent
+ * tool_call 条目被分组进 AgentGroupComponent,使 replay 匹配 live 行为。
+ * 其他条目使用原始追加路径。
  *
- * Unlike `tryAttachAgentToolCall`, this does not write
- * `state.pendingAgentGroup`; after replay, live events must take over from a
- * clean pending group state.
+ * 与 `tryAttachAgentToolCall` 不同,此函数不写 `state.pendingAgentGroup`;
+ * replay 之后,live 事件必须从干净的待决组状态接管。
  */
 export function hydrateProjectedEntries(
   state: TUIState,

--- a/apps/cli/src/tui/byf-tui.ts
+++ b/apps/cli/src/tui/byf-tui.ts
@@ -1,10 +1,9 @@
 /**
- * ByfTui owns the terminal UI shell for a Byf Code session.
+ * ByfTui 拥有 Byf Code 会话的终端 UI 外壳。
  *
- * It builds the pi-tui layout, tracks view state, wires editor shortcuts and
- * slash commands, drives session startup/switching, renders SDK events into the
- * transcript and live panes, and bridges approval, question, auth, and config
- * flows back to the harness.
+ * 它构建 pi-tui 布局、跟踪视图状态、接线编辑器快捷键与斜杠命令、驱动
+ * 会话启动 / 切换、把 SDK 事件渲染进 transcript 与实时面板,并把审批、
+ * 问题、认证与配置流程桥接回 harness。
  */
 
 import { homedir } from 'node:os';

--- a/apps/cli/src/tui/commands/cron.ts
+++ b/apps/cli/src/tui/commands/cron.ts
@@ -1,11 +1,11 @@
 /**
- * /cron slash command parser (PRD-0024).
+ * /cron 斜杠命令解析器(PRD-0024)。
  *
- * Grammar:
- *   /cron              → list
- *   /cron list         → list
- *   /cron delete <id>  → delete (id = 8 lowercase hex)
- *   anything else      → usage error
+ * 文法:
+ *   /cron              → 列表
+ *   /cron list         → 列表
+ *   /cron delete <id>  → 删除(id = 8 位小写十六进制)
+ *   其他任何内容      → 用法错误
  */
 
 export type CronCommand =

--- a/apps/cli/src/tui/commands/goal.ts
+++ b/apps/cli/src/tui/commands/goal.ts
@@ -1,15 +1,15 @@
 /**
- * /goal slash command parser (PRD-0019 #204).
+ * /goal 斜杠命令解析器(PRD-0019 #204)。
  *
- * `parseGoalCommand(rawArgs)` returns a tagged union over the six goal
- * sub-commands. The parser is intentionally pure (string in → union out);
- * side effects live in `apps/cli/src/tui/actions/goal.ts`.
+ * `parseGoalCommand(rawArgs)` 返回六个 goal 子命令的带标签联合。
+ * 解析器刻意保持纯函数(字符串进 → 联合出);副作用位于
+ * `apps/cli/src/tui/actions/goal.ts`。
  *
- * Grammar (PRD R2):
- *   /goal                                → status
- *   /goal status                         → status
- *   /goal pause                          → pause (soft stop)
- *   /goal resume                         → resume
+ * 文法(PRD R2):
+ *   /goal                                → 状态
+ *   /goal status                         → 状态
+ *   /goal pause                          → 暂停(软停)
+ *   /goal resume                         → 恢复
  *   /goal cancel                         → cancel (hard stop)
  *   /goal <objective>                    → create
  *   /goal <objective> --max-turns N ...  → create with budget

--- a/apps/cli/src/tui/commands/handler-registry.ts
+++ b/apps/cli/src/tui/commands/handler-registry.ts
@@ -1,24 +1,23 @@
-// Slash command handler registry.
+// 斜杠命令处理器注册表。
 //
-// Replaces the 27-case `handleBuiltInSlashCommand` switch with a Map-based
-// dispatch. Each builtin command registers its handler here; the dispatch
-// is a single `Map.get(name)(args)` lookup.
+// 用基于 Map 的分发取代 27 分支的 `handleBuiltInSlashCommand` switch。
+// 每个内置命令在此注册其处理器;分发就是一次 `Map.get(name)(args)` 查找。
 //
-// The `SlashCommandHost` interface lives in `handlers/slash-host.ts`.
-// Group modules under `handlers/` register against this registry.
+// `SlashCommandHost` 接口位于 `handlers/slash-host.ts`。
+// `handlers/` 下的分组模块向本注册表注册。
 
 import type { BuiltinSlashCommandName } from './registry';
 
 /**
- * A slash command handler: receives the raw args string, does its work.
+ * 斜杠命令处理器:接收原始参数字符串并执行其工作。
  */
 export type SlashCommandHandler = (args: string) => Promise<void>;
 
 /**
- * Registry mapping builtin command names to their handlers.
+ * 内置命令名到其处理器的注册表映射。
  *
- * Exhaustiveness is enforced at the registration site — the registrar must
- * provide a handler for every `BuiltinSlashCommandName`.
+ * 穷尽性在注册点强制——注册器必须为每个 `BuiltinSlashCommandName`
+ * 提供处理器。
  */
 export class SlashCommandHandlerRegistry {
   private readonly handlers = new Map<BuiltinSlashCommandName, SlashCommandHandler>();

--- a/apps/cli/src/tui/commands/handlers/add-dir.ts
+++ b/apps/cli/src/tui/commands/handlers/add-dir.ts
@@ -1,8 +1,8 @@
 /**
- * `/add-dir` slash command (PRD-0023 R5).
+ * `/add-dir` 斜杠命令(PRD-0023 R5)。
  *
- *   /add-dir list | (no args)  → list workspace + additional roots
- *   /add-dir <path>            → choice: session-only | remember to .byf/local.toml | cancel
+ *   /add-dir list | (无参数)  → 列出工作区 + 附加根目录
+ *   /add-dir <path>           → 选择:仅会话 | 记住到 .byf/local.toml | 取消
  */
 
 import { ChoicePickerComponent } from '#/tui/components/dialogs/choice-picker';

--- a/apps/cli/src/tui/commands/handlers/auth.ts
+++ b/apps/cli/src/tui/commands/handlers/auth.ts
@@ -1,5 +1,5 @@
-// Auth slash commands: login / logout / connect.
-// Calls flows/login-flow.ts and flows/connect-flow.ts directly (PRD-0021 AC15).
+// 认证斜杠命令:login / logout / connect。
+// 直接调用 flows/login-flow.ts 与 flows/connect-flow.ts(PRD-0021 AC15)。
 
 import { applyProviderConfig, fetchModelsByType } from '@byfriends/sdk';
 

--- a/apps/cli/src/tui/commands/handlers/config.ts
+++ b/apps/cli/src/tui/commands/handlers/config.ts
@@ -1,4 +1,4 @@
-// Config / session-ops slash commands: title / yolo / compact / fork / init / feedback.
+// 配置 / 会话操作斜杠命令:title / yolo / compact / fork / init / feedback。
 
 import { NO_ACTIVE_SESSION_MESSAGE } from '#/tui/constant/byf-tui';
 import { FEEDBACK_ISSUE_URL } from '#/tui/constant/feedback';

--- a/apps/cli/src/tui/commands/handlers/cron.ts
+++ b/apps/cli/src/tui/commands/handlers/cron.ts
@@ -1,4 +1,4 @@
-// /cron — list/delete session cron tasks (PRD-0024).
+// /cron — 列出 / 删除会话 cron 任务(PRD-0024)。
 
 import { handleCronCommand as runCronAction } from '#/tui/actions/cron';
 import { parseCronCommand } from '#/tui/commands/cron';

--- a/apps/cli/src/tui/commands/handlers/dialog.ts
+++ b/apps/cli/src/tui/commands/handlers/dialog.ts
@@ -1,4 +1,4 @@
-// Dialog / panel slash commands that mostly open an existing controller.
+// 对话框 / 面板斜杠命令,大多打开既有控制器。
 
 import type { SlashCommandHandler } from '../handler-registry';
 import type { SlashCommandHost } from './slash-host';

--- a/apps/cli/src/tui/commands/handlers/editor.ts
+++ b/apps/cli/src/tui/commands/handlers/editor.ts
@@ -1,4 +1,4 @@
-// Editor / theme / model slash commands.
+// 编辑器 / 主题 / 模型斜杠命令。
 
 import { isTheme } from '#/tui/theme';
 

--- a/apps/cli/src/tui/commands/handlers/goal.ts
+++ b/apps/cli/src/tui/commands/handlers/goal.ts
@@ -1,4 +1,4 @@
-// /goal — calls actions/goal.ts directly (PRD-0021 AC15).
+// /goal — 直接调用 actions/goal.ts(PRD-0021 AC15)。
 
 import { handleGoalCommand as runGoalAction } from '#/tui/actions/goal';
 import { parseGoalCommand } from '#/tui/commands/goal';

--- a/apps/cli/src/tui/commands/handlers/register.ts
+++ b/apps/cli/src/tui/commands/handlers/register.ts
@@ -1,5 +1,5 @@
-// Registers all builtin slash handlers from group modules.
-// Exhaustiveness is enforced via `satisfies Record<BuiltinSlashCommandName, …>`.
+// 从分组模块注册全部内置斜杠处理器。
+// 穷尽性经 `satisfies Record<BuiltinSlashCommandName, …>` 强制。
 
 import type { SlashCommandHandler, SlashCommandHandlerRegistry } from '../handler-registry';
 import type { BuiltinSlashCommandName } from '../registry';
@@ -16,8 +16,8 @@ import type { SlashCommandHost } from './slash-host';
 export type { SlashCommandHost } from './slash-host';
 
 /**
- * Register every BuiltinSlashCommandName against the registry.
- * Compiles only when the merged map covers the full name union.
+ * 向注册表注册每个 BuiltinSlashCommandName。
+ * 仅当合并后的映射覆盖完整名称联合时才可编译。
  */
 export function registerBuiltinSlashHandlers(
   registry: SlashCommandHandlerRegistry,

--- a/apps/cli/src/tui/commands/handlers/session.ts
+++ b/apps/cli/src/tui/commands/handlers/session.ts
@@ -1,4 +1,4 @@
-// Session lifecycle slash commands: exit / help / version / new / sessions.
+// 会话生命周期斜杠命令:exit / help / version / new / sessions。
 
 import type { SlashCommandHandler } from '../handler-registry';
 import type { SlashCommandHost } from './slash-host';

--- a/apps/cli/src/tui/commands/handlers/slash-host.ts
+++ b/apps/cli/src/tui/commands/handlers/slash-host.ts
@@ -1,13 +1,13 @@
-// Narrow capability surface for slash command modules (PRD-0021 H1-a).
+// 斜杠命令模块的窄能力表面(PRD-0021 H1-a)。
 //
-// Handlers never hold a ByfTui reference. The host exposes:
-// - shared UI/session primitives used by ≥2 handlers
-// - dialogManager / dialogHost accessors
-// - controller entry points not yet extracted to DialogManager
-// - a few root-coupled seams (init turn machine, fork rewrite, theme/editor
-//   persistence) as single capability methods — not one handle* per command.
+// 处理器绝不持有 ByfTui 引用。宿主暴露:
+// - 至少 2 个处理器共享的 UI / 会话原语
+// - dialogManager / dialogHost 访问器
+// - 尚未抽取到 DialogManager 的控制器入口
+// - 少数根耦合接缝(init turn 机、fork 重写、主题 / 编辑器持久化)——
+//   以单一能力方法呈现,而非每命令一个 handle*。
 //
-// Per-command control flow lives in commands/handlers/<group>.ts.
+// 每命令的控制流位于 commands/handlers/<group>.ts。
 
 import type {
   ByfConfig,
@@ -23,7 +23,7 @@ import type { Theme } from '#/tui/theme';
 import type { ColorPalette } from '#/tui/theme/colors';
 import type { DialogHost } from '#/tui/types';
 
-/** App-state fields slash handlers read/write. */
+/** 斜杠处理器读写的应用状态字段。 */
 export interface SlashHostAppState {
   readonly availableModels: Readonly<Record<string, ModelAlias>>;
   readonly sessionTitle: string | null;

--- a/apps/cli/src/tui/components/chrome/footer.ts
+++ b/apps/cli/src/tui/components/chrome/footer.ts
@@ -1,9 +1,9 @@
 /**
- * Footer/status bar — multi-line status display at the bottom of the TUI.
+ * 页脚 / 状态栏——TUI 底部的多行状态显示。
  *
- * Layout:
- *   Line 1: [yolo] [plan] <model> <cwd>  <git-badge>  <shortcut hints>
- *   Line 2: context: XX.X% (tokens/max)
+ * 布局:
+ *   第 1 行:[yolo] [plan] <model> <cwd>  <git-badge>  <快捷键提示>
+ *   第 2 行:context: XX.X% (tokens/max)
  */
 
 import type { GoalSnapshot } from '@byfriends/sdk';
@@ -119,14 +119,12 @@ function formatGoalUsageCompact(snapshot: GoalSnapshot, wallClockMs?: number): s
 }
 
 /**
- * Render the goal badge for the footer line 1 (PRD-0019 R13). Returns `null`
- * when there is no goal. The glyph encodes the status; the tail carries a
- * compact usage summary so the user can watch budget burn down at a glance.
+ * 渲染页脚第 1 行的 goal 徽章(PRD-0019 R13)。无 goal 时返回 `null`。
+ * 字形编码状态;尾部携带紧凑用量摘要,使用户能一眼看到预算消耗。
  *
- * `wallClockMs` overrides the snapshot's `usage.wallClockMs` — used by the
- * footer's 1s local timer to extrapolate the elapsed value mid-turn (the
- * snapshot's value is only updated at turn boundaries / status changes per
- * N3; between events the footer advances it locally, ADR-0027).
+ * `wallClockMs` 覆盖快照的 `usage.wallClockMs`——页脚的 1s 本地定时器
+ * 用它外推 turn 进行中的已用时间(快照值只在 turn 边界 / 状态变化时
+ * 更新,见 N3;事件之间页脚在本地推进它,ADR-0027)。
  */
 export function formatGoalBadge(
   snapshot: GoalSnapshot | null | undefined,

--- a/apps/cli/src/tui/components/chrome/gutter-container.ts
+++ b/apps/cli/src/tui/components/chrome/gutter-container.ts
@@ -1,12 +1,10 @@
 /**
- * Container that reserves left/right gutter columns around its children,
- * so the chrome (statusline, transcript, panels) lines up with the input
- * box's inner content area instead of butting up against the terminal edge.
+ * 在子元素周围保留左 / 右沟槽列的 Container,使 chrome(状态行、transcript、
+ * 面板)与输入框的内部内容区对齐,而不是紧贴终端边缘。
  *
- * Children are rendered at `width - left - right` and each emitted line is
- * prefixed with `left` plain spaces. Right padding is logical only — we
- * never emit trailing spaces, since terminals already paint background to
- * the edge and adding them would just churn the diff renderer.
+ * 子元素以 `width - left - right` 渲染,每行发出时前缀 `left` 个普通空格。
+ * 右内边距仅是逻辑上的——我们绝不发出尾随空格,因为终端已把背景绘制到
+ * 边缘,追加它们只会徒增 diff 渲染器的变动。
  */
 
 import { Container } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/components/chrome/todo-panel.ts
+++ b/apps/cli/src/tui/components/chrome/todo-panel.ts
@@ -1,17 +1,14 @@
 /**
- * TodoPanel — live-updating TODO list shown before the input area.
+ * TodoPanel — 输入区前实时更新的 TODO 列表。
  *
- * Mounted as a dedicated `Container` slot between the activity pane
- * (spinners / thinking stream) and the queue / editor block. The host
- * calls {@link setTodos} whenever the LLM invokes the `TodoList`
- * tool; state survives across turns so the list stays visible until
- * explicitly cleared (`todos: []`), a new session starts, or `/clear`
- * is issued.
+ * 挂载在活动面板(spinners / 思考流)与队列 / 编辑器块之间的专用
+ * `Container` 槽位。LLM 每次调用 `TodoList` 工具时宿主调用
+ * {@link setTodos};状态跨 turn 存活,列表保持可见,直到显式清空
+ * (`todos: []`)、新会话开始或发出 `/clear`。
  *
- * Implements {@link Expandable} so the host can toggle between a
- * collapsed view (up to 5 items + "+N more") and a fully expanded
- * view (all items + "collapse" hint).  Uses `Ctrl+T` via the
- * editor keybinding system (see `custom-editor.ts`).
+ * 实现 {@link Expandable},使宿主可在折叠视图(最多 5 项 + "+N more")
+ * 与完全展开视图(全部项 + "collapse" 提示)间切换。经编辑器按键系统
+ * 使用 `Ctrl+T`(见 `custom-editor.ts`)。
  */
 
 import type { Component } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/components/chrome/welcome.ts
+++ b/apps/cli/src/tui/components/chrome/welcome.ts
@@ -1,6 +1,6 @@
 /**
- * Welcome panel shown at the top of the TUI.
- * Renders a round-bordered box with the logo, session, model, and version.
+ * TUI 顶部显示的欢迎面板。
+ * 渲染圆角边框盒,内含 logo、会话、模型与版本。
  */
 
 import type { Component } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/components/dialogs/approval-panel.ts
+++ b/apps/cli/src/tui/components/dialogs/approval-panel.ts
@@ -1,7 +1,7 @@
 /**
- * ApprovalPanel — pi-tui version of the approval request UI.
+ * ApprovalPanel — 审批请求 UI 的 pi-tui 版本。
  *
- * Container-based component with keyboard navigation.
+ * 基于容器的组件,支持键盘导航。
  */
 
 import {
@@ -184,8 +184,8 @@ function headerFor(toolName: string): string {
 }
 
 /**
- * Converts a `DiffDisplayBlock` or `FileContentDisplayBlock` into a pre-rendered
- * `FileViewerSection` suitable for the fullscreen `FileViewerComponent`.
+ * 把 `DiffDisplayBlock` 或 `FileContentDisplayBlock` 转换为适合全屏
+ * `FileViewerComponent` 的预渲染 `FileViewerSection`。
  */
 export function resolveSection(
   block: DiffDisplayBlock | FileContentDisplayBlock,

--- a/apps/cli/src/tui/components/dialogs/btw-controller.ts
+++ b/apps/cli/src/tui/components/dialogs/btw-controller.ts
@@ -1,12 +1,11 @@
 /**
- * BtwController owns the `/btw` side-query overlay lifecycle.
+ * BtwController 拥有 `/btw` 侧查询浮层的生命周期。
  *
- * It mounts a {@link BtwViewer} as a center-anchored overlay, drives a read-only
- * side query through `Session.askSide`, routes the streaming `btw.*` events back
- * into the viewer, and manages hide/restore when an approval or question modal
- * needs the foreground. Extracted from `byf-tui.ts` per ADR-0017; follows the
- * same DI shape as `DialogManager` — it takes `TUIState` plus a narrow host
- * interface and never holds a reference to the full `ByfTui` instance.
+ * 它把 {@link BtwViewer} 挂载为居中锚定浮层,经 `Session.askSide` 驱动
+ * 只读侧查询,把流式 `btw.*` 事件路由回查看器,并在审批或问题模态框需要
+ * 前台时管理隐藏 / 恢复。按 ADR-0017 从 `byf-tui.ts` 抽出;遵循与
+ * `DialogManager` 相同的 DI 形态——接收 `TUIState` 加窄宿主接口,
+ * 绝不持有完整 `ByfTui` 实例的引用。
  */
 
 import { randomUUID } from 'node:crypto';
@@ -26,11 +25,11 @@ import type { TUIState } from '#/tui/types';
 import { BtwViewer } from './btw-viewer';
 
 /**
- * Narrow host capabilities the controller needs from its owner.
- * Kept explicit to avoid a reference back to the full ByfTui instance.
+ * 控制器需要从属主获得的窄宿主能力。
+ * 保持显式,避免对完整 ByfTui 实例的反向引用。
  */
 export interface BtwHost {
-  /** The active session. Dynamic (changes on create/switch), so a getter. */
+  /** 活跃会话。动态(创建 / 切换时变化),因此用 getter。 */
   getSession(): Session | undefined;
   /** Surface a transient error message outside the overlay. */
   showError(message: string): void;

--- a/apps/cli/src/tui/components/dialogs/btw-viewer.ts
+++ b/apps/cli/src/tui/components/dialogs/btw-viewer.ts
@@ -1,11 +1,10 @@
 /**
- * BtwViewer — full-screen overlay for a `/btw` side query.
+ * BtwViewer — `/btw` 侧查询的全屏浮层。
  *
- * Shows the user's question (static) and the streamed answer side-by-side,
- * following the same Container + Focusable skeleton as TaskOutputViewer /
- * SubagentLiveViewer. The answer arrives incrementally via `setProps`
- * (driven by `btw.delta` events); closing the overlay aborts the in-flight
- * side query. The exchange never touches the main transcript.
+ * 并排显示用户问题(静态)与流式答案,遵循与 TaskOutputViewer /
+ * SubagentLiveViewer 相同的 Container + Focusable 骨架。答案经 `setProps`
+ * 增量到达(由 `btw.delta` 事件驱动);关闭浮层中止进行中的侧查询。
+ * 该交流永不触碰主 transcript。
  */
 
 import {

--- a/apps/cli/src/tui/components/dialogs/choice-picker.ts
+++ b/apps/cli/src/tui/components/dialogs/choice-picker.ts
@@ -1,11 +1,10 @@
 /**
- * ChoicePicker — modal single-select list for slash commands that ask
- * the user to pick from a small set of preset values.
+ * ChoicePicker — 供请求用户从少量预设值中选择的斜杠命令使用的
+ * 模态单选列表。
  *
- * Mirrors SessionPickerComponent's container-replacement pattern: host
- * calls `showChoicePicker(...)` which clears the editor container,
- * addChild(picker), setFocus(picker); the picker invokes `onSelect` or
- * `onCancel`, and the host tears it down.
+ * 镜像 SessionPickerComponent 的容器替换模式:宿主调用
+ * `showChoicePicker(...)`,它清空编辑器容器、addChild(picker)、
+ * setFocus(picker);选择器调用 `onSelect` 或 `onCancel`,宿主将其拆除。
  */
 
 import {

--- a/apps/cli/src/tui/components/dialogs/compaction.ts
+++ b/apps/cli/src/tui/components/dialogs/compaction.ts
@@ -1,18 +1,18 @@
 /**
- * Renders a compaction block in the transcript.
+ * 在 transcript 中渲染压缩块。
  *
- * Lifecycle:
- *   - constructed on `compaction.started` → blinking white bullet +
- *     "Compacting context..." and optional custom instruction
- *   - `markDone()` on `compaction.completed` → solid green bullet +
- *     "Compaction complete (X → Y tokens)" + optional summary (Ctrl-O)
- *   - `markCanceled()` on `compaction.cancelled` → solid warning bullet +
+ * 生命周期:
+ *   - `compaction.started` 时构造 → 闪烁白色圆点 +
+ *     "Compacting context..." 与可选的自定义指令
+ *   - `compaction.completed` 时 `markDone()` → 实心绿点 +
+ *     "Compaction complete (X → Y tokens)" + 可选摘要(Ctrl-O)
+ *   - `compaction.cancelled` 时 `markCanceled()` → 实心警示圆点 +
  *     "Compaction cancelled"
  *
- * Bullet animation mirrors `ToolCallComponent` (500ms blink) so the user
- * reads the same "work in progress" signal across the UI.
+ * 圆点动画镜像 `ToolCallComponent`(500ms 闪烁),使整个 UI 传达相同的
+ * 「进行中」信号。
  *
- * Implements `Expandable` so Ctrl-O (`toggleToolOutputExpansion`) can
+ * 实现 `Expandable`,使 Ctrl-O(`toggleToolOutputExpansion`)可以
  * show/hide the compaction summary — the same shared shortcut used by
  * tool output and thinking blocks. The summary text comes from the
  * already-existing `CompactionCompletedEvent.result.summary` field; no

--- a/apps/cli/src/tui/components/dialogs/feedback-input-dialog.ts
+++ b/apps/cli/src/tui/components/dialogs/feedback-input-dialog.ts
@@ -1,9 +1,9 @@
 /**
- * FeedbackInputDialog — blue rounded box that collects a single line of
- * user feedback before submitting it to the managed Byf Code platform.
+ * FeedbackInputDialog — 在把单行用户反馈提交到受管的 Byf Code 平台前
+ * 收集它的蓝色圆角框。
  *
- * The box embeds a `pi-tui` Input for the actual text entry; cursor
- * visibility tracks the dialog's `focused` flag.
+ * 框内嵌一个 `pi-tui` Input 用于实际文本输入;光标可见性跟随对话框的
+ * `focused` 标志。
  */
 
 import {

--- a/apps/cli/src/tui/components/dialogs/file-viewer.ts
+++ b/apps/cli/src/tui/components/dialogs/file-viewer.ts
@@ -1,11 +1,10 @@
 /**
- * FileViewerComponent — fullscreen viewer for reviewing file content and
- * diffs during approval prompts. Displays pre-computed sections (each with
- * a header and ANSI-rendered lines) as a single scrollable view with
- * vim-style navigation.
+ * FileViewerComponent — 审批提示期间审阅文件内容与 diff 的全屏查看器。
+ * 把预计算的区块(各带标题与 ANSI 渲染行)显示为单个可滚动视图,
+ * 支持 vim 风格导航。
  *
- * Follows the same pattern as TaskOutputViewer: Container + Focusable,
- * Terminal-aware, header/body/footer layout, scroll management.
+ * 遵循与 TaskOutputViewer 相同的模式:Container + Focusable、
+ * Terminal 感知、头部 / 主体 / 页脚布局、滚动管理。
  */
 
 import {

--- a/apps/cli/src/tui/components/dialogs/help-panel.ts
+++ b/apps/cli/src/tui/components/dialogs/help-panel.ts
@@ -1,11 +1,10 @@
 /**
- * HelpPanel — modal `/help` display. Lists keyboard shortcuts, slash
- * commands (with aliases + descriptions) in colour-coded sections.
+ * HelpPanel — 模态 `/help` 显示。以配色区段列出键盘快捷键与斜杠命令
+ * (含别名与描述)。
  *
- * Mirrors the container-replacement pattern used by SessionPicker /
- * ApprovalPanel: host mounts the panel into `editorContainer`, picks
- * it as the focused component, and tears it down on the `onClose`
- * callback (fired on Esc / Enter / q).
+ * 镜像 SessionPicker / ApprovalPanel 使用的容器替换模式:宿主把面板挂载进
+ * `editorContainer`,选它为焦点组件,并在 `onClose` 回调(Esc / Enter / q
+ * 触发)时将其拆除。
  */
 
 import {
@@ -31,7 +30,7 @@ export interface HelpPanelCommand {
   readonly description: string;
 }
 
-/** Static list — keep in sync with the global editor bindings. */
+/** 静态列表——与全局编辑器绑定保持同步。 */
 export const DEFAULT_KEYBOARD_SHORTCUTS: readonly KeyboardShortcut[] = [
   // { keys: 'Ctrl-G', description: 'Edit in external editor ($VISUAL / $EDITOR)' },
   { keys: 'Ctrl-O', description: 'Toggle tool output expansion' },

--- a/apps/cli/src/tui/components/dialogs/question-dialog.ts
+++ b/apps/cli/src/tui/components/dialogs/question-dialog.ts
@@ -1,8 +1,8 @@
 /**
- * QuestionDialog — pi-tui version of the structured question prompt.
+ * QuestionDialog — 结构化问题提示的 pi-tui 版本。
  *
- * Each question collects an answer locally, and a final Submit tab
- * reviews everything before the answers are emitted upstream.
+ * 每个问题在本地收集答案,最后的 Submit 标签页在答案向上游发出前
+ * 复核全部内容。
  */
 
 import {

--- a/apps/cli/src/tui/components/dialogs/session-picker.ts
+++ b/apps/cli/src/tui/components/dialogs/session-picker.ts
@@ -1,5 +1,5 @@
 /**
- * SessionPicker — pi-tui version of the session selection dialog.
+ * SessionPicker — 会话选择对话框的 pi-tui 版本。
  */
 
 import {

--- a/apps/cli/src/tui/components/dialogs/subagents/controller.ts
+++ b/apps/cli/src/tui/components/dialogs/subagents/controller.ts
@@ -1,5 +1,5 @@
 /**
- * SubagentsController — manages the /agent full-screen lifecycle.
+ * SubagentsController — 管理 /agent 全屏生命周期。
  */
 
 import type { Terminal } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/components/dialogs/subagents/list-app.ts
+++ b/apps/cli/src/tui/components/dialogs/subagents/list-app.ts
@@ -1,12 +1,12 @@
 /**
- * SubagentsListApp — full-screen list of foreground sub-agents.
+ * SubagentsListApp — 前台子 agent 的全屏列表。
  *
- * Three-pane layout (matching /tasks):
- *   Left: scrollable sub-agent list
- *   Right top: selected sub-agent detail
- *   Right bottom: selected sub-agent output preview
+ * 三栏布局(与 /tasks 一致):
+ *   左:可滚动的子 agent 列表
+ *   右上:选中子 agent 的详情
+ *   右下:选中子 agent 的输出预览
  *
- * Falls back to single-pane list on narrow terminals (< 80 cols).
+ * 窄终端(< 80 列)回退为单栏列表。
  */
 
 import { Container, Key, matchesKey, truncateToWidth, visibleWidth } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/components/dialogs/subagents/live-viewer.ts
+++ b/apps/cli/src/tui/components/dialogs/subagents/live-viewer.ts
@@ -1,10 +1,9 @@
 /**
- * SubagentLiveViewer — full-screen real-time viewer of a foreground sub-agent's
- * tool-activity trail.
+ * SubagentLiveViewer — 前台子 agent 工具活动轨迹的全屏实时查看器。
  *
- * Based on TaskOutputViewer skeleton, aligned with approval-fullscreen-viewer
- * props pattern. Subscribes to ToolCallComponent.setSnapshotListener for live
- * updates; follow-tail when user is parked at the bottom.
+ * 基于 TaskOutputViewer 骨架,与 approval-fullscreen-viewer 的 props 模式
+ * 对齐。订阅 ToolCallComponent.setSnapshotListener 以实时更新;
+ * 用户停在底部时跟随尾部。
  */
 
 import {

--- a/apps/cli/src/tui/components/dialogs/task-output-viewer.ts
+++ b/apps/cli/src/tui/components/dialogs/task-output-viewer.ts
@@ -1,12 +1,10 @@
 /**
- * TaskOutputViewer — full-screen pi-tui rendered output viewer for
- * a single background task. Replaces the previous "shell out to less"
- * approach so the experience stays inside the TUI: same colors, same
- * fonts, same redraw cycle, no alt-screen flip-flop.
+ * TaskOutputViewer — 单个后台任务的全屏 pi-tui 渲染输出查看器。
+ * 取代之前「shell 出去用 less」的做法,使体验留在 TUI 内:同样的颜色、
+ * 同样的字体、同样的重绘周期,无 alt-screen 翻转。
  *
- * Mounted by `byf-tui.ts` via nested container swap on top of the
- * TasksBrowserApp. Snapshot view (no live tail) — content is fetched
- * once when the viewer opens.
+ * 由 `byf-tui.ts` 在 TasksBrowserApp 之上经嵌套容器交换挂载。
+ * 快照视图(无实时尾部)——查看器打开时一次性获取内容。
  */
 
 import type { BackgroundTaskInfo, BackgroundTaskStatus } from '@byfriends/sdk';

--- a/apps/cli/src/tui/components/dialogs/tasks-browser.ts
+++ b/apps/cli/src/tui/components/dialogs/tasks-browser.ts
@@ -1,15 +1,12 @@
 /**
- * TasksBrowserApp — full-screen alt-screen takeover for browsing
- * background tasks. Three-pane layout (left task list, right top
- * detail, right bottom preview output) framed by a header row and
- * footer key hint.
+ * TasksBrowserApp — 浏览后台任务的全屏 alt-screen 接管。三栏布局
+ * (左任务列表、右上详情、右下输出预览),由头部行与页脚按键提示框定。
  *
- * Mounted by `byf-tui.ts` via container swap rather than `showOverlay`
- * — the main TUI's children are saved, cleared, and this component is
- * added as the sole child so it covers the entire screen. The
- * controller restores the children when the user exits.
+ * 由 `byf-tui.ts` 经容器交换而非 `showOverlay` 挂载——主 TUI 的子元素被
+ * 保存、清空,本组件作为唯一子元素添加,覆盖整个屏幕。用户退出时控制器
+ * 恢复原子元素。
  *
- * Data (tasks list, tail output) flows in via `setProps`; user actions
+ * 数据(任务列表、尾部输出)经 `setProps` 流入;用户操作
  * fire the `on*` callbacks back to the controller.
  */
 

--- a/apps/cli/src/tui/components/editor/custom-editor.ts
+++ b/apps/cli/src/tui/components/editor/custom-editor.ts
@@ -1,5 +1,5 @@
 /**
- * Custom editor extending pi-tui Editor with app-level keybindings.
+ * 扩展 pi-tui Editor、带应用级按键绑定的自定义编辑器。
  */
 
 import { Editor, isKeyRelease, matchesKey, Key, type TUI } from '@earendil-works/pi-tui';
@@ -30,18 +30,16 @@ interface AutocompleteInternals {
 }
 
 /**
- * Workaround for a pi-tui bug that surfaces when Kitty keyboard protocol
- * is active AND caps_lock is on. In that state terminals emit, e.g.,
- * `ESC[68;69u` for ctrl+d (codepoint=68=`D`, modifier=ctrl|caps_lock).
- * pi-tui's `matchesKittySequence` masks `caps_lock` out of the *modifier*
- * but leaves the *codepoint* capitalised, so `matchesKey(data, "ctrl+d")`
- * (which expects codepoint=100=`d`) fails and every ctrl-shortcut is
- * silently dropped.
+ * 针对 pi-tui 在 Kitty 键盘协议激活**且** caps_lock 开启时暴露的 bug 的
+ * 变通方案。该状态下终端为 ctrl+d 发出例如 `ESC[68;69u`
+ * (codepoint=68=`D`,modifier=ctrl|caps_lock)。pi-tui 的
+ * `matchesKittySequence` 会把 `caps_lock` 从 *modifier* 中掩掉,但
+ * *codepoint* 仍是大写,因此 `matchesKey(data, "ctrl+d")`(期望
+ * codepoint=100=`d`)失败,所有 ctrl 快捷键被静默丢弃。
  *
- * We rewrite the sequence back to its unlocked form before dispatching,
- * but only when ctrl is held and shift is not — i.e. exactly the
- * `ctrl+<letter>` case. Plain uppercase (caps_lock only, no ctrl) and
- * explicit ctrl+shift+<letter> are left alone.
+ * 我们在分发前把序列重写回未锁定形式,但仅在按住 ctrl 且未按 shift 时——
+ * 即恰好是 `ctrl+<letter>` 情形。纯大写(caps_lock 仅开、无 ctrl)与
+ * 显式 ctrl+shift+<letter> 保持原样。
  */
 export function normalizeCapsLockedCtrl(data: string): string {
   const m = data.match(KITTY_CSI_U);
@@ -292,10 +290,9 @@ export class CustomEditor extends Editor {
 }
 
 /**
- * Return a copy of `line` with the first `/token` coloured using `hex`.
- * `line` may already contain SGR escapes (cursor inverse, etc.); we
- * locate `/` via visible-index math so ANSI pass-through survives.
- * Returns `undefined` if no token is found.
+ * 返回 `line` 的副本,第一个 `/token` 用 `hex` 着色。
+ * `line` 可能已含 SGR 转义(光标反显等);我们经可见索引数学定位 `/`,
+ * 使 ANSI 透传得以存活。未找到 token 时返回 `undefined`。
  */
 export function highlightFirstSlashToken(line: string, hex: string): string | undefined {
   const visible = stripSgr(line);
@@ -324,14 +321,12 @@ export function highlightFirstSlashToken(line: string, hex: string): string | un
 }
 
 /**
- * Overlay a terminal-style `> ` prompt symbol on the first content line.
- * Column 0 is reserved for the left vertical border (overlaid later by
- * wrapWithSideBorders); column 1 is a single-space gap, so the `>` token
- * lives at column 2 with column 3 separating it from content.
- * Relies on the editor being configured with `paddingX >= 4` so the line
- * starts with at least four literal spaces. Emits no SGR so the terminal's
- * default foreground colour renders the symbol. Returns `undefined` if the
- * line is too short or doesn't begin with the expected padding.
+ * 在首个内容行上叠加终端风格的 `> ` 提示符。
+ * 列 0 预留给左侧垂直边框(稍后由 wrapWithSideBorders 叠加);列 1 是
+ * 单空格间隙,因此 `>` token 位于列 2,列 3 将其与内容分隔。
+ * 依赖编辑器配置为 `paddingX >= 4`,使行以至少四个字面空格开头。
+ * 不发出 SGR,使终端的默认前景色渲染该符号。行过短或不以预期内边距
+ * 开头时返回 `undefined`。
  */
 export function injectPromptSymbol(
   line: string,
@@ -376,16 +371,13 @@ function stripVisiblePrefix(input: string, expected: string): string | null {
 }
 
 /**
- * Post-process pi-tui's editor output to draw a full box around it.
+ * 后处理 pi-tui 的编辑器输出,在其周围绘制完整边框。
  *
- * pi-tui only renders horizontal top/bottom borders; we wrap them with
- * `╭╮╰╯` corners and add vertical `│` bars on each row's outer columns.
- * Horizontal-border rows (those whose first visible char is `─`, including
- * scroll indicators like `── ↑ N more ──`) are stripped of their existing
- * SGR and repainted as a single box-drawn span. Content rows keep their
- * inner SGR intact; only column 0 and the last column are overlaid, and
- * only if they're literal spaces — that protects the cursor-overflow
- * case where the rightmost column is an SGR-tagged inverse cursor.
+ * pi-tui 只渲染水平顶 / 底边框;我们用 `╭╮╰╯` 角包裹它们,并在每行
+ * 外侧列添加垂直 `│` 条。水平边框行(首个可见字符为 `─` 的行,含
+ * `── ↑ N more ──` 之类的滚动指示器)会剥离既有 SGR,重绘为单个
+ * 盒绘 span。内容行保持内部 SGR 完整;只叠加列 0 与最后一列,且仅当
+ * 它们是字面空格时——这保护了最右列是 SGR 标记反显光标的光标溢出情形。
  */
 export function wrapWithSideBorders(lines: string[], paint: (s: string) => string): string[] {
   let seenTop = false;

--- a/apps/cli/src/tui/components/editor/file-mention-provider.ts
+++ b/apps/cli/src/tui/components/editor/file-mention-provider.ts
@@ -1,13 +1,12 @@
 /**
- * `@file` autocomplete provider for the input box.
+ * 输入框的 `@file` 自动补全提供者。
  *
- * pi-tui's `CombinedAutocompleteProvider` handles the mechanical parts
- * (extract `@…` prefix, insert completion with the right quoting). This
- * wrapper adds byf-specific ranking + filtering so the default "empty
- * `@`" list surfaces files the user actually wants, not alphabetical
- * noise from `.agents/skills/*` et al.
+ * pi-tui 的 `CombinedAutocompleteProvider` 处理机制部分(提取 `@…` 前缀、
+ * 以正确引号插入补全)。本包装添加 byf 特定的排序 + 过滤,使默认的
+ * 「空 `@`」列表浮现用户真正想要的文件,而非来自 `.agents/skills/*`
+ * 等的字母序噪声。
  *
- * Sort order — empty query:
+ * 排序顺序——空查询:
  *   1. recently edited (from `git log --name-only`)
  *   2. recent fs mtime
  *   3. basename alphabetical

--- a/apps/cli/src/tui/components/media/code-highlight.ts
+++ b/apps/cli/src/tui/components/media/code-highlight.ts
@@ -1,6 +1,6 @@
 /**
- * Shared syntax-highlighting helpers for code previews
- * (tool-call Write/Edit, approval-panel Write content, etc.).
+ * 代码预览共享的语法高亮辅助
+ * (工具调用 Write/Edit、审批面板 Write 内容等)。
  */
 
 import { extname } from 'node:path';

--- a/apps/cli/src/tui/components/media/diff-preview.ts
+++ b/apps/cli/src/tui/components/media/diff-preview.ts
@@ -1,8 +1,8 @@
 /**
- * Diff preview rendering as plain ANSI strings.
+ * 以纯 ANSI 字符串渲染 diff 预览。
  *
- * Reuses the diff algorithm from approval/DiffPreview.tsx, but outputs
- * formatted text lines instead of React elements.
+ * 复用 approval/DiffPreview.tsx 的 diff 算法,但输出格式化文本行
+ * 而非 React 元素。
  */
 
 import chalk from 'chalk';
@@ -222,13 +222,12 @@ function formatDiffRow(line: DiffLine, s: DiffStyles): string {
 }
 
 /**
- * Render a diff with surrounding context, eliding unchanged middle
- * regions between change clusters with a `… N unchanged lines …`
- * separator. When `maxLines` is set, the body is capped at a cluster
- * boundary and a `ctrl+o to expand` footer is appended.
+ * 渲染带周围上下文的 diff,用 `… N unchanged lines …` 分隔符省略变更簇
+ * 之间未变的中间区域。设置 `maxLines` 时,主体在簇边界处封顶,
+ * 并追加 `ctrl+o to expand` 页脚。
  *
- * Used by Edit's call preview where we want to show *what changed*
- * with enough context to read the change, but not the whole file.
+ * 用于 Edit 的调用预览——我们希望展示*变更了什么*,并带足够上下文
+ * 读懂变更,但不需要整个文件。
  */
 export function renderDiffLinesClustered(
   oldText: string,

--- a/apps/cli/src/tui/components/media/image-thumbnail.ts
+++ b/apps/cli/src/tui/components/media/image-thumbnail.ts
@@ -1,15 +1,12 @@
 /**
- * Transcript-side rendering of a pasted image.
+ * 粘贴图片的 transcript 侧渲染。
  *
- * On terminals that speak the Kitty graphics protocol or iTerm2 inline
- * image protocol (detected by pi-tui's `getCapabilities()`), we show
- * the actual image. Everywhere else we fall back to a one-line text
- * marker matching the placeholder the user sees in the input box —
- * this keeps the transcript readable on Terminal.app / Linux default
- * terminals / `script` recordings without extra chrome.
+ * 在支持 Kitty 图形协议或 iTerm2 内联图片协议的终端上(由 pi-tui 的
+ * `getCapabilities()` 检测),显示实际图片。其他环境回退为与用户在输入框
+ * 所见一致的单行文本标记——使 transcript 在 Terminal.app / Linux 默认
+ * 终端 / `script` 录制中无需额外 chrome 即可阅读。
  *
- * Height is capped at ~12 rows so a single screenshot can't monopolize
- * the viewport; pi-tui handles proportional scaling internally.
+ * 高度上限约 12 行,使单个截图不会独占视口;比例缩放由 pi-tui 内部处理。
  */
 
 import { Container, Image, Text, type ImageTheme, getCapabilities } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/components/messages/agent-group.ts
+++ b/apps/cli/src/tui/components/messages/agent-group.ts
@@ -1,18 +1,17 @@
 /**
- * AgentGroupComponent renders 2+ Agent tool calls from the same step as one group.
+ * AgentGroupComponent 把同一步骤中的 2+ 个 Agent 工具调用渲染为一组。
  *
- * Design:
- * - State container: each child Agent keeps its real state in its
- *   `ToolCallComponent` (subagent meta, phase, sub-tool calls, tokens, text).
- *   AgentGroup only stores references and does not copy state. Event handlers
- *   still route through `state.pendingToolComponents.get(parent_tool_call_id)`.
- * - Subscription: `attach` registers a snapshot listener on each child so the
- *   group can refresh when child state changes.
- * - Throttling: normal changes are coalesced into one render every 200ms.
- *   Phase transitions (spawning -> running -> done/failed) flush immediately.
- * - Mounting: `ByfTui` attaches the group to the transcript at the
- *   right time; the group handles `invalidate` plus `ui.requestRender`.
- * - Ungrouping is not implemented. Once formed, a group stays grouped.
+ * 设计:
+ * - 状态容器:每个子 Agent 的真实状态留在各自的 `ToolCallComponent`
+ *   (subagent 元信息、阶段、子工具调用、tokens、文本)。AgentGroup 只存引用,
+ *   不复制状态。事件处理器仍经
+ *   `state.pendingToolComponents.get(parent_tool_call_id)` 路由。
+ * - 订阅:`attach` 在每个子组件上注册快照监听器,子状态变化时组可刷新。
+ * - 节流:普通变化每 200ms 合并为一次渲染。阶段转换
+ *   (spawning → running → done/failed)立即刷出。
+ * - 挂载:`ByfTui` 在适当时机把组挂到 transcript;组处理 `invalidate` 与
+ *   `ui.requestRender`。
+ * - 未实现取消分组。一旦形成,组保持分组。
  */
 
 import type { TUI } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/components/messages/assistant-message.ts
+++ b/apps/cli/src/tui/components/messages/assistant-message.ts
@@ -1,8 +1,7 @@
 /**
- * Renders an assistant message using pi-tui Markdown.
+ * 使用 pi-tui Markdown 渲染一条 assistant 消息。
  *
- * Displays a white bullet prefix with markdown content indented
- * to align after the bullet.
+ * 显示白色圆点前缀,markdown 内容缩进以与圆点对齐。
  */
 
 import type { Component, MarkdownTheme } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/components/messages/goal-completion.ts
+++ b/apps/cli/src/tui/components/messages/goal-completion.ts
@@ -1,11 +1,11 @@
 /**
- * Completion card for a finished goal (PRD-0019 R14).
+ * 已完成 goal 的完成卡片(PRD-0019 R14)。
  *
- * Rendered only when the model calls `UpdateGoal('complete')`. `cancel` does
- * NOT produce this card — it renders a low-presence lifecycle marker instead.
+ * 仅当模型调用 `UpdateGoal('complete')` 时渲染。`cancel` 不产生此卡片——
+ * 它改为渲染低存在感的生命周期标记。
  *
- * The card text is produced by a pure function from the `goal.updated` event
- * snapshot, so live and replay paths render identically.
+ * 卡片文本由 `goal.updated` 事件快照的纯函数生成,因此 live 与 replay
+ * 路径渲染一致。
  */
 
 import type { Component } from '@earendil-works/pi-tui';
@@ -17,7 +17,7 @@ import { STATUS_BULLET } from '#/tui/constant/symbols';
 import type { ColorPalette } from '#/tui/theme/colors';
 import type { GoalCompletionData } from '#/tui/types';
 
-/** Format the usage line shared by the completion card and markers. */
+/** 格式化完成卡片与标记共享的用量行。 */
 export function formatGoalUsageLine(data: {
   turns: number;
   tokens: number;

--- a/apps/cli/src/tui/components/messages/read-group.ts
+++ b/apps/cli/src/tui/components/messages/read-group.ts
@@ -1,20 +1,19 @@
 /**
- * ReadGroupComponent renders 2+ Read tool calls from the same step as one group.
+ * ReadGroupComponent 把同一步骤中的 2+ 个 Read 工具调用渲染为一组。
  *
- * It follows the same structure as `AgentGroupComponent`, with a smaller
- * surface:
- * - one summary header and a tree body listing each file path and status;
- * - permanently grouped, while the body remains visible;
- * - 200ms throttling, matching AgentGroup;
- * - state stays in each `ToolCallComponent`; the group only reads snapshots.
+ * 它遵循 `AgentGroupComponent` 的相同结构,表面更小:
+ * - 一个摘要头 + 列出各文件路径与状态的树形主体;
+ * - 永久分组,主体保持可见;
+ * - 200ms 节流,与 AgentGroup 一致;
+ * - 状态留在各 `ToolCallComponent`;组只读取快照。
  *
- * Header forms:
+ * 头部形式:
  *   pending > 0: Reading {N} files
  *   all done:    Read {N} files · {L} lines
  *   some failed: append · {F} failed
  *   all failed:  Read {N} files · failed
  *
- * Body lines follow AgentGroup's branch style:
+ * 主体行遵循 AgentGroup 的分支样式:
  *   src/main.ts · 51 lines
  *   src/cli.ts · reading
  *   src/missing.ts · failed

--- a/apps/cli/src/tui/components/messages/skill-activation.ts
+++ b/apps/cli/src/tui/components/messages/skill-activation.ts
@@ -1,15 +1,14 @@
 /**
- * Skill activation card.
+ * 技能激活卡片。
  *
- * When the user runs `/skill:foo bar`, the TUI renders a compact card instead
- * of expanding the SKILL.md body into the user bubble:
+ * 用户运行 `/skill:foo bar` 时,TUI 渲染紧凑卡片,而非把 SKILL.md 正文
+ * 展开进用户气泡:
  *
  *   ▶ Activated skill: foo
  *     bar
  *
- * The args line is optional. Core expands the skill body into the LLM context;
- * the TUI only consumes the `skill.activated` event and user_message origin
- * metadata.
+ * 参数行可选。核心把技能正文展开进 LLM 上下文;TUI 只消费
+ * `skill.activated` 事件与 user_message origin 元数据。
  */
 
 import { Container, Text, Spacer } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/components/messages/status-panel.ts
+++ b/apps/cli/src/tui/components/messages/status-panel.ts
@@ -1,8 +1,7 @@
 /**
- * Status report line builder for `/status`.
+ * `/status` 的状态报告行构建器。
  *
- * It mirrors `/usage` visual language but keeps runtime status formatting
- * separate from the TUI orchestration layer.
+ * 它镜像 `/usage` 的视觉语言,但把运行时状态格式化与 TUI 编排层分离。
  */
 
 import type { ModelAlias, PermissionMode, SessionStatus } from '@byfriends/sdk';

--- a/apps/cli/src/tui/components/messages/subagent-activity-store.ts
+++ b/apps/cli/src/tui/components/messages/subagent-activity-store.ts
@@ -1,16 +1,13 @@
 /**
- * SubagentActivityStore — standalone state container for a foreground sub-agent's
- * activity trail.
+ * SubagentActivityStore — 前台子 agent 活动轨迹的独立状态容器。
  *
- * Holds all subagent lifecycle state (spawning → running → done/failed),
- * sub-tool call tracking (ongoing + finished), accumulated text/thinking text,
- * timer management, and snapshot listener notification.
+ * 持有全部子 agent 生命周期状态(spawning → running → done/failed)、
+ * 子工具调用跟踪(进行中 + 已完成)、累积的文本 / 思考文本、定时器管理,
+ * 以及快照监听器通知。
  *
- * `ToolCallComponent` composes this store and delegates subagent mutations to
- * it, while retaining rendering (header, body, chip formatting) as its own
- * responsibility. External consumers (`AgentGroupComponent`, `ReadGroupComponent`,
- * `SubagentLiveViewer`) subscribe to snapshot change notifications through the
- * store.
+ * `ToolCallComponent` 组合此 store,把子 agent 变更委托给它,同时保留渲染
+ * (头部、主体、chip 格式化)为己任。外部消费者(`AgentGroupComponent`、
+ * `ReadGroupComponent`、`SubagentLiveViewer`)经此 store 订阅快照变更通知。
  */
 
 import { isAbsolute, relative, sep } from 'node:path';
@@ -55,14 +52,14 @@ export interface SubToolActivity {
 // ── Exported snapshot types ────────────────────────────────────────────
 
 /**
- * Immutable subagent state snapshot. `AgentGroupComponent` reads one-time
- * views via `ToolCallComponent.getSubagentSnapshot()`; `onSnapshotChange`
- * notifies it when state changes.
+ * 不可变子 agent 状态快照。`AgentGroupComponent` 经
+ * `ToolCallComponent.getSubagentSnapshot()` 读取一次性视图;
+ * `onSnapshotChange` 在状态变化时通知它。
  *
- * `latestActivity` priority, used only while running:
- *   1. latest ongoing sub-tool (`Using {name} ({keyArg})`)
- *   2. latest finished sub-tool (`Used {name} ({keyArg})`)
- *   3. last non-empty line from accumulated subagent text
+ * `latestActivity` 优先级,仅运行期间使用:
+ *   1. 最新的进行中子工具(`Using {name} ({keyArg})`)
+ *   2. 最新的已完成子工具(`Used {name} ({keyArg})`)
+ *   3. 累积子 agent 文本的最后一个非空行
  */
 export interface ToolCallSubagentSnapshot {
   readonly toolCallId: string;
@@ -79,9 +76,8 @@ export interface ToolCallSubagentSnapshot {
 }
 
 /**
- * Full subagent activity detail for the live viewer.
- * Contains the complete tool-call sequence (not truncated), all text output,
- * and thinking text.
+ * 供实时查看器使用的完整子 agent 活动详情。
+ * 包含完整工具调用序列(不截断)、全部文本输出与思考文本。
  */
 export interface SubagentActivityLine {
   readonly orderSeq: number;

--- a/apps/cli/src/tui/components/messages/thinking.ts
+++ b/apps/cli/src/tui/components/messages/thinking.ts
@@ -1,8 +1,7 @@
 /**
- * Renders thinking content in the transcript.
- * Supports live in-place updates while thinking streams, then finalizes
- * without replacing the component.
- * Supports expand/collapse via Ctrl+O (shared with tool output).
+ * 在 transcript 中渲染思考内容。
+ * 思考流式输出时支持原地实时更新,完成后定型而不替换组件。
+ * 支持通过 Ctrl+O 展开 / 折叠(与工具输出共享)。
  */
 
 import type { Component, TUI } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/components/messages/tool-call.ts
+++ b/apps/cli/src/tui/components/messages/tool-call.ts
@@ -1,6 +1,6 @@
 /**
- * Renders a tool call entry in the transcript.
- * Supports expand/collapse via Ctrl+O.
+ * 在 transcript 中渲染一条工具调用条目。
+ * 支持通过 Ctrl+O 展开 / 折叠。
  */
 
 import { Container, Text, Spacer, visibleWidth } from '@earendil-works/pi-tui';
@@ -36,10 +36,10 @@ const STREAMING_PROGRESS_INTERVAL_MS = 1000;
 const PROGRESS_URL_RE = /https?:\/\/\S+/g;
 
 /**
- * Immutable Read tool state snapshot. `ReadGroupComponent` reads one-time
- * views via `ToolCallComponent.getReadSnapshot()` and sums lines for the group
- * header. `lines` is 0 while pending or failed, and the non-empty result line
- * count when done, matching the single-card chip.
+ * 不可变 Read 工具状态快照。`ReadGroupComponent` 经
+ * `ToolCallComponent.getReadSnapshot()` 读取一次性视图,并为组头汇总行数。
+ * pending 或 failed 时 `lines` 为 0,完成时为非空结果行数,
+ * 与单卡片 chip 一致。
  */
 export interface ToolCallReadSnapshot {
   readonly toolCallId: string;

--- a/apps/cli/src/tui/components/messages/tool-renderers/chip.ts
+++ b/apps/cli/src/tui/components/messages/tool-renderers/chip.ts
@@ -1,11 +1,9 @@
 /**
- * Header chip providers — produce a short "stat" suffix appended to the
- * tool call header once a result has arrived. Chips own the *numeric*
- * summary (line counts, exit codes, byte sizes), so summary renderers
- * below don't repeat them.
+ * 头部 chip 提供者——结果到达后,生成追加到工具调用头部的短「统计」后缀。
+ * chip 拥有*数值*摘要(行数、退出码、字节大小),因此下面的摘要渲染器
+ * 不再重复它们。
  *
- * A chip returning `''` is suppressed; tools without an entry in the
- * registry get no chip at all.
+ * 返回 `''` 的 chip 被抑制;注册表中无条目的工具完全没有 chip。
  */
 
 import { computeDiffLines } from '#/tui/components/media/diff-preview';

--- a/apps/cli/src/tui/components/messages/tool-renderers/media.ts
+++ b/apps/cli/src/tui/components/messages/tool-renderers/media.ts
@@ -1,16 +1,13 @@
 /**
- * ReadMediaFile renderer.
+ * ReadMediaFile 渲染器。
  *
- * The ReadMediaFile tool `output` is the JSON-serialized array of
- * content parts the tool returned — which includes the full base64 of
- * the image/video. Dumping that string into the transcript blasts a
- * multi-screen blob of base64. This renderer parses the envelope and
- * surfaces just the human-readable bits (kind, path, mime, size) via
- * a header chip + a tiny expanded body. It never emits the base64.
+ * ReadMediaFile 工具的 `output` 是工具返回的内容 part 的 JSON 序列化数组——
+ * 包含图片 / 视频的完整 base64。把该字符串倾泻进 transcript 会爆出多屏
+ * base64 大块。本渲染器解析信封,仅通过头部 chip + 微型展开主体呈现
+ * 人类可读的部分(kind、path、mime、size)。它绝不发出 base64。
  *
- * On error, or when the output isn't the expected media envelope, we
- * fall back to the truncated renderer so the user still sees the raw
- * message.
+ * 出错或输出不是预期的媒体信封时,回退到截断渲染器,使用户仍能看到
+ * 原始消息。
  */
 
 import type { Component } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/components/messages/tool-renderers/registry.ts
+++ b/apps/cli/src/tui/components/messages/tool-renderers/registry.ts
@@ -1,13 +1,11 @@
 /**
- * Tool result renderer registry.
+ * 工具结果渲染器注册表。
  *
- * Each tool name maps to a `ResultRenderer` that turns the tool's
- * `ToolResultBlockData` into renderable Components. Tools without an
- * explicit entry fall through to `renderTruncated` (the original
- * 3-line + ctrl+o behavior).
+ * 每个工具名映射到一个把工具的 `ToolResultBlockData` 变为可渲染
+ * Component 的 `ResultRenderer`。没有显式条目的工具回退到
+ * `renderTruncated`(原始的 3 行 + ctrl+o 行为)。
  *
- * Keep this dispatch flat — tool names live next to the renderer they
- * choose, so adding a new tool means appending one case.
+ * 保持此分发扁平——工具名与其选择的渲染器相邻,新增工具只需追加一个分支。
  */
 
 import { shellExecutionResultRenderer } from '../shell-execution';

--- a/apps/cli/src/tui/components/messages/tool-renderers/summary.ts
+++ b/apps/cli/src/tui/components/messages/tool-renderers/summary.ts
@@ -1,13 +1,10 @@
 /**
- * Summary-style renderers — produce optional inline-glance content for
- * tools whose raw output is high-volume but low-information (Grep,
- * Glob). The numeric summary (line counts, exit codes, sizes) lives in
- * the header chip (see chip.ts), so most tools intentionally render an
- * empty body and only expose details when the global expand toggle is
- * on.
+ * 摘要式渲染器——为原始输出量大但信息量低的工具(Grep、Glob)生成可选
+ * 的一瞥式内联内容。数值摘要(行数、退出码、大小)位于头部 chip
+ * (见 chip.ts),因此多数工具有意渲染空主体,仅在全局展开开关开启时
+ * 暴露细节。
  *
- * Errors always fall through to the truncated renderer so the user
- * sees the actual error message, not a synthetic summary.
+ * 错误总是回退到截断渲染器,使用户看到真实错误消息,而非合成摘要。
  */
 
 import type { Component } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/components/messages/usage-panel.ts
+++ b/apps/cli/src/tui/components/messages/usage-panel.ts
@@ -1,7 +1,6 @@
 /**
- * UsagePanelComponent — wraps pre-coloured `/usage` lines in a blue box
- * border with a left indent, mirroring the PlanBoxComponent layout so
- * the pattern stays consistent across command-triggered panels.
+ * UsagePanelComponent — 把已着色的 `/usage` 行包进蓝色边框盒,带左缩进,
+ * 镜像 PlanBoxComponent 布局,使命令触发的面板保持一致的样式。
  */
 
 import type { InputTokenBreakdown, SessionUsage, TokenUsage } from '@byfriends/sdk';

--- a/apps/cli/src/tui/components/messages/user-message.ts
+++ b/apps/cli/src/tui/components/messages/user-message.ts
@@ -1,5 +1,5 @@
 /**
- * Renders a user message in the transcript.
+ * 在 transcript 中渲染一条用户消息。
  */
 
 import type { Component } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/config.ts
+++ b/apps/cli/src/tui/config.ts
@@ -1,8 +1,8 @@
 /**
- * TUI-owned configuration.
+ * TUI 自有的配置。
  *
- * Agent/runtime settings live in core's `config.toml`; this file owns only
- * terminal UI preferences for the BYF client.
+ * agent / 运行时设置位于核心的 `config.toml`;本文件只拥有 BYF 客户端的
+ * 终端 UI 偏好。
  */
 
 import { existsSync } from 'node:fs';
@@ -62,10 +62,9 @@ export const DEFAULT_TUI_CONFIG: TuiConfig = TuiConfigSchema.parse({
 });
 
 /**
- * Thrown by `loadTuiConfig` when the on-disk TOML cannot be parsed.
- * Carries `fallback` so the caller can recover without re-running the
- * I/O, and use `message` (== `INVALID_TUI_CONFIG_MESSAGE`) as a
- * user-facing notice.
+ * `loadTuiConfig` 在磁盘 TOML 无法解析时抛出。携带 `fallback`,
+ * 使调用方无需重跑 I/O 即可恢复,并使用 `message`
+ * (== `INVALID_TUI_CONFIG_MESSAGE`)作为用户可见提示。
  */
 export class TuiConfigParseError extends Error {
   override readonly name = 'TuiConfigParseError';

--- a/apps/cli/src/tui/constant/feedback.ts
+++ b/apps/cli/src/tui/constant/feedback.ts
@@ -1,10 +1,8 @@
 /**
- * Constants for the /feedback command — endpoints, telemetry keys, and
- * the status messages shown around the feedback submission flow.
+ * /feedback 命令的常量——端点、遥测键,以及反馈提交流程周围显示的状态消息。
  *
- * Dialog-internal copy (the box title, subtitle, footer) lives next to
- * the dialog component itself, since it is part of that component's
- * visual contract.
+ * 对话框内部文案(框标题、副标题、页脚)与对话框组件本体相邻,
+ * 因为它是该组件视觉契约的一部分。
  */
 
 import { FEEDBACK_VERSION_PREFIX } from '#/constant/app';

--- a/apps/cli/src/tui/constant/rendering.ts
+++ b/apps/cli/src/tui/constant/rendering.ts
@@ -1,13 +1,12 @@
-// Continuation indent for transcript rows that use a two-cell leading marker.
+// 使用两单元前导标记的 transcript 行的续行缩进。
 export const MESSAGE_INDENT = '  ';
 
-// Outer left/right padding applied to the transcript, panels, and the
-// statusline so the chrome's left edge lines up with the input box's
-// interior (the `>` prompt). The editor itself stays at column 0 — its
-// vertical borders are the visual anchor everything else aligns against.
+// 应用于 transcript、面板与状态行的外侧左 / 右内边距,使 chrome 左缘与
+// 输入框内部(「>」提示符)对齐。编辑器本身保持在列 0——其垂直边框是
+// 一切对齐所参照的视觉锚点。
 export const CHROME_GUTTER = 1;
 
-// Shared preview caps used by thinking, tool results, and shell snippets.
+// thinking、工具结果与 shell 片段共享的预览上限。
 export const RESULT_PREVIEW_LINES = 3;
 export const COMMAND_PREVIEW_LINES = 10;
 

--- a/apps/cli/src/tui/constant/streaming.ts
+++ b/apps/cli/src/tui/constant/streaming.ts
@@ -1,10 +1,10 @@
-// Extracts useful string fields from partially streamed JSON tool args.
-// This is intentionally a preview parser, not a full JSON parser.
+// 从部分流式传输的 JSON 工具参数中提取有用字符串字段。
+// 这刻意是预览解析器,而非完整 JSON 解析器。
 export const STREAMING_ARGS_FIELD_RE =
   /"(path|file_path|command|pattern|query|url|description|title|name)"\s*:\s*"((?:\\.|[^"\\])*)"/g;
 
-// Bounds live tool-argument previews; final tool.call payloads remain complete.
+// 限制实时工具参数预览;最终的 tool.call 负载保持完整。
 export const STREAMING_ARGS_PREVIEW_MAX_CHARS = 64 * 1024;
 
-// Coalesces high-frequency model/tool deltas before rebuilding TUI components.
+// 在重建 TUI 组件前合并高频的模型 / 工具 delta。
 export const STREAMING_UI_FLUSH_MS = 50;

--- a/apps/cli/src/tui/constant/symbols.ts
+++ b/apps/cli/src/tui/constant/symbols.ts
@@ -1,7 +1,6 @@
-// Use U+25CF instead of U+23FA to avoid emoji/fallback rendering in terminals.
+// 使用 U+25CF 而非 U+23FA,避免终端中的 emoji / 回退渲染。
 export const STATUS_BULLET = '● ';
 
-// Shared transcript markers. Keep widths stable because message wrapping
-// assumes the marker occupies the leading cells.
+// 共享 transcript 标记。保持宽度稳定,因为消息换行假定标记占据前导单元。
 export const USER_MESSAGE_BULLET = '✨ ';
 export const FAILURE_MARK = '✗ ';

--- a/apps/cli/src/tui/dialog-manager.ts
+++ b/apps/cli/src/tui/dialog-manager.ts
@@ -24,7 +24,7 @@ import { formatErrorMessage } from '#/tui/utils/event-payload';
  * the dialog layer a pure function of state + host + callbacks.
  */
 /**
- * Result type for usage loading (success or captured error message).
+ * 用量加载的结果类型(成功或捕获的错误消息)。
  */
 export interface UsageReportResult {
   readonly usage?: SessionUsage;
@@ -32,7 +32,7 @@ export interface UsageReportResult {
 }
 
 /**
- * Result type for runtime status loading (success or captured error message).
+ * 运行时状态加载的结果类型(成功或捕获的错误消息)。
  */
 export interface StatusReportResult {
   readonly status?: SessionStatus;
@@ -56,9 +56,8 @@ export interface DialogManagerCallbacks {
 }
 
 /**
- * Owns the editor-replacement dialogs and selectors that were previously
- * private methods on ByfTui. This shrinks the TUI god object while leaving
- * stateful editor/streaming/approval logic where it belongs.
+ * 拥有此前为 ByfTui 私有方法的编辑器替换对话框与选择器。
+ * 这缩小了 TUI 上帝对象,同时把有状态的编辑器 / 流式 / 审批逻辑留在原位。
  */
 export class DialogManager {
   constructor(

--- a/apps/cli/src/tui/events/cron-fired-notice.ts
+++ b/apps/cli/src/tui/events/cron-fired-notice.ts
@@ -1,8 +1,7 @@
 /**
- * Pure formatter for session-cron `cron.fired` TUI notice cards (PRD-0023 #244).
+ * 会话内 cron `cron.fired` TUI 通知卡片的纯格式化器(PRD-0023 #244)。
  *
- * Kept out of ByfTui so the title/detail rules are unit-testable without
- * spinning up the full interactive host.
+ * 留在 ByfTui 之外,使标题 / 详情规则无需启动完整交互宿主即可单元测试。
  */
 
 export interface CronFiredNoticeOrigin {
@@ -19,8 +18,8 @@ export interface CronFiredNotice {
 const DETAIL_MAX = 200;
 
 /**
- * Build the notice title + detail for a `cron.fired` wire event.
- * Detail is truncated at 200 characters with an ellipsis when longer.
+ * 为 `cron.fired` wire 事件构建通知标题 + 详情。
+ * 详情超过 200 字符时以省略号截断。
  */
 export function formatCronFiredNotice(
   origin: CronFiredNoticeOrigin,

--- a/apps/cli/src/tui/events/goal-event-handler.ts
+++ b/apps/cli/src/tui/events/goal-event-handler.ts
@@ -1,17 +1,14 @@
 /**
- * goal.updated event handler (PRD-0019 #204 / #205).
+ * goal.updated 事件处理器(PRD-0019 #204 / #205)。
  *
- * Receives `goal.updated` events from the SDK event stream and projects them
- * onto two UI surfaces:
- *   1. The live footer badge — driven by the latest snapshot.
- *   2. The transcript — lifecycle markers (pause/resume/blocked/cancel) and
- *      the completion card, derived from the event `change` tag plus
- *      status-transition detection.
+ * 从 SDK 事件流接收 `goal.updated` 事件,投影到两个 UI 表面:
+ *   1. 实时页脚徽章——由最新快照驱动。
+ *   2. transcript——生命周期标记(pause/resume/blocked/cancel)与完成卡片,
+ *      由事件 `change` 标签加状态转换检测派生。
  *
- * Pure projection — does not mutate session state. Live/replay consistency is
- * guaranteed because both paths consume the same `goal.updated` event. The
- * handler tracks the previous status locally so pause/resume transitions
- * (which carry no `change` tag) can be surfaced as lifecycle markers.
+ * 纯投影——不修改会话状态。live/replay 一致性有保证,因为两条路径消费
+ * 同一个 `goal.updated` 事件。本处理器在本地跟踪上一状态,使不带
+ * `change` 标签的 pause/resume 转换也能作为生命周期标记呈现。
  */
 
 import type { GoalChange, GoalSnapshot, GoalStatus, GoalUpdatedEvent } from '@byfriends/sdk';

--- a/apps/cli/src/tui/flows/dialog-prompts.ts
+++ b/apps/cli/src/tui/flows/dialog-prompts.ts
@@ -104,11 +104,11 @@ export function promptConfiguredProviderSelection(
 }
 
 /**
- * Opens the API interface-type picker shown as the first `/login` step.
- * Returns the chosen ProviderType string, or `undefined` when cancelled.
+ * 打开作为 `/login` 第一步显示的 API 接口类型选择器。
+ * 返回选中的 ProviderType 字符串,取消时返回 `undefined`。
  *
- * Options are owned by the caller (`options`) so login-flow can keep the
- * per-type base-URL defaults next to the dispatch logic.
+ * 选项由调用方(`options`)持有,使 login-flow 能把各类型的 base-URL
+ * 默认值保留在分发逻辑旁。
  */
 export function promptApiTypeSelection(
   host: DialogHost,

--- a/apps/cli/src/tui/flows/login-flow.ts
+++ b/apps/cli/src/tui/flows/login-flow.ts
@@ -31,10 +31,9 @@ export interface ModelSelection {
 export type { SpinnerHandle } from '#/tui/utils/catalog-fetch';
 
 /**
- * Interface types offered by `/login`. Each entry maps to its native
- * model-listing fetcher and its official default base URL (used when the user
- * leaves the base-URL input empty). `google-genai` / `vertexai` are deferred —
- * their runtime does not consume a user-supplied baseUrl (ADR 0016).
+ * `/login` 提供的接口类型。每个条目映射到其原生模型列表获取器与官方默认
+ * base URL(用户留空 base-URL 输入时使用)。`google-genai` / `vertexai`
+ * 被推迟——其运行时不消费用户提供的 baseUrl(ADR 0016)。
  */
 
 export interface LoginFlowDeps {

--- a/apps/cli/src/tui/reverse-rpc/base-controller.ts
+++ b/apps/cli/src/tui/reverse-rpc/base-controller.ts
@@ -1,11 +1,10 @@
 /**
- * Base class for promise-based reverse RPC dialog controllers.
+ * 基于 promise 的 reverse RPC 对话框控制器基类。
  *
- * Approval and question flows wait for a UI action before returning a response.
- * Subclasses only need to define the default cancellation response.
+ * 审批与问题流程在返回响应前等待 UI 动作。子类只需定义默认取消响应。
  *
- * When concurrent requests arrive (e.g. multiple parallel subagents each
- * needing approval), only one panel is shown at a time; additional requests
+ * 并发请求到达时(如多个并行子 agent 各自需要审批),同一时间只显示一个
+ * 面板;额外请求
  * are queued in arrival order and advance after the current one resolves.
  */
 

--- a/apps/cli/src/tui/reverse-rpc/types.ts
+++ b/apps/cli/src/tui/reverse-rpc/types.ts
@@ -1,9 +1,8 @@
 /**
- * Reverse RPC view-layer types.
+ * Reverse RPC 视图层类型。
  *
- * These types are the contract between the UI layer and reverse RPC
- * controllers, not SDK event payloads. Approval and question adapters convert
- * core payloads into these shapes for panel components.
+ * 这些类型是 UI 层与 reverse RPC 控制器之间的契约,而非 SDK 事件负载。
+ * 审批与问题适配器把核心负载转换为这些形态供面板组件使用。
  */
 
 import type { QuestionAnswerMethod } from '@byfriends/sdk';
@@ -41,7 +40,7 @@ export interface FileOpDisplayBlock {
   detail?: string;
 }
 
-/** Full file content preview for Write — a code block, not a diff. */
+/** Write 的完整文件内容预览——代码块,而非 diff。 */
 export interface FileContentDisplayBlock {
   type: 'file_content';
   path: string;

--- a/apps/cli/src/tui/theme/colors.ts
+++ b/apps/cli/src/tui/theme/colors.ts
@@ -1,13 +1,13 @@
 /**
- * Color palette definitions for dark and light themes.
+ * 暗色与亮色主题的调色板定义。
  *
- * Two layers:
- *  - private `dark` / `light` raw palettes — unsemantic constants reused
- *    across multiple semantic tokens to avoid hex literal duplication.
- *  - exported `darkColors` / `lightColors` — the semantic `ColorPalette`
- *    consumed by every UI component via chalk.hex(...).
+ * 两层:
+ *  - 私有 `dark` / `light` 原始调色板——跨多个语义 token 复用的无语义常量,
+ *    避免十六进制字面量重复。
+ *  - 导出的 `darkColors` / `lightColors`——每个 UI 组件经 chalk.hex(...)
+ *    消费的语义 `ColorPalette`。
  *
- * Light palette values are tuned for ≥ 4.5:1 contrast against #FFFFFF
+ * 亮色调色板值针对与 #FFFFFF 的 ≥ 4.5:1 对比度调校
  * for text tokens and ≥ 3:1 for chrome (border / large text), matching
  * WCAG AA.
  */

--- a/apps/cli/src/tui/theme/detect.ts
+++ b/apps/cli/src/tui/theme/detect.ts
@@ -1,15 +1,14 @@
 /**
- * Terminal background detection.
+ * 终端背景检测。
  *
- * Strategy, in priority order:
- *   1. Reject — non-TTY, NO_COLOR, FORCE_COLOR=0, CI → safe `'dark'`.
- *   2. OSC 11 — write `ESC ] 11 ; ? BEL`, parse `ESC ] 11 ; rgb:RR/GG/BB BEL`,
- *      compute relative luminance. Capped at `timeoutMs` so unsupported
- *      terminals don't hang.
- *   3. COLORFGBG — VT100 / xterm fallback exposing `"fg;bg"`.
- *   4. Default — `'dark'`.
+ * 策略,按优先级:
+ *   1. 拒绝——非 TTY、NO_COLOR、FORCE_COLOR=0、CI → 安全 `'dark'`。
+ *   2. OSC 11——写入 `ESC ] 11 ; ? BEL`,解析 `ESC ] 11 ; rgb:RR/GG/BB BEL`,
+ *      计算相对亮度。以 `timeoutMs` 为上限,使不支持的终端不会挂起。
+ *   3. COLORFGBG——暴露 `"fg;bg"` 的 VT100 / xterm 回退。
+ *   4. 默认——`'dark'`。
  *
- * Must run before pi-tui enters raw mode; once the framework owns stdin
+ * 必须在 pi-tui 进入 raw 模式前运行;一旦框架拥有 stdin
  * the OSC reply gets eaten by the input loop.
  */
 
@@ -105,8 +104,8 @@ async function queryOsc11(opts: { timeoutMs: number }): Promise<ResolvedTheme | 
 }
 
 /**
- * COLORFGBG is `"fg;bg"` (sometimes `"fg;default;bg"`). The last token is
- * the background ANSI 16-color index; 0–6 and 8 are dark, the rest light.
+ * COLORFGBG 是 `"fg;bg"`(有时为 `"fg;default;bg"`)。最后一个 token 是
+ * 背景 ANSI 16 色索引;0–6 与 8 为暗色,其余为亮色。
  */
 export function parseColorFgBg(value: string | undefined): ResolvedTheme | null {
   if (value === undefined || value === '') return null;

--- a/apps/cli/src/tui/theme/index.ts
+++ b/apps/cli/src/tui/theme/index.ts
@@ -1,5 +1,5 @@
 /**
- * Theme system public API.
+ * 主题系统公开 API。
  */
 
 import type { ResolvedTheme } from './colors';
@@ -13,11 +13,9 @@ export { createMarkdownTheme, createEditorTheme } from './pi-tui-theme';
 export { detectTerminalTheme } from './detect';
 
 /**
- * User-facing theme preference. `'auto'` defers to terminal background
- * detection at startup; `'dark'` / `'light'` are explicit overrides that
- * never trigger detection. The persisted value in `tui.toml` is always
- * one of these three; the detected `ResolvedTheme` is computed at
- * startup and held only in memory.
+ * 用户可见的主题偏好。`'auto'` 在启动时交给终端背景检测;`'dark'` /
+ * `'light'` 是永不触发检测的显式覆盖。`tui.toml` 中持久化的值始终是
+ * 三者之一;检测出的 `ResolvedTheme` 在启动时计算,仅存于内存。
  */
 export type Theme = 'dark' | 'light' | 'auto';
 
@@ -26,9 +24,8 @@ export function isTheme(value: string): value is Theme {
 }
 
 /**
- * Resolve a user preference to a concrete palette key. `'auto'` triggers
- * terminal background detection (OSC 11 with COLORFGBG / dark fallback);
- * explicit choices pass through.
+ * 把用户偏好解析为具体调色板键。`'auto'` 触发终端背景检测
+ * (OSC 11,COLORFGBG / 暗色回退);显式选择直接透传。
  */
 export async function resolveTheme(theme: Theme): Promise<ResolvedTheme> {
   if (theme === 'auto') return detectTerminalTheme();
@@ -36,9 +33,8 @@ export async function resolveTheme(theme: Theme): Promise<ResolvedTheme> {
 }
 
 /**
- * Synchronous fallback used by paths that cannot wait on terminal probes
- * (initial state construction, in-TUI theme switches). `'auto'` collapses
- * to `'dark'`; explicit choices pass through.
+ * 无法等待终端探测的路径使用的同步回退(初始状态构建、TUI 内主题切换)。
+ * `'auto'` 归并为 `'dark'`;显式选择直接透传。
  */
 export function resolveThemeSync(theme: Theme): ResolvedTheme {
   if (theme === 'auto') return 'dark';

--- a/apps/cli/src/tui/theme/pi-tui-theme.ts
+++ b/apps/cli/src/tui/theme/pi-tui-theme.ts
@@ -1,8 +1,9 @@
 /**
- * Pi-tui theme adapters — MarkdownTheme and EditorTheme from our ColorPalette.
+ * Pi-tui 主题适配器——由我们的 ColorPalette 派生 MarkdownTheme 与
+ * EditorTheme。
  *
- * All chalk calls route through `ColorPalette` tokens so themes flip
- * cleanly. No raw `chalk.gray` / `chalk.dim` / `chalk.white` here.
+ * 所有 chalk 调用都经 `ColorPalette` token 路由,使主题可干净切换。
+ * 此处没有裸的 `chalk.gray` / `chalk.dim` / `chalk.white`。
  */
 
 import type { MarkdownTheme, EditorTheme } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/theme/styles.ts
+++ b/apps/cli/src/tui/theme/styles.ts
@@ -1,8 +1,7 @@
 /**
- * Theme-aware style helpers built on chalk. Components hold a reference
- * to a `ThemeStyles` instance via `state.theme.styles` and never reach into
- * raw chalk color names — that keeps theme switches consistent and lets
- * every visual token route through `ColorPalette`.
+ * 构建于 chalk 之上的主题感知样式辅助。组件经 `state.theme.styles` 持有
+ * `ThemeStyles` 实例的引用,绝不直接触碰原始 chalk 颜色名——这使主题切换
+ * 保持一致,并让每个视觉 token 都经 `ColorPalette` 路由。
  */
 
 import chalk from 'chalk';

--- a/apps/cli/src/tui/types.ts
+++ b/apps/cli/src/tui/types.ts
@@ -111,11 +111,10 @@ export interface SubagentReplayToolCallData {
 }
 
 /**
- * Sub-agent token usage shape: the input breakdown (cache read/creation/other)
- * plus output. Mirrors `TokenUsage` from `@byfriends/kosong`, which is what
- * `ResumedAgentState.usage.total` carries. Shared by the live path
- * (`ToolCallComponent.subagentUsage`) and the replay path
- * (`SubagentReplayBlockData.usage`).
+ * 子 agent token 用量形态:输入细分(缓存读 / 创建 / 其他)加输出。
+ * 镜像 `@byfriends/kosong` 的 `TokenUsage`——`ResumedAgentState.usage.total`
+ * 携带的正是它。live 路径(`ToolCallComponent.subagentUsage`)与 replay
+ * 路径(`SubagentReplayBlockData.usage`)共享。
  */
 export interface SubagentTokenUsage {
   readonly input?: number;
@@ -160,10 +159,9 @@ export interface CompactionTranscriptData {
 }
 
 /**
- * Completion-card payload for a finished goal (PRD-0019 R14). Only a model
- * `UpdateGoal('complete')` produces this — `cancel` renders a plain lifecycle
- * marker instead. `snapshot` is the live snapshot captured at completion time
- * (carries objective + final usage); `reason` is the optional model reason.
+ * 已完成 goal 的完成卡片负载(PRD-0019 R14)。只有模型 `UpdateGoal('complete')`
+ * 产生它——`cancel` 改为渲染普通生命周期标记。`snapshot` 是完成时刻捕获的
+ * 实时快照(携带目标 + 最终用量);`reason` 是可选的模型原因。
  */
 export interface GoalCompletionData {
   readonly objective: string;

--- a/apps/cli/src/tui/utils/background-task-status.ts
+++ b/apps/cli/src/tui/utils/background-task-status.ts
@@ -1,12 +1,11 @@
 /**
- * Format a `BackgroundTaskInfo` snapshot into the transcript card data
- * consumed by `BackgroundAgentStatusComponent`.
+ * 把 `BackgroundTaskInfo` 快照格式化为
+ * `BackgroundAgentStatusComponent` 消费的 transcript 卡片数据。
  *
- * Background tasks have six statuses (running / awaiting_approval /
- * completed / failed / killed / lost) but the transcript card only
- * renders three visual phases (started / completed / failed). The
- * mapping packs the extra nuance — exit code, kill reason, lost-reason
- * — into the dim detail line so the user still sees it.
+ * 后台任务有六种状态(running / awaiting_approval / completed / failed /
+ * killed / lost),但 transcript 卡片只渲染三个视觉阶段
+ * (started / completed / failed)。该映射把额外的细微信息——退出码、
+ * 终止原因、丢失原因——压进暗色详情行,使用户仍能看到。
  */
 
 import type { BackgroundTaskInfo, BackgroundTaskStatus } from '@byfriends/sdk';
@@ -88,10 +87,9 @@ function detailFor(info: BackgroundTaskInfo): string | undefined {
 }
 
 /**
- * Build a transcript card payload for a background task lifecycle
- * snapshot. The returned phase drives bullet color in the renderer
- * (`BackgroundAgentStatusComponent`); the detail line carries the extra
- * status nuance (exit code, kill reason, etc.).
+ * 为后台任务生命周期快照构建 transcript 卡片负载。返回的阶段驱动渲染器
+ * (`BackgroundAgentStatusComponent`)中的圆点颜色;详情行携带额外状态
+ * 细微信息(退出码、终止原因等)。
  */
 export function formatBackgroundTaskTranscript(
   info: BackgroundTaskInfo,

--- a/apps/cli/src/tui/utils/catalog-fetch.ts
+++ b/apps/cli/src/tui/utils/catalog-fetch.ts
@@ -24,10 +24,9 @@ export interface CatalogFetchOptions {
 }
 
 /**
- * Fetches the models.dev catalog with a hard timeout and cancel-in-flight
- * wiring, falling back to the built-in catalog when allowed. Shared by
- * /login (best-effort enrichment, ADR 0012) and /connect (catalog is
- * essential, errors are surfaced).
+ * 带硬超时与取消进行中请求接线的 models.dev 目录获取,允许时回退到内置
+ * 目录。/login(尽力增强,ADR 0012)与 /connect(目录是必需的,错误被
+ * 呈现)共享。
  */
 export async function fetchCatalogWithFallback(
   opts: CatalogFetchOptions,

--- a/apps/cli/src/tui/utils/dead-terminal.ts
+++ b/apps/cli/src/tui/utils/dead-terminal.ts
@@ -1,11 +1,9 @@
 /**
- * Detects errors that mean the controlling terminal (stdout/stderr pty) is
- * effectively gone — for example after the parent shell crashed, the tmux
- * server vanished, or an SSH connection dropped without delivering SIGHUP.
+ * 检测意味着控制终端(stdout/stderr pty)实际已消失的错误——例如父 shell
+ * 崩溃、tmux 服务端消失,或 SSH 连接未送达 SIGHUP 即断开。
  *
- * Continuing to write to a dead terminal would re-fire the same error on every
- * render tick and pin a CPU core. Callers should respond by skipping any
- * cleanup that touches stdout/stderr and exiting immediately.
+ * 继续向死终端写入会在每个渲染 tick 重复触发同一错误并钉死一个 CPU 核。
+ * 调用方应跳过任何触碰 stdout/stderr 的清理并立即退出。
  */
 const DEAD_TERMINAL_ERROR_CODES = new Set<string>(['EIO', 'EPIPE', 'ENOTCONN']);
 

--- a/apps/cli/src/tui/utils/image-attachment-store.ts
+++ b/apps/cli/src/tui/utils/image-attachment-store.ts
@@ -1,18 +1,15 @@
 /**
- * Registry for media pasted into the input box.
+ * 粘贴进输入框的媒体注册表。
  *
- * Each paste produces an `ImageAttachment` with an auto-incrementing id
- * or `VideoAttachment` with a human-readable placeholder (`[image #1
- * (640×480)]` / `[video #2 sample.mov]`). The placeholder is what the
- * user sees in the input field; on submit, `extractMediaAttachments`
- * walks the text and expands image placeholders to image content parts
- * and video placeholders to file-path tags for `ReadMediaFile`.
+ * 每次粘贴产生一个带自增 id 的 `ImageAttachment`,或带人类可读占位符的
+ * `VideoAttachment`(`[image #1 (640×480)]` / `[video #2 sample.mov]`)。
+ * 占位符是用户在输入字段中看到的内容;提交时,`extractMediaAttachments`
+ * 遍历文本,把图片占位符展开为图片内容 part,视频占位符展开为
+ * `ReadMediaFile` 的文件路径标签。
  *
- * Scope is per-`ByfTui` instance. Reloads (`/new`, `/clear`,
- * session switch) call `clear()` so ids restart from 1 and stale
- * prompt attachments are dropped. We intentionally do NOT persist
- * attachments across sessions — coding-agent doesn't either, and
- * `--resume` wouldn't know how to materialize the files anyway.
+ * 作用域为每个 `ByfTui` 实例。重载(`/new`、`/clear`、切换会话)调用
+ * `clear()`,使 id 从 1 重新开始,过期提示附件被丢弃。我们刻意**不**跨会话
+ * 持久化附件——coding-agent 也不这么做,且 `--resume` 无从物化这些文件。
  */
 
 export interface ImageAttachment {

--- a/apps/cli/src/tui/utils/image-placeholder.ts
+++ b/apps/cli/src/tui/utils/image-placeholder.ts
@@ -1,18 +1,15 @@
 /**
- * Scan submitted text for media placeholders and produce
- * the `PromptPart[]` we'll send to the SDK prompt endpoint.
+ * 扫描提交的文本中的媒体占位符,生成要发送到 SDK prompt 端点的
+ * `PromptPart[]`。
  *
- * Rules:
- *   - Only placeholders that resolve against `store` get extracted.
- *     A literal `[image #999 ...]` the user typed themselves stays in
- *     the text (we can't hallucinate files for it).
- *   - Order is preserved for text/image/video segments. Image placeholders
- *     expand to image content parts so the prompt reaches the provider
- *     without relying on a model tool call. Video placeholders still expand
- *     to file-path tags so `ReadMediaFile` can own video upload behavior.
- *   - Adjacent text segments are flattened — empty / whitespace-only
- *     segments drop out so we never emit `{type:'text', text:' '}`
- *     noise between two media parts.
+ * 规则:
+ *   - 只有能对照 `store` 解析的占位符才被提取。用户自己输入的
+ *     字面量 `[image #999 ...]` 保留在文本中(我们不能为它臆造文件)。
+ *   - 文本 / 图片 / 视频段的顺序被保留。图片占位符展开为图片内容 part,
+ *     使提示词无需依赖模型工具调用即可到达 provider。视频占位符仍展开为
+ *     文件路径标签,让 `ReadMediaFile` 负责视频上传行为。
+ *   - 相邻文本段被展平——空 / 仅空白的段被丢弃,避免在两个媒体 part 之间
+ *     发出 `{type:'text', text:' '}` 噪声。
  */
 
 import type { PromptPart } from '@byfriends/sdk';

--- a/apps/cli/src/tui/utils/mcp-tool-name.ts
+++ b/apps/cli/src/tui/utils/mcp-tool-name.ts
@@ -1,6 +1,5 @@
-// Decodes the `mcp__<server>__<tool>` qualified names produced by byf-core's
-// `qualifyMcpToolName`. Returns null for non-MCP tools and for hash-truncated
-// qualified names (where the trailing `__<tool>` segment has been collapsed).
+// 解码 byf-core 的 `qualifyMcpToolName` 产生的 `mcp__<server>__<tool>` 限定名。
+// 非 MCP 工具以及哈希截断的限定名(尾部 `__<tool>` 段已被折叠)返回 null。
 export function decodeMcpToolName(
   name: string,
 ): { readonly serverName: string; readonly toolName: string } | null {

--- a/apps/cli/src/tui/utils/object-patch.ts
+++ b/apps/cli/src/tui/utils/object-patch.ts
@@ -1,5 +1,5 @@
-// Returns true when applying `patch` would change at least one own property.
-// Used before UI refresh paths so repeated equivalent state patches are cheap.
+// 当应用 `patch` 至少会改变一个自有属性时返回 true。
+// 用于 UI 刷新路径之前,使重复的等价状态补丁保持廉价。
 export function hasPatchChanges<T extends object>(target: T, patch: Partial<T>): boolean {
   for (const key of Object.keys(patch) as Array<keyof T>) {
     if (!Object.is(target[key], patch[key])) return true;

--- a/apps/cli/src/tui/utils/paging.ts
+++ b/apps/cli/src/tui/utils/paging.ts
@@ -1,19 +1,18 @@
 /**
- * Pure paging math shared by list pickers (ChoicePicker, ModelSelector).
+ * 列表选择器(ChoicePicker、ModelSelector)共享的纯分页数学。
  *
- * The component owns a single `selectedIndex` into its (already filtered)
- * item list; the page is derived from it, so ↑↓ moves the cursor smoothly
- * across page boundaries while the view still shows an explicit page number.
+ * 组件拥有指向其(已过滤)条目列表的单一 `selectedIndex`;页码由其派生,
+ * 因此 ↑↓ 可平滑跨页移动光标,而视图仍显示明确的页码。
  */
 
 export interface PageView {
-  /** Zero-based index of the page containing `selectedIndex`. */
+  /** 包含 `selectedIndex` 的页码(从 0 起)。 */
   readonly page: number;
-  /** Total number of pages; always at least 1, even for an empty list. */
+  /** 总页数;即使列表为空也至少为 1。 */
   readonly pageCount: number;
-  /** Inclusive slice start of the current page. */
+  /** 当前页的包含式切片起点。 */
   readonly start: number;
-  /** Exclusive slice end of the current page (clamped to `total`). */
+  /** 当前页的排他式切片终点(钳制到 `total`)。 */
   readonly end: number;
 }
 

--- a/apps/cli/src/tui/utils/printable-key.ts
+++ b/apps/cli/src/tui/utils/printable-key.ts
@@ -1,23 +1,21 @@
 /**
- * Decode raw stdin bytes into a comparable printable character.
+ * 把原始 stdin 字节解码为可比较的可打印字符。
  *
- * When a terminal (e.g. the VSCode integrated terminal) enables the Kitty
- * keyboard protocol disambiguate flag, ordinary printable keys are sent as
- * CSI-u sequences: pressing `r` arrives as "\x1b[114u", pressing `q` as
- * "\x1b[113u". A bare `data === 'q'` comparison inside a Container's
- * `handleInput` therefore never matches under Kitty-mode terminals.
+ * 当终端(如 VSCode 集成终端)启用 Kitty 键盘协议的 disambiguate 标志时,
+ * 普通可打印键以 CSI-u 序列发送:按 `r` 到达 "\x1b[114u",按 `q` 到达
+ * "\x1b[113u"。因此在 Kitty 模式终端下,Container `handleInput` 内裸的
+ * `data === 'q'` 比较永远不会命中。
  *
- * Rules:
- * - Every bare-literal printable-character comparison (letters, digits,
- *   space, punctuation) must go through this function first.
- * - Functional keys (arrows, Enter, Tab, Esc, ...) continue to use
- *   `matchesKey(data, Key.*)`; pi-tui's `matchesKey` already handles Kitty.
- * - Control characters (codepoint < 32, e.g. ctrl-b, ctrl-f) may still
- *   compare against the raw `data` — `decodeKittyPrintable` rejects them.
+ * 规则:
+ * - 所有裸字面量可打印字符比较(字母、数字、空格、标点)必须先经过本函数。
+ * - 功能键(方向键、Enter、Tab、Esc …)继续使用 `matchesKey(data, Key.*)`;
+ *   pi-tui 的 `matchesKey` 已处理 Kitty。
+ * - 控制字符(codepoint < 32,如 ctrl-b、ctrl-f)仍可比较原始 `data`——
+ *   `decodeKittyPrintable` 会拒绝它们。
  *
- * The module's existence is itself the "don't forget to decode" constraint:
- * `test/tui/printable-key-guard.test.ts` scans every `handleInput` under
- * `tui/components/**` and rejects bare-literal comparisons.
+ * 本模块的存在本身就是「别忘了解码」的约束:
+ * `test/tui/printable-key-guard.test.ts` 扫描 `tui/components/**` 下每个
+ * `handleInput`,拒绝裸字面量比较。
  */
 
 import { decodeKittyPrintable } from '@earendil-works/pi-tui';
@@ -27,9 +25,8 @@ export function printableChar(data: string): string {
 }
 
 /**
- * True when a decoded key is a single printable character safe to append to a
- * text query (e.g. a search box). Rejects C0 control chars, DEL, and any
- * multi-codepoint escape sequence. Space is accepted.
+ * 当解码后的键是单个可打印字符、可安全追加到文本查询(如搜索框)时为 true。
+ * 拒绝 C0 控制字符、DEL 与任何多码点转义序列。空格被接受。
  */
 export function isPrintableChar(ch: string): boolean {
   if (ch.length !== 1) return false;

--- a/apps/cli/src/tui/utils/proctitle.ts
+++ b/apps/cli/src/tui/utils/proctitle.ts
@@ -1,12 +1,11 @@
 /**
- * Terminal window title synchronization.
+ * 终端窗口标题同步。
  *
- * Uses the session title when present, capped at 80 characters to keep tabs
- * readable. New or unnamed sessions fall back to `Byf Code`.
+ * 会话标题存在时使用它,截断到 80 字符以保持标签页可读。
+ * 新会话或无标题会话回退为 `Byf Code`。
  *
- * Writes both `process.title`, for process listings, and OSC 0/2 escape
- * sequences, which most terminals use for window/tab titles. Non-TTY stdout
- * skips the OSC write.
+ * 同时写入 `process.title`(用于进程列表)与 OSC 0/2 转义序列
+ * (多数终端用它设置窗口 / 标签页标题)。stdout 非 TTY 时跳过 OSC 写入。
  */
 import { PRODUCT_NAME } from '#/constant/app';
 import { MAX_PROCESS_TITLE_LENGTH } from '#/tui/constant/terminal';

--- a/apps/cli/src/tui/utils/sanitize-text.ts
+++ b/apps/cli/src/tui/utils/sanitize-text.ts
@@ -1,31 +1,25 @@
 /**
- * Matches ANSI escape sequences that terminals interpret as commands rather
- * than printable text. This includes CSI sequences (colors, cursor movement,
- * erase), OSC sequences (hyperlinks, window titles), and APC sequences.
+ * 匹配终端解释为命令而非可打印文本的 ANSI 转义序列。包括 CSI 序列
+ * (颜色、光标移动、擦除)、OSC 序列(超链接、窗口标题)与 APC 序列。
  *
- * deliberately conservative: any ESC-prefixed sequence is removed so the TUI
- * layout cannot be corrupted by cursor positioning or erase commands embedded
- * in streamed output.
+ * 刻意保守:任何 ESC 前缀序列都被移除,使流式输出中嵌入的光标定位或
+ * 擦除命令无法破坏 TUI 布局。
  */
 const ANSI_ESCAPE_RE =
   /\u001B(?:[@-Z\\_-]|\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001B\\)|_.*?(?:\u0007|\u001B\\)|\^.*?\u001B\\)/g;
 
 /**
- * Sanitize external text before rendering it in the TUI.
+ * 在 TUI 中渲染前净化外部文本。
  *
- * Streamed sub-agent output (`assistant.delta`, tool output, error text) can
- * carry raw C0 control characters — `\r` (carriage return), `\b` (backspace),
- * `\x07` (bell), vertical tab / form feed, etc. In a terminal these move the
- * cursor or beep instead of rendering, which is what produced the
- * "one character per line" garble when a long output line contained a stray
- * `\r`. This helper replaces them with a visible placeholder so the layout
- * never gets corrupted by incoming content. `\t` is expanded to spaces so
- * column alignment stays predictable.
+ * 流式子 agent 输出(`assistant.delta`、工具输出、错误文本)可能携带原始
+ * C0 控制字符——`\r`(回车)、`\b`(退格)、`\x07`(响铃)、垂直制表 /
+ * 换页等。在终端中这些会移动光标或响铃而非渲染——当长输出行含游离 `\r`
+ * 时,正是它产生了「每行一个字符」的乱码。本辅助函数把它们替换为可见
+ * 占位符,使布局永不因传入内容而损坏。`\t` 展开为空格,列对齐保持可预期。
  *
- * The regex keeps the `g` flag to replace ALL control chars in one pass, but
- * is used only via `.replace()` (never `.test()`/`.exec()`), so there is no
- * `lastIndex` state to manage — `.replace()` does not leak `lastIndex` to the
- * caller for a single invocation.
+ * 正则保留 `g` 标志以一趟替换全部控制字符,但只经 `.replace()` 使用
+ * (绝不 `.test()`/`.exec()`),因此无需管理 `lastIndex` 状态——
+ * 单次调用的 `.replace()` 不会把 `lastIndex` 泄漏给调用方。
  */
 const CONTROL_CHAR_RE = /[\u0000-\u0008\u000B\u000C\u000D\u000E-\u001F\u007F]/g;
 
@@ -36,16 +30,13 @@ export function sanitizeForDisplay(text: string): string {
 }
 
 /**
- * Sanitize terminal output (e.g. captured stdout/stderr from a background
- * task) before it is rendered inside a TUI frame.
+ * 在 TUI 帧内渲染前净化终端输出(如后台任务捕获的 stdout/stderr)。
  *
- * Unlike {@link sanitizeForDisplay}, which keeps control chars visible as
- * placeholders for small inline snippets, this helper strips **all** ANSI
- * escape sequences and removes destructive C0 control characters (`\r`, `\b`,
- * `\x07`, etc.) entirely. Progress bars and live-updating CLI tools commonly
- * use `\r` or CSI cursor movement to redraw the same line; if those sequences
- * reach the TUI renderer they move the hardware cursor and overwrite panel
- * borders.
+ * 与 {@link sanitizeForDisplay}(为小型内联片段把控制字符保留为可见
+ * 占位符)不同,本辅助**剥离全部** ANSI 转义序列,并完全移除破坏性的
+ * C0 控制字符(`\r`、`\b`、`\x07` 等)。进度条与实时更新的 CLI 工具
+ * 常用 `\r` 或 CSI 光标移动重绘同一行;若这些序列到达 TUI 渲染器,
+ * 会移动硬件光标并覆盖面板边框。
  */
 export function sanitizeTerminalOutput(text: string): string {
   if (text.length === 0) return text;

--- a/apps/cli/src/tui/utils/searchable-list.ts
+++ b/apps/cli/src/tui/utils/searchable-list.ts
@@ -1,11 +1,10 @@
 /**
- * Cursor + fuzzy-search + paging state machine shared by list pickers
- * (ChoicePicker, ModelSelector). Pure logic, no rendering.
+ * 列表选择器(ChoicePicker、ModelSelector)共享的光标 + 模糊搜索 + 分页
+ * 状态机。纯逻辑,不渲染。
  *
- * The component owns presentation and the keys that carry component-specific
- * meaning — Enter (submit), Esc (cancel), and ←/→ (paging in one picker, a
- * thinking toggle in another). This unit owns the keys that behave identically
- * everywhere: ↑/↓, PgUp/PgDn, and search editing.
+ * 组件拥有呈现与携带组件特定含义的按键——Enter(提交)、Esc(取消)、
+ * ←/→(一个选择器里是分页,另一个里是思考切换)。本单元拥有各处行为
+ * 一致的按键:↑/↓、PgUp/PgDn 与搜索编辑。
  */
 
 import { fuzzyFilter, Key, matchesKey } from '@earendil-works/pi-tui';

--- a/apps/cli/src/tui/utils/terminal-notification.ts
+++ b/apps/cli/src/tui/utils/terminal-notification.ts
@@ -57,19 +57,17 @@ export function formatNotification(notification: TerminalNotification): string {
 }
 
 /**
- * Build the OSC/BEL bytes for a terminal notification.
+ * 构建终端通知的 OSC/BEL 字节。
  *
- * - `supportsOsc9 === true`: emit a single OSC 9 sequence — the modern
- *   desktop-notification path used by iTerm2, WezTerm, Kitty, Ghostty
- *   and Warp.
- * - `supportsOsc9 === false`: fall back to a bare BEL so the user still
- *   gets the system bell on terminals that don't recognize OSC 9.
+ * - `supportsOsc9 === true`:发出单个 OSC 9 序列——iTerm2、WezTerm、
+ *   Kitty、Ghostty 与 Warp 使用的现代桌面通知路径。
+ * - `supportsOsc9 === false`:回退为裸 BEL,使不识别 OSC 9 的终端
+ *   用户仍能听到系统响铃。
  *
- * When `insideTmux === true` and we're emitting OSC 9, wrap the sequence
- * in a tmux DCS passthrough (`ESC P tmux ; <payload> ESC \`) and double
- * any `ESC` bytes inside the payload — otherwise tmux swallows the OSC.
- * BEL is single-byte and passes through tmux unchanged, so no wrap is
- * needed in the fallback path.
+ * 当 `insideTmux === true` 且发出 OSC 9 时,把序列包进 tmux DCS
+ * 直通(`ESC P tmux ; <payload> ESC \`),并把负载内的任何 `ESC` 字节
+ * 加倍——否则 tmux 会吞掉 OSC。BEL 是单字节,经 tmux 原样透传,
+ * 因此回退路径无需包裹。
  */
 export function buildTerminalNotificationSequences(
   notification: TerminalNotification,
@@ -89,11 +87,9 @@ export function buildTerminalNotificationSequences(
 }
 
 /**
- * Best-effort detection of OSC 9 desktop-notification support, driven
- * entirely off well-known environment variables. The allow-list is
- * intentionally short and conservative because BEL is safe everywhere,
- * while shipping OSC 9 to a terminal that doesn't grok it would print
- * escape garbage on screen.
+ * OSC 9 桌面通知支持的尽力检测,完全依据已知环境变量驱动。允许列表
+ * 刻意短而保守,因为 BEL 处处安全,而向不识别 OSC 9 的终端发送它会
+ * 在屏幕上打印转义垃圾。
  */
 export function supportsOsc9Notification(env: NodeJS.ProcessEnv = process.env): boolean {
   const termProgram = env['TERM_PROGRAM'] ?? '';

--- a/apps/cli/src/utils/clipboard/clipboard-image.ts
+++ b/apps/cli/src/utils/clipboard/clipboard-image.ts
@@ -1,11 +1,10 @@
 /**
- * Read media from the system clipboard with graceful platform fallbacks.
+ * 从系统剪贴板读取媒体,带优雅的平台回退。
  *
- * byf-core's LLM pipeline only accepts PNG/JPEG/GIF/WebP, and the
- * clipboard sources we query already emit those formats on supported
- * platforms — so we deliberately do not include a BMP→PNG converter.
+ * byf-core 的 LLM 管线只接受 PNG/JPEG/GIF/WebP,而我们查询的剪贴板源
+ * 在受支持平台上已输出这些格式——因此刻意不包含 BMP→PNG 转换器。
  *
- * Lookup order:
+ * 查找顺序:
  *   macOS file clipboard       -> osascript/AppKit file URLs
  *   macOS / Windows            -> native `@mariozechner/clipboard`
  *   Linux Wayland              -> wl-paste

--- a/apps/cli/src/utils/clipboard/clipboard-native.ts
+++ b/apps/cli/src/utils/clipboard/clipboard-native.ts
@@ -1,11 +1,10 @@
 /**
- * Optional native clipboard binding.
+ * 可选的原生剪贴板绑定。
  *
- * `@mariozechner/clipboard` is a native Node binding that can read image
- * binaries from the system clipboard on macOS and Windows. It's an
- * optional dependency — if the native module fails to load (e.g. on a
- * platform where no prebuilt is available) we degrade to shell-based
- * fallbacks (wl-paste / xclip / PowerShell) in `clipboard-image.ts`.
+ * `@mariozechner/clipboard` 是可在 macOS 与 Windows 上从系统剪贴板读取
+ * 图片二进制的原生 Node 绑定。它是可选依赖——若原生模块加载失败
+ * (例如所在平台无预编译产物),我们在 `clipboard-image.ts` 中降级到
+ * 基于 shell 的回退(wl-paste / xclip / PowerShell)。
  */
 
 import { createRequire } from 'node:module';

--- a/apps/cli/src/utils/format.ts
+++ b/apps/cli/src/utils/format.ts
@@ -1,15 +1,14 @@
 /**
- * Pure formatting helpers used across TUI components.
+ * TUI 组件共用的纯格式化辅助。
  *
- * Kept ANSI-free (no chalk) so they're trivial to unit-test; colouring
- * is the caller's responsibility.
+ * 保持无 ANSI(不用 chalk),使单元测试简单;着色是调用方的责任。
  */
 
 /**
- * Format a byte count into a human-readable string (B / KB / MB).
- * Uses consistent `.toFixed(1)` for KB/MB.
+ * 把字节数格式化为人类可读字符串(B / KB / MB)。
+ * KB/MB 统一使用 `.toFixed(1)`。
  *
- * CANONICAL definition.  `apps/vis/web/src/components/shared/SizePreview.tsx`
+ * 规范定义。`apps/vis/web/src/components/shared/SizePreview.tsx`
  * duplicates this — keep both in sync.  There is intentionally no shared
  * utility package between the two apps.
  */
@@ -20,8 +19,8 @@ export function formatBytes(bytes: number): string {
 }
 
 /**
- * Format elapsed seconds into a human-readable string (s / m s).
- * Example: `30s`, `2m 15s`.
+ * 把已用秒数格式化为人类可读字符串(s / m s)。
+ * 示例:`30s`、`2m 15s`。
  */
 export function formatElapsed(seconds: number): string {
   if (seconds < 60) return `${String(seconds)}s`;

--- a/apps/cli/src/utils/git/git-ls-files.ts
+++ b/apps/cli/src/utils/git/git-ls-files.ts
@@ -1,11 +1,10 @@
 /**
- * Git-aware file listing + relevance signals with a short-TTL cache.
- * Used as the cross-directory `@file` completion source when `fd` is
- * not installed.
+ * Git 感知的文件列表 + 相关信号,带短 TTL 缓存。
+ * 未安装 `fd` 时作为跨目录 `@file` 补全源。
  *
- * Tracks three things per snapshot, all refreshed atomically:
- *   - `files`            deduped (tracked + untracked-not-ignored), capped at 1000
- *   - `mtimeByPath`      absolute-path → fs mtime (ms), for recency ranking
+ * 每个快照跟踪三样东西,全部原子刷新:
+ *   - `files`           去重(已跟踪 + 未跟踪且未忽略),上限 1000
+ *   - `mtimeByPath`     绝对路径 → fs mtime(毫秒),用于近期排序
  *   - `recencyOrder`     file path → position in recent git history (0-indexed; smaller = more recent)
  *
  * Rebuild strategy: 2s TTL plus `.git/index` mtime invalidation so

--- a/apps/cli/src/utils/git/git-status.ts
+++ b/apps/cli/src/utils/git/git-status.ts
@@ -1,10 +1,9 @@
 /**
- * Cached git branch + working-tree status for the footer/statusline.
+ * 页脚 / 状态行使用的缓存 git 分支 + 工作树状态。
  *
- * Branch name refreshes every 5s, porcelain status every 15s. Branch
- * and status reads stay synchronous with short timeouts. Pull request
- * lookup uses an async cache so a slow `gh pr view` never blocks
- * footer rendering.
+ * 分支名每 5s 刷新,porcelain 状态每 15s。分支与状态读取保持同步,
+ * 带短超时。拉取请求查找使用异步缓存,使慢 `gh pr view` 永不阻塞
+ * 页脚渲染。
  */
 
 import { execFile, spawnSync } from 'node:child_process';

--- a/apps/cli/src/utils/history/input-history.ts
+++ b/apps/cli/src/utils/history/input-history.ts
@@ -1,12 +1,12 @@
 /**
- * User input history persistence — JSONL file with `{"content": "..."}` per line.
+ * 用户输入历史持久化——JSONL 文件,每行 `{"content": "..."}`。
  *
- * Semantics:
- * - One JSON object per line (`InputHistoryEntry { content }`)
- * - Append-only writes
- * - Skip empty entries
- * - Skip when same as last entry (consecutive deduplication)
- * - Tolerate corrupt lines: log + skip, do not abort load
+ * 语义:
+ * - 每行一个 JSON 对象(`InputHistoryEntry { content }`)
+ * - 只追加写入
+ * - 跳过空条目
+ * - 与最后一条相同时跳过(连续去重)
+ * - 容忍损坏行:记录 + 跳过,不中止加载
  */
 
 import { z } from 'zod';
@@ -26,8 +26,8 @@ export async function loadInputHistory(file: string): Promise<InputHistoryEntry[
 }
 
 /**
- * Append an entry to the history file. Returns true if written, false if
- * skipped (empty or equal to `lastContent`).
+ * 向历史文件追加条目。写入时返回 true;跳过(空或等于 `lastContent`)
+ * 时返回 false。
  */
 export async function appendInputHistory(
   file: string,

--- a/apps/cli/src/utils/image/image-mime.ts
+++ b/apps/cli/src/utils/image/image-mime.ts
@@ -1,11 +1,10 @@
 /**
- * Detect image MIME type + dimensions from raw bytes.
+ * 从原始字节检测图片 MIME 类型 + 尺寸。
  *
- * Uses magic-byte sniffing for MIME and minimal format-specific parsing
- * for dimensions. Only formats that the byf-core multimodal pipeline
- * accepts are supported: PNG / JPEG / GIF / WebP.
+ * MIME 用 magic-byte 嗅探,尺寸用最小的格式特定解析。只支持 byf-core
+ * 多模态管线接受的格式:PNG / JPEG / GIF / WebP。
  *
- * Unsupported or truncated inputs return `null` so the caller can
+ * 不支持或截断的输入返回 `null`,使调用方可
  * decline the paste cleanly.
  */
 

--- a/apps/cli/src/utils/paths.ts
+++ b/apps/cli/src/utils/paths.ts
@@ -1,8 +1,8 @@
 /**
- * CLI-owned data path helpers.
+ * CLI 自有的数据路径辅助。
  *
- * These paths are for local app data such as logs and input history. Config
- * files are owned by Core/SDK and intentionally do not live behind this module.
+ * 这些路径用于日志、输入历史等本地应用数据。配置文件由 Core/SDK 拥有,
+ * 刻意不放在本模块之后。
  */
 
 import { createHash } from 'node:crypto';
@@ -19,9 +19,9 @@ import {
 } from '#/constant/app';
 
 /**
- * Return the root data directory for BYF.
+ * 返回 BYF 的根数据目录。
  *
- * Priority: `BYF_HOME` env var > `~/.byf`.
+ * 优先级:`BYF_HOME` 环境变量 > `~/.byf`。
  */
 export function getDataDir(): string {
   const envDir = process.env[BYF_HOME_ENV];
@@ -32,22 +32,22 @@ export function getDataDir(): string {
 }
 
 /**
- * Return the diagnostic log directory: `<dataDir>/logs/`.
+ * 返回诊断日志目录:`<dataDir>/logs/`。
  */
 export function getLogDir(): string {
   return join(getDataDir(), BYF_LOG_DIR_NAME);
 }
 
 /**
- * Return the update cache file: `<dataDir>/updates/latest.json`.
+ * 返回更新缓存文件:`<dataDir>/updates/latest.json`。
  */
 export function getUpdateStateFile(): string {
   return join(getDataDir(), BYF_UPDATE_DIR_NAME, BYF_UPDATE_STATE_FILE_NAME);
 }
 
 /**
- * Return the user input history file for a given working directory.
- * Layout: `<share_dir>/user-history/<md5(cwd)>.jsonl`.
+ * 返回给定工作目录的用户输入历史文件。
+ * 布局:`<share_dir>/user-history/<md5(cwd)>.jsonl`。
  */
 export function getInputHistoryFile(workDir: string): string {
   const hash = createHash('md5').update(workDir, 'utf-8').digest('hex');

--- a/apps/cli/src/utils/persistence.ts
+++ b/apps/cli/src/utils/persistence.ts
@@ -1,9 +1,8 @@
 /**
- * Small persistence helpers for CLI-owned data files.
+ * CLI 自有数据文件的小型持久化辅助。
  *
- * This module is intentionally for non-config files only. User-facing
- * configuration is owned by core/SDK; do not route `config.toml` through
- * these helpers.
+ * 本模块刻意只用于非配置文件。用户可见配置由 core/SDK 拥有;
+ * 不要把 `config.toml` 路由经这些辅助。
  */
 
 import { appendFile, mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';

--- a/apps/cli/src/utils/process/external-editor.ts
+++ b/apps/cli/src/utils/process/external-editor.ts
@@ -1,11 +1,10 @@
 /**
- * External-editor helper — spawn $VISUAL / $EDITOR (or a configured
- * command) on a temp file seeded with the current editor buffer, then
- * read the edited contents back.
+ * 外部编辑器辅助——在预置当前编辑器缓冲区的临时文件上拉起
+ * $VISUAL / $EDITOR(或配置的命令),然后读回编辑后的内容。
  *
- * Resolution priority:
- *   configured (from Core/SDK defaults or `/editor`) >
- *   $VISUAL > $EDITOR > undefined (caller handles "no editor" toast).
+ * 解析优先级:
+ *   配置的(来自 Core/SDK 默认或 `/editor`)>
+ *   $VISUAL > $EDITOR > undefined(调用方处理「无编辑器」toast)。
  */
 
 import { spawn } from 'node:child_process';
@@ -24,12 +23,11 @@ export function resolveEditorCommand(configured?: string | null): string | undef
 }
 
 /**
- * Launch `command` (tokenised via a shell) against a temp file seeded
- * with `initialText`. Returns the edited contents on success, or
- * `undefined` if the editor exited non-zero / the file disappeared.
+ * 对预置 `initialText` 的临时文件拉起 `command`(经 shell 分词)。
+ * 成功时返回编辑后的内容;编辑器以非零退出或文件消失时返回 `undefined`。
  *
- * The command is passed to `/bin/sh -c "<cmd> <tmpfile>"` so users can
- * supply argv-style strings like `"code --wait"` or `"nvim +set ft=markdown"`.
+ * 命令传给 `/bin/sh -c "<cmd> <tmpfile>"`,使用户可提供 `"code --wait"`
+ * 或 `"nvim +set ft=markdown"` 这类 argv 风格字符串。
  */
 export async function editInExternalEditor(
   initialText: string,

--- a/apps/cli/src/utils/process/fd-detect.ts
+++ b/apps/cli/src/utils/process/fd-detect.ts
@@ -1,14 +1,13 @@
 /**
- * Probe for the `fd` binary so the pi-tui `CombinedAutocompleteProvider`
- * can enable its cross-directory fuzzy file search.
+ * 探测 `fd` 二进制,使 pi-tui 的 `CombinedAutocompleteProvider` 能启用
+ * 跨目录模糊文件搜索。
  *
- * Naming differs across distros:
- *   - Homebrew / Arch / most Linuxes: `fd`
- *   - Debian / Ubuntu:                `fdfind`
+ * 各发行版命名不同:
+ *   - Homebrew / Arch / 多数 Linux:`fd`
+ *   - Debian / Ubuntu:`fdfind`
  *
- * We use `spawnSync(..., { stdio: 'ignore' })` rather than shelling out
- * to `which` so the check doesn't depend on the parent shell's PATH
- * resolution semantics and stays cheap (~ms) on startup.
+ * 我们用 `spawnSync(..., { stdio: 'ignore' })` 而非 shell 出去调 `which`,
+ * 使检查不依赖父 shell 的 PATH 解析语义,并在启动时保持廉价(~毫秒)。
  */
 
 import { spawnSync } from 'node:child_process';

--- a/apps/cli/src/utils/process/proctitle.ts
+++ b/apps/cli/src/utils/process/proctitle.ts
@@ -1,11 +1,11 @@
 /**
- * Early-startup process name initialization.
+ * 早期启动的进程名初始化。
  *
- * Sets the process title so `ps`/`top` and the terminal tab show
- * `Byf Code` from the moment the binary launches — before Commander
- * parses argv, before any preflight, even on `--help`/`--version`.
+ * 设置进程标题,使 `ps`/`top` 与终端标签页从二进制启动那一刻起就显示
+ * `Byf Code`——在 Commander 解析 argv 之前、任何预检之前,
+ * 甚至在 `--help`/`--version` 上也是如此。
  *
- * OSC is written to stderr (not stdout) so it still reaches the terminal
+ * OSC 写入 stderr(而非 stdout),使它仍能到达终端
  * when stdout is piped, e.g. `byf --print | grep ...`.
  */
 import { PRODUCT_NAME } from '#/constant/app';

--- a/apps/cli/src/utils/usage/usage-format.ts
+++ b/apps/cli/src/utils/usage/usage-format.ts
@@ -1,8 +1,7 @@
 /**
- * Formatting helpers for the `/usage` slash command.
+ * `/usage` 斜杠命令的格式化辅助。
  *
- * Kept pure + ANSI-free so they're trivial to unit-test; the slash
- * command itself chalks the colour afterwards.
+ * 保持纯函数 + 无 ANSI,使单元测试简单;斜杠命令之后自行着色。
  */
 
 export function formatTokenCount(n: number): string {
@@ -13,8 +12,8 @@ export function formatTokenCount(n: number): string {
 }
 
 /**
- * Build a `[███░░░░░░░]` style bar. Returns a plain-ASCII string with
- * `filled`/`empty` glyphs — colouring is the caller's responsibility.
+ * 构建 `[███░░░░░░░]` 风格条。返回带 `filled`/`empty` 字形的纯 ASCII
+ * 字符串——着色是调用方的责任。
  */
 export function renderProgressBar(ratio: number, width = 20, filled = '█', empty = '░'): string {
   const clamped = safeUsageRatio(ratio);
@@ -27,8 +26,8 @@ export function safeUsageRatio(ratio: number): number {
 }
 
 /**
- * Map a usage ratio to a semantic colour token — the `/usage` renderer
- * translates these into palette hex values.
+ * 把用量比例映射为语义颜色 token——`/usage` 渲染器将其转换为调色板
+ * 十六进制值。
  */
 export function ratioSeverity(ratio: number): 'ok' | 'warn' | 'danger' {
   if (ratio >= 0.85) return 'danger';
@@ -37,16 +36,16 @@ export function ratioSeverity(ratio: number): 'ok' | 'warn' | 'danger' {
 }
 
 /**
- * Coerce RPC/serialized values to a safe non-negative finite number, defaulting to 0.
+ * 把 RPC / 序列化值强制为安全的非负有限数,默认 0。
  */
 export function safeNumber(value: unknown): number {
   return Number.isFinite(value) && (value as number) >= 0 ? (value as number) : 0;
 }
 
 /**
- * Compute cache hit rate (0..1).
- * Formula: inputCacheRead / (inputOther + inputCacheRead + inputCacheCreation)
- * Returns undefined when denominator is zero (signal: "no data").
+ * 计算缓存命中率(0..1)。
+ * 公式:inputCacheRead / (inputOther + inputCacheRead + inputCacheCreation)
+ * 分母为零时返回 undefined(信号:「无数据」)。
  */
 export function computeCacheHitRate(
   inputOther: number,
@@ -59,9 +58,9 @@ export function computeCacheHitRate(
 }
 
 /**
- * Format cache hit rate as integer percentage string like "87%".
- * Uses round-half-to-even (banker's rounding) for exact .5 ties.
- * Returns undefined when rate is undefined or ≤ 0 (signal: "don't display").
+ * 把缓存命中率格式化为「87%」式的整数百分比字符串。
+ * 对精确 .5 平局使用四舍六入五成双(银行家舍入)。
+ * rate 为 undefined 或 ≤ 0 时返回 undefined(信号:「不显示」)。
  */
 export function formatCacheHitRate(rate: number | undefined): string | undefined {
   if (rate === undefined || rate <= 0) return undefined;


### PR DESCRIPTION
## 背景

仓库语言规范（`docs/agents/language.md`）要求公开 API 的 JSDoc 与文件/模块顶部注释按简体中文撰写。本 PR 将 CLI（apps/cli）源文件的此类注释统一为中文，与已合入的 agent-core 阶段（#280）保持一致。

cache-impact: none

## 改动内容

- **范围**：`apps/cli/src` 全部 116 个含英文注释的源文件中的**文件/模块顶部说明性注释**与 **export 符号上的 JSDoc**（tui 组件/工具/命令、utils、cli 子命令、native、constant 等），共 115 个文件、140+ 注释块。
- **范围纪律**：
  - 已译：模块头注释、公开函数/类/接口/常量 JSDoc、公开接口字段注释
  - 保留英文：函数体内部行内注释、`@deprecated` 等 JSDoc 标签、代码标识符与技术术语（如 `CSI-u`、`CronTaskSnapshot`）
- **代表性文件**：`tui/byf-tui.ts`、`components/dialogs/*`、`components/editor/custom-editor.ts`（含 Kitty 协议 caps_lock 变通方案注释）、`cli/update/source.ts`、`cli/headless-exit.ts`、`utils/git/*`、`native/standalone.ts` 等。

## 验收

- **零代码变更**：`git diff` 逐行校验——全部变更行均为注释（0 处非注释变更）
- `bun run --filter '@byfriends/cli' typecheck` 通过
- `bun run lint` 0 错误；`bun run fmt:check` 通过
- CLI 测试 **882 pass / 0 fail**

## Changeset

**无需 changeset**：注释在编译时被剥离、不进入发布产物，属于纯文档性改动（`gen-changesets` skill 规则 #6，与 #280 判定一致）。