### PR TITLE
docs(vis): 模块头注释与公开 JSDoc 译为中文

### DIFF
--- a/apps/vis/server/src/app.ts
+++ b/apps/vis/server/src/app.ts
@@ -109,14 +109,14 @@ function tokenMatches(actual: string, expected: string): boolean {
   return actualBytes.length === expectedBytes.length && timingSafeEqual(actualBytes, expectedBytes);
 }
 
-/** Result of building the Hono app; `staticEnabled` is false in API-only mode. */
+/** 构建 Hono 应用的结果;API-only 模式下 `staticEnabled` 为 false。 */
 export interface CreateAppResult {
   readonly app: Hono;
-  /** Whether the SPA bundle is being served. False means API-only. */
+  /** 是否正在提供 SPA bundle。false 表示仅 API。 */
   readonly staticEnabled: boolean;
 }
 
-/** Build a Hono app mounting /api/* routes, plus SPA static fallback. */
+/** 构建挂载 /api/* 路由的 Hono 应用,外加 SPA 静态回退。 */
 export async function createApp(options: CreateAppOptions = {}): Promise<CreateAppResult> {
   const app = new Hono();
 

--- a/apps/vis/server/src/config.ts
+++ b/apps/vis/server/src/config.ts
@@ -1,7 +1,7 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-/** Resolve BYF_HOME (env > ~/.byf). */
+/** 解析 BYF_HOME(env > ~/.byf)。 */
 export function resolveByfHome(): string {
   const envHome = process.env['BYF_HOME'];
   if (envHome !== undefined && envHome.length > 0) {
@@ -10,7 +10,7 @@ export function resolveByfHome(): string {
   return join(homedir(), '.byf');
 }
 
-/** HTTP port for the vis API server. */
+/** vis API 服务器的 HTTP 端口。 */
 export function resolvePort(): number {
   const raw = process.env['PORT'];
   if (raw !== undefined && raw.length > 0) {
@@ -22,7 +22,7 @@ export function resolvePort(): number {
   return 3001;
 }
 
-/** HTTP host for the vis API server. Defaults to loopback. */
+/** vis API 服务器的 HTTP 主机。默认为回环。 */
 export function resolveHost(): string {
   const raw = process.env['VIS_HOST'] ?? process.env['HOST'];
   const host = raw?.trim();

--- a/apps/vis/server/src/lib/agent-record-types.ts
+++ b/apps/vis/server/src/lib/agent-record-types.ts
@@ -1,6 +1,6 @@
 // apps/vis/server/src/lib/agent-record-types.ts
-// Re-exports shared DTOs from @byfriends/vis-shared.
-// Server-only runtime code (e.g. AGENT_WIRE_PROTOCOL_VERSION) stays here.
+// 从 @byfriends/vis-shared 重导出共享 DTO。
+// 仅服务端运行时代码(如 AGENT_WIRE_PROTOCOL_VERSION)留在此处。
 
 export { AGENT_WIRE_PROTOCOL_VERSION } from '@byfriends/agent-core';
 

--- a/apps/vis/server/src/lib/agent-tree.ts
+++ b/apps/vis/server/src/lib/agent-tree.ts
@@ -5,11 +5,10 @@ export interface AgentNode extends AgentInfo {
 }
 
 /**
- * Build a parent/child tree from the flat agent inventory found on
- * `state.json.agents`. Roots are agents with no `parentAgentId`, plus any
- * agent whose `parentAgentId` does not resolve in the inventory (orphans).
- * The returned roots are sorted so that the `main` agent always appears
- * first; remaining roots fall back to a stable lexicographic order.
+ * 从 `state.json.agents` 上的扁平 agent 清单构建父子树。根是无
+ * `parentAgentId` 的 agent,加上任何 `parentAgentId` 在清单中无法解析的
+ * agent(孤儿)。返回的根已排序,使 `main` agent 总是首先出现;其余根
+ * 回退到稳定的字典序。
  */
 export function buildAgentTree(agents: ReadonlyArray<AgentInfo>): AgentNode[] {
   const byId = new Map<string, AgentNode>();

--- a/apps/vis/server/src/lib/context-projector.ts
+++ b/apps/vis/server/src/lib/context-projector.ts
@@ -20,21 +20,18 @@ export type { ProjectedMessage, UsageTotals, ConfigSnapshot, ContextProjection }
 
 const ZERO: TokenUsage = { inputOther: 0, output: 0, inputCacheRead: 0, inputCacheCreation: 0 };
 
-/** Build a conversation timeline + derived state from a sequence of
- *  wire entries.
+/** 从一串 wire 条目构建会话时间线 + 派生状态。
  *
- *  The fold logic (step.begin/content.part/tool.call/tool.result/step.end,
- *  deferred-message flushing during tool exchanges, tool-output
- *  normalisation) is delegated to agent-core's `wire-fold` module (pure
- *  functions; single source of truth shared with the live agent). Each fold
- *  call returns the messages it committed, so vis attaches its display
- *  metadata (`lineNo` / `time` / `source`) to the return values instead of an
- *  `onMessage` effect port (Phase 5 signature adaptation — the effect ports
- *  are gone from the shared fold).
+ *  fold 逻辑(step.begin/content.part/tool.call/tool.result/step.end、
+ *  工具交换期间的延迟消息刷出、工具输出归一化)委托给 agent-core 的
+ *  `wire-fold` 模块(纯函数;与 live agent 共享的单一事实源)。每次 fold
+ *  调用返回其提交的消息,因此 vis 把展示元数据(`lineNo` / `time` /
+ *  `source`)附加到返回值,而非 `onMessage` effect 端口(Phase 5 签名
+ *  适配——共享 fold 中的 effect 端口已消失)。
  *
- *  vis-specific concerns stay here: attaching `lineNo` / `time` / `source`
- *  display metadata to each projected message, and aggregating usage /
- *  config / permission snapshots that the fold does not own. */
+ *  vis 特定关注点留在此处:为每条投影消息附加 `lineNo` / `time` /
+ *  `source` 展示元数据,并聚合 fold 不拥有的 usage / config /
+ *  permission 快照。 */
 export function projectContext(entries: ReadonlyArray<WireEntry>): ContextProjection {
   const messages: ProjectedMessage[] = [];
   const state: WireFoldState = createWireFoldState();

--- a/apps/vis/server/src/lib/reveal.ts
+++ b/apps/vis/server/src/lib/reveal.ts
@@ -5,8 +5,8 @@ export interface RevealCommand {
   readonly args: readonly string[];
 }
 
-/** Resolve the platform-specific "reveal in file manager" command for
- *  the given absolute path. Kept pure (no IO) so it can be unit-tested. */
+/** 为给定绝对路径解析平台特定的「在文件管理器中显示」命令。
+ *  保持纯函数(无 IO),使可单元测试。 */
 export function revealCommandFor(
   path: string,
   platform: NodeJS.Platform = process.platform,
@@ -24,10 +24,9 @@ export function revealCommandFor(
   }
 }
 
-/** Spawn the OS file manager to reveal `path`. Resolves once the launcher
- *  process has started; rejects only if the launcher itself fails to
- *  spawn (missing binary etc.) — not if it later fails to find the path,
- *  since the launcher exits asynchronously after we've detached. */
+/** 拉起 OS 文件管理器显示 `path`。启动器进程启动后 resolve;仅在启动器
+ *  本身无法拉起(缺少二进制等)时 reject——不会因它后来找不到路径而
+ *  reject,因为启动器在我们 detach 后异步退出。 */
 export async function revealInOs(path: string): Promise<void> {
   const { command, args } = revealCommandFor(path);
   return new Promise<void>((resolve, reject) => {

--- a/apps/vis/server/src/lib/session-store.ts
+++ b/apps/vis/server/src/lib/session-store.ts
@@ -8,11 +8,10 @@ import type { SessionSummary, SessionDetail, AgentInfo, SessionHealth } from './
 const SESSION_ID_RE = /^session_[A-Za-z0-9._-]+$/;
 const AGENT_ID_RE = /^[A-Za-z0-9._-]+$/;
 
-/** Reject agent ids that could escape the session directory via path
- *  joins. Defence-in-depth: the on-disk source of these ids is
- *  agent-core (which only generates main / agent-N), but a corrupted
- *  or hand-edited `state.json.agents` key could otherwise turn vis
- *  into a local-file-read primitive when exposed beyond loopback. */
+/** 拒绝可能经路径拼接逃出会话目录的 agent id。纵深防御:这些 id 的
+ *  磁盘来源是 agent-core(只生成 main / agent-N),但损坏或手工编辑的
+ *  `state.json.agents` 键,在 vis 暴露于回环之外时,可能把它变成
+ *  本地文件读取原语。 */
 export function isSafeAgentId(id: string): boolean {
   return AGENT_ID_RE.test(id) && id !== '.' && id !== '..';
 }

--- a/apps/vis/server/src/lib/wire-reader.ts
+++ b/apps/vis/server/src/lib/wire-reader.ts
@@ -29,15 +29,13 @@ function bestEffortMigrations(): readonly WireMigration[] {
   }
 }
 
-/** Read a single agent's `wire.jsonl`.
+/** 读取单个 agent 的 `wire.jsonl`。
  *
- *  Each record is returned as a `WireEntry` containing both the
- *  on-disk parsed form (`raw`) and the migrated current-protocol form
- *  (`data`). For wires that declare a protocol version `agent-core`
- *  does not recognise (historic 2.x labels, or truly future versions),
- *  the reader falls back to a best-effort path: records are run
- *  through the 1.0-onwards migration chain and a warning is added to
- *  `warnings[]` so the UI can surface the caveat. */
+ *  每条记录以 `WireEntry` 返回,同时含磁盘解析形态(`raw`)与迁移后的
+ *  当前协议形态(`data`)。对声明 `agent-core` 不认识的协议版本
+ *  (历史 2.x 标签,或真正未来的版本)的 wire,读取器回退到尽力路径:
+ *  记录经 1.0 起的迁移链运行,并向 `warnings[]` 添加警告,使 UI 能
+ *  呈现该注意事项。 */
 export async function readAgentWire(path: string): Promise<WireReadResult> {
   const stream = createReadStream(path, { encoding: 'utf8' });
   const rl = createInterface({ input: stream, crlfDelay: Infinity });

--- a/apps/vis/server/src/server.ts
+++ b/apps/vis/server/src/server.ts
@@ -2,33 +2,33 @@ import { createApp } from './app';
 import { resolveByfHome, resolveHost, resolvePort, resolveVisAuthToken } from './config';
 import { formatStartupBanner } from './startup-banner';
 
-/** Options for starting a vis HTTP server programmatically. */
+/** 以编程方式启动 vis HTTP 服务器的选项。 */
 export interface StartVisServerOptions {
-  /** Bind host. Defaults to `resolveHost()` (loopback). */
+  /** 绑定主机。默认为 `resolveHost()`(回环)。 */
   readonly host?: string;
-  /** Bind port. Defaults to `resolvePort()` (3001). */
+  /** 绑定端口。默认为 `resolvePort()`(3001)。 */
   readonly port?: number;
-  /** Auth token. Defaults to `resolveVisAuthToken(host)` (required outside loopback). */
+  /** 认证 token。默认为 `resolveVisAuthToken(host)`(回环外必填)。 */
   readonly authToken?: string;
   /**
-   * Directory holding the built SPA assets to serve. When omitted, the
-   * `public/` directory next to the compiled server bundle is used (if any);
-   * in dev mode this resolves to `null` and only the API is served.
+   * 持有要提供的构建后 SPA 资产的目录。省略时,使用编译后的服务器
+   * bundle 旁的 `public/` 目录(若有);开发模式解析为 `null`,
+   * 只提供 API。
    */
   readonly publicDir?: string;
 }
 
-/** A handle to a running vis server. */
+/** 运行中 vis 服务器的句柄。 */
 export interface VisServerHandle {
-  /** The host the server is bound to. */
+  /** 服务器绑定的主机。 */
   readonly host: string;
-  /** The port the server is bound to. */
+  /** 服务器绑定的端口。 */
   readonly port: number;
-  /** Whether the SPA bundle is being served. False means API-only. */
+  /** 是否正在提供 SPA bundle。false 表示仅 API。 */
   readonly staticEnabled: boolean;
-  /** Base URL (`http://<host>:<port>`), with IPv6 hosts bracketed. */
+  /** Base URL(`http://<host>:<port>`),IPv6 主机带方括号。 */
   readonly url: string;
-  /** Stop the server. Subsequent connections are refused. */
+  /** 停止服务器。后续连接被拒绝。 */
   close(): void;
 }
 
@@ -38,12 +38,11 @@ function hostForUrl(host: string): string {
 }
 
 /**
- * Start the vis HTTP server programmatically. Resolves once the server is
- * listening. Used by the CLI `byf vis` subcommand (in-process) and by the
- * standalone `index.ts` entry.
+ * 以编程方式启动 vis HTTP 服务器。服务器开始监听后 resolve。
+ * CLI `byf vis` 子命令(进程内)与独立 `index.ts` 入口使用。
  *
- * Binds via `Bun.serve` (library runtime contract is Bun-only). Bind failures
- * such as `EADDRINUSE` throw synchronously so callers can catch them.
+ * 经 `Bun.serve` 绑定(库运行时契约仅 Bun)。`EADDRINUSE` 等绑定失败
+ * 同步抛出,使调用方可捕获。
  */
 export async function startVisServer(
   options: StartVisServerOptions = {},
@@ -78,16 +77,16 @@ export async function startVisServer(
 }
 
 /**
- * Resolve the BYF_HOME the server reads session records from. Exposed for the
- * standalone entry's startup banner. CLI consumers rely on the same env var.
+ * 解析服务器读取会话记录所用的 BYF_HOME。暴露给独立入口的启动横幅。
+ * CLI 消费者依赖同一环境变量。
  */
 export function resolveVisByfHome(): string {
   return resolveByfHome();
 }
 
 /**
- * Format the startup banner text. Exposed so the CLI can reuse the exact same
- * wording without depending on startup-banner internals.
+ * 格式化启动横幅文本。暴露使 CLI 无需依赖启动横幅内部实现即可复用
+ * 完全相同的措辞。
  */
 export function formatVisStartupBanner(input: {
   readonly authToken?: string;

--- a/apps/vis/web/src/components/context/ChurnRibbon.tsx
+++ b/apps/vis/web/src/components/context/ChurnRibbon.tsx
@@ -6,10 +6,10 @@ interface ChurnRibbonProps {
 }
 
 /**
- * Ribbon marking where the static cache prefix changed between turns
- * (PRD-0029 R3 — break-side attribution). Mirrors {@link CompactionRibbon}'s
- * horizontal-divider paradigm. The projector encodes the changed block name and
- * cache scope into the message text as `<blockName> · <cacheScope>`.
+ * 标记 turn 之间静态缓存前缀发生变化位置的丝带(PRD-0029 R3——
+ * 破坏侧归因)。镜像 {@link CompactionRibbon} 的水平分隔线范式。
+ * projector 把变化的块名与缓存作用域编码进消息文本,形如
+ * `<blockName> · <cacheScope>`。
  */
 export function ChurnRibbon({ message }: ChurnRibbonProps) {
   const detail = extractDetail(message);

--- a/apps/vis/web/src/components/context/CompactionRibbon.tsx
+++ b/apps/vis/web/src/components/context/CompactionRibbon.tsx
@@ -6,10 +6,9 @@ interface CompactionRibbonProps {
 }
 
 /**
- * Horizontal ribbon that marks where a `context.apply_compaction` record
- * collapsed earlier messages into a single summary. Receives the
- * `ProjectedMessage` whose `source === 'compaction_summary'` so we can
- * render the summary text inline.
+ * 标记 `context.apply_compaction` 记录把早期消息折叠为单个摘要位置的水平
+ * 丝带。接收 `source === 'compaction_summary'` 的 `ProjectedMessage`,
+ * 使我们可以内联渲染摘要文本。
  */
 export function CompactionRibbon({ message }: CompactionRibbonProps) {
   const summary = extractSummary(message);

--- a/apps/vis/web/src/components/shared/ImagePreview.tsx
+++ b/apps/vis/web/src/components/shared/ImagePreview.tsx
@@ -8,11 +8,11 @@ interface ImagePreviewProps {
   label?: string;
 }
 
-/** Inline preview for an image ContentPart URL.
- *  Renders the actual `<img>` for `data:image/*` and `http(s)://` URLs;
- *  falls back to the raw URL for any other scheme.
- *  Click "expand" to lift the height cap to 80vh; click "open in tab"
- *  to view the full asset in a new browser tab. */
+/** 图片 ContentPart URL 的内联预览。
+ *  对 `data:image/*` 与 `http(s)://` URL 渲染真实 `<img>`;
+ *  任何其他 scheme 回退为原始 URL。
+ *  点击「expand」把高度上限提升到 80vh;点击「open in tab」
+ *  在新浏览器标签页查看完整资产。 */
 export function ImagePreview({ url, label = 'image_url' }: ImagePreviewProps) {
   const [open, setOpen] = useState(false);
   const [failed, setFailed] = useState(false);

--- a/apps/vis/web/src/components/shared/SizePreview.tsx
+++ b/apps/vis/web/src/components/shared/SizePreview.tsx
@@ -49,11 +49,10 @@ export function SizePreview({
 }
 
 /**
- * Format a byte count into a human-readable string (B / KB / MB).
+ * 把字节数格式化为人类可读字符串(B / KB / MB)。
  *
- * MUST stay in sync with `apps/cli/src/utils/format.ts` — the canonical
- * definition.  Both apps deliberately duplicate this so neither needs
- * a shared utility package.
+ * 必须与 `apps/cli/src/utils/format.ts` 保持同步——那里是规范定义。
+ * 两个应用刻意重复此函数,使双方都不需要共享工具包。
  */
 export function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;

--- a/apps/vis/web/src/components/state/StateTab.tsx
+++ b/apps/vis/web/src/components/state/StateTab.tsx
@@ -20,11 +20,10 @@ interface StateJsonShape {
   custom?: Record<string, unknown> & { imported_from_byf_cli?: boolean };
 }
 
-/** State tab — renders the raw `state.json` blob from session detail.
- *  At the top, a handful of highlight cards surface the most-asked fields
- *  (title / lastPrompt / created / updated / agent count). Below that, the
- *  full JSON is shown via the shared JsonViewer so any custom fields the
- *  upstream writer adds remain readable without code changes. */
+/** 状态标签页——渲染会话详情中的原始 `state.json` 数据块。
+ *  顶部几张高亮卡片呈现最常被问的字段(title / lastPrompt / created /
+ *  updated / agent 数)。其下,完整 JSON 经共享 JsonViewer 显示,使上游
+ *  写入方添加的任何自定义字段无需代码变更即可保持可读。 */
 export function StateTab({ state }: StateTabProps) {
   const s = useMemo<StateJsonShape>(() => {
     return (state ?? {}) as StateJsonShape;

--- a/apps/vis/web/src/components/wire/WireHeadline.tsx
+++ b/apps/vis/web/src/components/wire/WireHeadline.tsx
@@ -63,7 +63,7 @@ function loopEventSummary(ev: LoopRecordedEvent): string {
   }
 }
 
-/** Render the collapsed-headline for a wire record. */
+/** 渲染 wire 记录的折叠式标题。 */
 export function renderHeadline(r: AgentRecord): HeadlineRender {
   // oxlint-disable-next-line typescript(switch-exhaustiveness-check) -- minor context.* record kinds fall through to the unknown-record fallback below
   switch (r.type) {

--- a/apps/vis/web/src/components/wire/WireRow.tsx
+++ b/apps/vis/web/src/components/wire/WireRow.tsx
@@ -6,10 +6,9 @@ import { TypeBadge } from './TypeBadge';
 import { renderHeadline } from './WireHeadline';
 import { WireRowDetail } from './WireRowDetail';
 
-/** Pairing hint for a `tool.call` ↔ `tool.result` row. Computed by the
- *  parent (WireTab) from the full record list and threaded down here so
- *  the row can render an inline cross-reference and participate in the
- *  hover-highlight protocol. */
+/** `tool.call` ↔ `tool.result` 行的配对提示。由父级(WireTab)从完整
+ *  记录列表计算,并向下传入,使行可渲染内联交叉引用并参与悬停高亮
+ *  协议。 */
 export interface PairHint {
   toolCallId: string;
   kind: 'call' | 'result';

--- a/apps/vis/web/src/components/wire/typeMeta.ts
+++ b/apps/vis/web/src/components/wire/typeMeta.ts
@@ -3,7 +3,7 @@ import type { PillTone } from '../shared/Pill';
 
 type RecordType = AgentRecord['type'];
 
-/** Visual tone for each record type. */
+/** 每种记录类型的视觉色调。 */
 export const TYPE_TONE: Record<RecordType, PillTone> = {
   metadata: 'meta',
   'config.update': 'config',
@@ -34,7 +34,7 @@ export const TYPE_TONE: Record<RecordType, PillTone> = {
   'goal.clear': 'warning',
 };
 
-/** Compact human label for each record type (used in the type badge). */
+/** 每种记录类型的紧凑人类标签(用于类型徽章)。 */
 export const TYPE_LABEL: Record<RecordType, string> = {
   metadata: 'meta',
   'config.update': 'config',

--- a/apps/vis/web/src/hooks/useContext.ts
+++ b/apps/vis/web/src/hooks/useContext.ts
@@ -3,12 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 import { api } from '../api';
 
 /**
- * Fetch the projected context for a given agent in a session.
+ * 获取会话中给定 agent 的投影上下文。
  *
- * The `/api/sessions/:id/context?agent=<agentId>` route returns the
- * full `ContextProjection` (messages, usage totals, config snapshot,
- * permission mode). Defaults to `main` when no agent id
- * is provided, but callers should pass an explicit id for clarity.
+ * `/api/sessions/:id/context?agent=<agentId>` 路由返回完整
+ * `ContextProjection`(消息、用量总计、配置快照、权限模式)。
+ * 未提供 agent id 时默认为 `main`,但调用方应传显式 id 以求清晰。
  */
 export function useContext(sessionId: string, agentId: string) {
   return useQuery({

--- a/apps/vis/web/src/hooks/useTheme.ts
+++ b/apps/vis/web/src/hooks/useTheme.ts
@@ -32,9 +32,9 @@ function apply(resolved: ResolvedTheme): void {
 }
 
 /**
- * Three-state theme: auto (follow system), light, dark. The resolved concrete
- * theme is reflected on `<html data-theme="...">`. User choice is persisted
- * in localStorage; absence ⇒ auto.
+ * 三态主题:auto(跟随系统)、light、dark。解析后的具体主题反映在
+ * `<html data-theme="...">` 上。用户选择持久化在 localStorage;
+ * 缺席 ⇒ auto。
  */
 export function useTheme(): {
   choice: ThemeChoice;

--- a/apps/vis/web/src/lib/issues.ts
+++ b/apps/vis/web/src/lib/issues.ts
@@ -1,14 +1,14 @@
-// Aggregate every "something went wrong" signal from a wire timeline
-// into a flat list consumable by the Issues drawer. Pure — no React.
+// 把 wire 时间线中的每个「出问题」信号聚合为 Issues 抽屉可消费的扁平
+// 列表。纯函数——无 React。
 //
-// Detection rules for the new agent-core wire protocol:
-//   - tool.call without paired tool.result (orphan tool.call)
-//   - tool.result without preceding tool.call (orphan tool.result)
-//   - step.begin without paired step.end (incomplete step)
-//   - full_compaction.begin without complete/cancel (incomplete compaction)
-//   - permission.record_approval_result with decision='rejected' (info)
+// 新 agent-core wire 协议的检测规则:
+//   - tool.call 无配对的 tool.result(孤儿 tool.call)
+//   - tool.result 无前导的 tool.call(孤儿 tool.result)
+//   - step.begin 无配对的 step.end(未完成 step)
+//   - full_compaction.begin 无 complete/cancel(未完成压缩)
+//   - permission.record_approval_result 且 decision='rejected'(信息)
 //
-// Wire-file parse warnings are appended as info-level entries with no lineNo.
+// Wire 文件解析警告作为无 lineNo 的信息级条目追加。
 
 import type { WireEntry } from '../types';
 
@@ -39,8 +39,8 @@ const SEVERITY_ORDER: Record<IssueSeverity, number> = {
   info: 2,
 };
 
-/** Scan `records` + `warnings` and produce an ordered issue list.
- *  Sorted by severity first, then lineNo ascending. Warnings (no lineNo) go last. */
+/** 扫描 `records` + `warnings`,产生有序问题列表。
+ *  先按严重度排序,再按 lineNo 升序。警告(无 lineNo)排在最后。 */
 export function computeIssues(entries: readonly WireEntry[], warnings: readonly string[]): Issue[] {
   const out: Issue[] = [];
 
@@ -158,7 +158,7 @@ export function computeIssues(entries: readonly WireEntry[], warnings: readonly 
   return out;
 }
 
-/** Top-level summary tone used for the toolbar pill — "worst wins". */
+/** 工具栏药丸使用的顶层摘要色调——「最差者胜」。 */
 export function topSeverity(issues: readonly Issue[]): IssueSeverity | null {
   if (issues.length === 0) return null;
   for (const i of issues) if (i.severity === 'error') return 'error';

--- a/apps/vis/web/src/types.ts
+++ b/apps/vis/web/src/types.ts
@@ -1,6 +1,6 @@
-// Client-side types — re-export vis DTOs (type-only).
-// Canonical shared DTO definitions live in @byfriends/vis-shared (apps/vis/shared/types.ts).
-// Both vis-web and vis-server import from the same single source.
+// 客户端类型——重导出 vis DTO(仅类型)。
+// 规范共享 DTO 定义位于 @byfriends/vis-shared(apps/vis/shared/types.ts)。
+// vis-web 与 vis-server 都从同一单一来源导入。
 
 export type {
   SessionSummary,
@@ -33,10 +33,10 @@ export interface DeleteSessionResponse {
 }
 
 /**
- * Shape returned by `GET /api/sessions/:id/context?agent=<agentId>`.
+ * `GET /api/sessions/:id/context?agent=<agentId>` 返回的形态。
  *
- * Mirrors `ContextProjection` from @byfriends/vis-shared, plus the `sessionId`
- * and `agentId` echoed by the route.
+ * 镜像 @byfriends/vis-shared 的 `ContextProjection`,外加路由回显的
+ * `sessionId` 与 `agentId`。
  */
 export interface ContextResponse {
   sessionId: string;

--- a/apps/vis/web/src/util/time.ts
+++ b/apps/vis/web/src/util/time.ts
@@ -1,4 +1,4 @@
-/** Format an epoch-ms timestamp as a short relative string ("2m ago", "3h ago"). */
+/** 把 epoch 毫秒时间戳格式化为简短相对字符串("2m ago"、"3h ago")。 */
 export function formatRelativeTime(epochMs: number): string {
   if (!epochMs || !Number.isFinite(epochMs)) return '—';
   const diff = Date.now() - epochMs;
@@ -16,7 +16,7 @@ export function formatRelativeTime(epochMs: number): string {
   return `${Math.floor(mo / 12)}y ago`;
 }
 
-/** Format an epoch-ms timestamp as ISO-ish local time (YYYY-MM-DD HH:MM:SS). */
+/** 把 epoch 毫秒时间戳格式化为类 ISO 本地时间(YYYY-MM-DD HH:MM:SS)。 */
 export function formatAbsoluteTime(epochMs: number): string {
   if (!epochMs || !Number.isFinite(epochMs)) return '—';
   const d = new Date(epochMs);
@@ -24,7 +24,7 @@ export function formatAbsoluteTime(epochMs: number): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 }
 
-/** Format an epoch-ms timestamp as HH:MM:SS (wall clock). */
+/** 把 epoch 毫秒时间戳格式化为 HH:MM:SS(墙钟)。 */
 export function formatWallClock(epochMs: number): string {
   if (!epochMs || !Number.isFinite(epochMs)) return '--:--:--';
   const d = new Date(epochMs);


### PR DESCRIPTION
## 背景

仓库语言规范（`docs/agents/language.md`）要求公开 API 的 JSDoc 与文件/模块顶部注释按简体中文撰写。本 PR 完成 vis（可视化调试工具）的此类注释统一，为整个代码库注释中文化划上句号（前四阶段：#279 文档、#280 agent-core、#281 CLI、#282 SDK 层均已合入）。

cache-impact: none

## 改动内容

- **范围**：`apps/vis/server/src`（9 文件，Hono API 服务 + lib）与 `apps/vis/web/src`（13 文件，React SPA），共 **22 个文件**、38 个注释块。
- **范围纪律**：
  - 已译：模块头注释、公开函数/类/接口/常量 JSDoc、公开接口字段注释、组件 props 注释
  - 保留英文：函数体内行内注释、代码标识符与技术术语（如 `wire.jsonl`、`cacheScope`）
  - 已排除：`.d.ts` 类型声明文件

## 验收

- **零代码变更**：`git diff` 逐行校验——全部变更行均为注释（0 处非注释变更）
- `bun run build:vis`（vis-server + vis-web）通过
- `bun run lint` 0 错误；`bun run fmt:check` 通过

## Changeset

**无需 changeset**：注释在编译时被剥离、不进入发布产物，属于纯文档性改动（`gen-changesets` skill 规则 #6，与前四阶段判定一致）。